### PR TITLE
Readd all the std::chrono calls back into the game loop

### DIFF
--- a/src/Core/Core.h
+++ b/src/Core/Core.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <chrono>
 
 namespace Vortex {
 
@@ -51,7 +52,7 @@ struct TimingData;
 typedef const String& StringRef;
 typedef uint64_t TextureHandle;
 
-extern float deltaTime;
+extern std::chrono::duration<double> deltaTime;
 
 extern void HudNote(const char* fmt, ...);
 extern void HudInfo(const char* fmt, ...);

--- a/src/Core/TextDraw.cpp
+++ b/src/Core/TextDraw.cpp
@@ -321,8 +321,6 @@ void Text::draw(vec2i textPos)
 		}
 		batch.flush();
 	}
-
-	VortexCheckGlError();
 }
 
 };

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -894,13 +894,13 @@ void tick()
 	gTextOverlay->handleInputs(events);
 
 	GuiMain::setViewSize(r.w, r.h);
-	GuiMain::frameStart(deltaTime, events);
+	GuiMain::frameStart(deltaTime.count(), events);
 
 	vec2i view = gSystem->getWindowSize();
 
 	handleDialogs();
 
-	gui_->tick({ 0, 0, view.x, view.y }, deltaTime, events);
+	gui_->tick({ 0, 0, view.x, view.y }, deltaTime.count(), events);
 
 	if (!GuiMain::isCapturingText())
 	{

--- a/src/Editor/Music.cpp
+++ b/src/Editor/Music.cpp
@@ -3,6 +3,7 @@
 #include <limits.h>
 #include <stdint.h>
 #include <math.h>
+#include <chrono>
 
 #include <Core/Vector.h>
 #include <Core/Reference.h>
@@ -48,7 +49,7 @@ struct MusicImpl : public Music, public MixSource {
 
 Mixer* myMixer;
 Sound mySamples;
-double myPlayTimer;
+std::chrono::steady_clock::time_point myPlayTimer;
 TickData myBeatTick, myNoteTick;
 String myTitle, myArtist;
 int myMusicSpeed;

--- a/src/Editor/Sound.cpp
+++ b/src/Editor/Sound.cpp
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <limits.h>
+#include <chrono>
 
 namespace Vortex {
 
@@ -93,7 +94,7 @@ private:
 	int myCurrentFrame;
 	int myReservedFrames;
 	uchar myProgress;
-	double myStartTime;
+	std::chrono::steady_clock::time_point myStartTime;
 };
 
 Sound::Thread::~Thread()

--- a/src/Editor/TextOverlay.cpp
+++ b/src/Editor/TextOverlay.cpp
@@ -411,7 +411,7 @@ void tickHud()
 		{
 			fade += 0.5f;
 		}
-		float delta = clamp(deltaTime * fade, 0.0f, 1.0f);
+		float delta = clamp(deltaTime.count() * fade, 0.0, 1.0);
 
 		hudEntries_[i].timeLeft -= delta;
 		if(hudEntries_[i].timeLeft <= -0.5f) hudEntries_.erase(i);
@@ -625,7 +625,7 @@ void drawAbout()
 
 	DrawTitleText("ABOUT", "[ESC] close", nullptr);
 
-	auto fps = Str::fmt("%1 FPS").arg(1.0f / max(deltaTime, 0.0001f), 0, 0);
+	auto fps = Str::fmt("%1 FPS").arg(1.0f / max(deltaTime.count(), 0.0001), 0, 0);
 	Text::arrange(Text::TR, fps);
 	Text::draw(vec2i{size.x - 4, 4});
 }

--- a/src/System/Debug.cpp
+++ b/src/System/Debug.cpp
@@ -5,7 +5,7 @@
 #include <io.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <time.h>
+#include <chrono>
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -17,22 +17,18 @@ namespace Debug {
 
 // ================================================================================================
 // Debug :: timing functions.
+using namespace std::chrono;
 
-double getElapsedTime()
+steady_clock::time_point getElapsedTime()
 {
-	static const double timer = []() {
-		LARGE_INTEGER freq;
-		return QueryPerformanceFrequency(&freq) ? 1.0 / static_cast<double>(freq.QuadPart) : 1.0;
-	}();
-
-	LARGE_INTEGER counter;
-	QueryPerformanceCounter(&counter);
-	return static_cast<double>(counter.QuadPart) * timer;
+	return std::chrono::steady_clock::now();
 }
 
-double getElapsedTime(double startTime)
+double getElapsedTime(steady_clock::time_point startTime)
 {
-	return getElapsedTime() - startTime;
+	auto currentTime = steady_clock::now();
+	const duration<double> deltaTime = currentTime - startTime;
+	return deltaTime.count();
 }
 
 // ================================================================================================

--- a/src/System/Debug.h
+++ b/src/System/Debug.h
@@ -2,6 +2,7 @@
 
 #include <Core/Core.h>
 #include <assert.h>
+#include <chrono>
 
 #ifndef _DEBUG
 #define VORTEX_DISABLE_ASSERTS
@@ -15,10 +16,10 @@ namespace Debug
 	enum Type { INFO, WARNING, ERROR };
 
 	/// Returns a timestamp of the current time.
-	double getElapsedTime();
+	std::chrono::steady_clock::time_point getElapsedTime();
 
 	/// Returns the number of seconds elapsed since the start time.
-	double getElapsedTime(double startTime);
+	double getElapsedTime(std::chrono::steady_clock::time_point startTime);
 
 	/// Creates a blank log file.
 	void openLogFile();


### PR DESCRIPTION
I don't think there was ever an issue with this--I just caused some confusion by shipping a performance improvement that broke assist tick at the same time as these changes.