### PR TITLE
Copy/Paste Timestamp

### DIFF
--- a/src/Core/StringUtils.cpp
+++ b/src/Core/StringUtils.cpp
@@ -267,6 +267,29 @@ bool Str::readBool(StringRef s, bool alt)
 	return alt;
 }
 
+double Str::readTime(StringRef s, double alt)
+{
+	auto time = Str::split(s, ":", false, false);
+	double v = 0.0;
+
+	switch(time.size())
+	{
+	case 3:
+		v = (readInt(time[0]) * 3600) + (readInt(time[1]) * 60) + readDouble(time[2]);
+		break;
+	case 2:
+		v = (readInt(time[0]) * 60) + readDouble(time[1]);
+		break;
+	default:
+		v = readDouble(time[0]);
+		break;
+	}
+
+	if (v == 0 && *s.myStr == 0) return alt;
+	alt = v;
+	return alt;
+}
+
 bool Str::read(StringRef s, int* out)
 {
 	char* end;

--- a/src/Core/StringUtils.h
+++ b/src/Core/StringUtils.h
@@ -73,6 +73,9 @@ struct Str
 	/// Converts the string to a boolean; returns alt on failure.
 	static bool readBool(StringRef s, bool alt = false);
 
+	/// Converts the string to a timestamp double; returns alt on failure.
+	static double readTime(StringRef s, double alt = 0);
+
 	/// Converts the string to a boolean; returns alt on failure.
 	static bool read(StringRef s, bool alt = false);
 

--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -1022,7 +1022,13 @@ void exportNotesAsLuaTable()
 
 void copySelectionToClipboard(bool remove)
 {
-	if(gSelection->getType() == Selection::TEMPO)
+	if(gSelection->getType() == Selection::NONE)
+	{
+		String time = Str::formatTime(gView->getCursorTime());
+		gSystem->setClipboardText(Str::fmt("%1").arg(time));
+		HudNote("Copied timestamp to Clipboard.");
+	}
+	else if(gSelection->getType() == Selection::TEMPO)
 	{
 		gTempo->copyToClipboard();
 		if(remove) gTempo->removeSelectedSegments();
@@ -1043,6 +1049,16 @@ void pasteFromClipboard(bool insert)
 	else if(HasClipboardData(TempoMan::clipboardTag))
 	{
 		gTempo->pasteFromClipboard(insert);
+	}
+	else
+	{
+		String text = gSystem->getClipboardText();
+		double target = Str::readTime(text);
+		if(target > 0)
+		{
+			HudNote("Jump to %s.", Str::formatTime(target));
+			gView->setCursorTime(target);
+		}
 	}
 }
 


### PR DESCRIPTION
- Copying with nothing selected copies a formatted timestamp: `00:03.496`
- Pasting will attempt to parse a timestamp and jump to that time in the song.

Pasting should work with both of these timestamp formats:
- `11:22:33.456` or `40953.456`
- `22:33.456` or `1353.456`
- `33.456`

_Really will just attempt to parse the current clipboard as a number regardless of what is on it._

This has been extremely useful when collabing or reading/writing notes and speeds up work flow a ton.