### PR TITLE
Quantizations compatibility to close #70

### DIFF
--- a/src/Editor/TextOverlay.cpp
+++ b/src/Editor/TextOverlay.cpp
@@ -591,7 +591,7 @@ void drawAbout()
 {
 	vec2i size = gSystem->getWindowSize();
 
-	Text::arrange(Text::BC, "ArrowVortex release 1.0.0 (beta)");
+	Text::arrange(Text::BC, "ArrowVortex release v1.0.0");
 	Text::draw(vec2i{size.x / 2, size.y / 2 - 128});
 	String buildDate = "Build date: " + System::getBuildData();
 	Text::arrange(Text::TC, buildDate.str());
@@ -611,7 +611,7 @@ void drawAbout()
 	Text::draw(r);
 
 	Text::arrange(Text::TC, "Current GitHub maintainers:\n"
-		"@uvcat/TheUltravioletCatastrophe\n"
+		"@uvcat7/TheUltravioletCatastrophe\n"
 		"@sukibaby/Jasmine\n"
 		"\n"
 		"Source code contributors:\n"

--- a/src/Simfile/LoadSm.cpp
+++ b/src/Simfile/LoadSm.cpp
@@ -526,7 +526,6 @@ static void ParseNotes(ParseData& data, Chart* chart, StringRef style, char* not
 				}
 			}
 
-			Debug::log("quantization was %d", quantization);
 			line = measureText;
 			int ofs = ROWS_PER_NOTE_SECTION / numLines;
 			for (int i = 0; i < numLines; ++i)

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -526,7 +526,20 @@ static void GetSectionCompression(const char* section, int width, std::list<uint
 			// The first (largest) match is always the best
 			if (valid && i >= MIN_SECTIONS_PER_MEASURE)
 			{
-				count = i;
+				// Is our factor a standard snap? If so, use it.
+				for (int j = 0; j < NUM_MEASURE_SUBDIV; j++)
+				{
+					if (MEASURE_SUBDIV[j] == i)
+					{
+						count = i;
+						break;
+					}
+				}
+				// If not, save the measure as 192nds for SM5 Editor compatibility.
+				if (count != i)
+				{
+					count = ROWS_PER_NOTE_SECTION;
+				}
 				break;
 			}
 		}

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -526,23 +526,16 @@ static void GetSectionCompression(const char* section, int width, std::list<uint
 			// The first (largest) match is always the best
 			if (valid && i >= MIN_SECTIONS_PER_MEASURE)
 			{
-				// Is our factor a standard snap? If so, use it.
-				for (int j = 0; j < NUM_MEASURE_SUBDIV; j++)
-				{
-					if (MEASURE_SUBDIV[j] == i)
-					{
-						count = i;
-						break;
-					}
-				}
-				// If not, save the measure as 192nds for SM5 Editor compatibility.
-				if (count != i)
-				{
-					count = ROWS_PER_NOTE_SECTION;
-				}
+				count = i;
 				break;
 			}
 		}
+	}
+	// Is our factor a standard snap? If so, use it.
+	// If not, save the measure as 192nds for SM5 Editor compatibility.
+	if (ROWS_PER_NOTE_SECTION % count != 0)
+	{
+		count = ROWS_PER_NOTE_SECTION;
 	}
 	pitch = (ROWS_PER_NOTE_SECTION * width) / count;
 }


### PR DESCRIPTION
Now files try to compress 192nd rows down to custom quantizations on loading, and save nonstandard quantizations as 192nd snaps.
