### PR TITLE
Move to row at cursor by middle click

### DIFF
--- a/src/Editor/View.cpp
+++ b/src/Editor/View.cpp
@@ -139,7 +139,7 @@ void onMouseScroll(MouseScroll& evt) override
 		else
 		{
 			setCursorRow(myCursorRow + (int)(delta / myPixPerRow));
-		}		
+		}
 	}
 	evt.handled = true;
 }
@@ -150,6 +150,14 @@ void onMousePress(MousePress& evt) override
 	if(evt.button == Mouse::LMB && isMouseOverReceptors(evt.x, evt.y) && evt.unhandled())
 	{
 		myIsDraggingReceptors = true;
+		evt.setHandled();
+	}
+
+	if (evt.unhandled() && evt.button == Mouse::MMB) {
+		Vortex::vec2i mouse_pos = gSystem->getMousePos();
+		Vortex::ChartOffset ofs = gView->yToOffset(mouse_pos.y);
+
+		setCursorRow(snapRow(offsetToRow(ofs), SnapDir::SNAP_CLOSEST));
 		evt.setHandled();
 	}
 }


### PR DESCRIPTION
Exactly what it says on the tin. You press middle click and it moves receptors to the snapping row under the mouse cursor.