### PR TITLE
Insert Beats Changes

### DIFF
--- a/src/Managers/NoteMan.cpp
+++ b/src/Managers/NoteMan.cpp
@@ -505,6 +505,9 @@ String myApplyInsertRows(ReadStream& in, bool undo, bool redo)
 			myUpdateNotes();
 		}
 
+		// Jump to start row.
+		gView->setCursorRow(startRow);
+
 		target = in.read<Chart*>();
 	}
 	return String();

--- a/src/Managers/TempoMan.cpp
+++ b/src/Managers/TempoMan.cpp
@@ -279,6 +279,10 @@ void myQueueInsertRows(int startRow, int numRows, bool curChartOnly)
 			{
 				myWriteInsertRows(stream, myChart->tempo, startRow, numRows);
 			}
+			else
+			{
+				myWriteInsertRows(stream, mySimfile->tempo, startRow, numRows);
+			}
 		}
 		else
 		{
@@ -304,7 +308,7 @@ void myApplyInsertRowsOffset(Tempo* tempo, int startRow, int numRows)
 	{
 		for(auto seg = list->begin(), end = list->end(); seg != end; ++seg)
 		{
-			if(seg->row >= startRow)
+			if(seg->row >= startRow && seg->row > 0)
 			{
 				seg->row += numRows;
 			}


### PR DESCRIPTION
- Don't move tempo objects at row 0 to avoid multiple issues.
- Adjust tempo objects on a single chart when only a sim tempo is found.
- Set cursor to start of offset when undoing/redoing.