### PR TITLE
Add Insert Paste via Shift

### DIFF
--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -139,7 +139,7 @@ void onKeyPress(KeyPress& evt) override
 		}
 		else if(kc == Key::V)
 		{
-			pasteFromClipboard();
+			pasteFromClipboard(evt.keyflags & Keyflag::SHIFT);
 			evt.handled = true;
 		}
 	}
@@ -957,15 +957,15 @@ void copySelectionToClipboard(bool remove)
 	}
 }
 
-void pasteFromClipboard()
+void pasteFromClipboard(bool insert)
 {
 	if(gChart->isOpen() && HasClipboardData(NotesMan::clipboardTag))
 	{
-		gNotes->pasteFromClipboard();
+		gNotes->pasteFromClipboard(insert);
 	}
 	else if(HasClipboardData(TempoMan::clipboardTag))
 	{
-		gTempo->pasteFromClipboard();
+		gTempo->pasteFromClipboard(insert);
 	}
 }
 

--- a/src/Managers/NoteMan.cpp
+++ b/src/Managers/NoteMan.cpp
@@ -774,7 +774,7 @@ void copyToClipboard(bool timeBased)
 	}
 }
 
-void pasteFromClipboard()
+void pasteFromClipboard(bool insert)
 {
 	Vector<uchar> buffer = GetClipboardData(clipboardTag);
 	ReadStream stream(buffer.data(), buffer.size());
@@ -808,8 +808,8 @@ void pasteFromClipboard()
 
 	// Perform the changes.
 	static const NotesMan::EditDescription desc = {"Pasted %1 note", "Pasted %1 notes"};
-	gNotes->modify(edit, true, &desc);
-	gNotes->select(SELECT_SET, edit.add.begin(), edit.add.size());
+	modify(edit, !insert, &desc);
+	select(SELECT_SET, edit.add.begin(), edit.add.size());
 }
 
 // ================================================================================================

--- a/src/Managers/NoteMan.h
+++ b/src/Managers/NoteMan.h
@@ -52,7 +52,7 @@ struct NotesMan
 
 	// Clipboard functions.
 	virtual void copyToClipboard(bool timeBased) = 0;
-	virtual void pasteFromClipboard() = 0;
+	virtual void pasteFromClipboard(bool insert) = 0;
 
 	// Statistics functions.
 	virtual int getNumSteps() const = 0; ///< Includes jumps/holds/rolls.

--- a/src/Managers/TempoMan.cpp
+++ b/src/Managers/TempoMan.cpp
@@ -143,11 +143,11 @@ void myFinishEdit(Tempo* tempo)
 // ================================================================================================
 // TempoManImpl :: apply segments.
 
-void myQueueSegments(const SegmentEdit& edit)
+void myQueueSegments(const SegmentEdit& edit, bool clearRegion)
 {
 	stopTweaking(false);
 	SegmentEditResult result;
-	myTempo->segments->prepareEdit(edit, result);
+	myTempo->segments->prepareEdit(edit, result, clearRegion);
 	if(result.add.numSegments() + result.rem.numSegments() > 0)
 	{
 		WriteStream stream;
@@ -259,7 +259,7 @@ void myWriteInsertRows(WriteStream& stream, Tempo* tempo, int startRow, int numR
 				}
 			}
 		}
-		segs->prepareEdit(edit, result);
+		segs->prepareEdit(edit, result, true);
 	}
 	stream.write(tempo);
 	result.rem.encode(stream);
@@ -471,8 +471,13 @@ static double ClampAndRound(double val, double min, double max)
 
 void modify(const SegmentEdit& edit)
 {
+	modify(edit, true);
+}
+
+void modify(const SegmentEdit& edit, bool clearRegion)
+{
 	stopTweaking(false);
-	myQueueSegments(edit);
+	myQueueSegments(edit, clearRegion);
 }
 
 void removeSelectedSegments()
@@ -591,7 +596,7 @@ void copyToClipboard()
 	}
 }
 
-void pasteFromClipboard()
+void pasteFromClipboard(bool insert)
 {
 	SegmentEdit clipboard;
 
@@ -616,7 +621,7 @@ void pasteFromClipboard()
 	}
 
 	// Add the pasted segments to the current tempo.
-	modify(clipboard);
+	modify(clipboard, !insert);
 }
 
 // ================================================================================================

--- a/src/Managers/TempoMan.h
+++ b/src/Managers/TempoMan.h
@@ -59,9 +59,10 @@ struct TempoMan
 
 	/// Editing functions.
 	virtual void modify(const SegmentEdit& edit) = 0;
+	virtual void modify(const SegmentEdit& edit, bool clearRegion) = 0;
 	virtual void insertRows(int row, int numRows, bool curChartOnly) = 0;
 	virtual void removeSelectedSegments() = 0;
-	virtual void pasteFromClipboard() = 0;
+	virtual void pasteFromClipboard(bool insert) = 0;
 	virtual void copyToClipboard() = 0;
 
 	/// Sets the global music offset.

--- a/src/Simfile/SegmentGroup.cpp
+++ b/src/Simfile/SegmentGroup.cpp
@@ -45,21 +45,24 @@ void SegmentGroup::sanitize(const Chart* owner)
 	}
 }
 
-void SegmentGroup::prepareEdit(const SegmentEdit& in, SegmentEditResult& out)
+void SegmentGroup::prepareEdit(const SegmentEdit& in, SegmentEditResult& out, bool clearRegion)
 {
 	int regionBegin = INT_MAX;
 	int regionEnd = 0;
-	ForEachType(type)
+	if(clearRegion)
 	{
-		auto& list = in.add.myLists[type];
-		if(list.size() >= 2)
+		ForEachType(type)
 		{
-			auto first = list.begin();
-			auto last = list.rbegin();
-			if(last->row > first->row)
+			auto& list = in.add.myLists[type];
+			if(list.size() >= 2)
 			{
-				regionBegin = min(regionBegin, first->row);
-				regionEnd = max(regionEnd, last->row);
+				auto first = list.begin();
+				auto last = list.rbegin();
+				if(last->row > first->row)
+				{
+					regionBegin = min(regionBegin, first->row);
+					regionEnd = max(regionEnd, last->row);
+				}
 			}
 		}
 	}

--- a/src/Simfile/SegmentGroup.h
+++ b/src/Simfile/SegmentGroup.h
@@ -77,7 +77,7 @@ public:
 
 	// Prepares a modification. The input is a list of segments which should be added and removed.
 	// The output is a list of segments that actually end up being added and removed.
-	void prepareEdit(const SegmentEdit& in, SegmentEditResult& out);
+	void prepareEdit(const SegmentEdit& in, SegmentEditResult& out, bool clearRegion);
 
 	// Appends a default constructed segment of the given type at the given row.
 	void append(Segment::Type type, int row);


### PR DESCRIPTION
While holding shift, inserts notes or tempo objects without clearing the region.

Closes #32.