### PR TITLE
Create a GitHub action for Windows build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,9 +16,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: main
-      - name: Generate zipfile name
-        run: >
-          echo "AV_ZIP_NAME=\"ArrowVortex-$(date +'%Y-%m-%d %H-%M-%S')\"" >> $GITHUB_ENV
       - name: Get MSBuild
         uses: microsoft/setup-msbuild@v2
       - name: Obtain oggenc2.exe


### PR DESCRIPTION
We're doing this shit.

This will activate on every push to main branch and upload an AV zip to http://167.71.33.176/, which is my personal VPS. Temporary measure until a more permanent file storage is found.