### PR TITLE
Replace all typedefs with standard types

### DIFF
--- a/src/Core/ByteStream.cpp
+++ b/src/Core/ByteStream.cpp
@@ -13,7 +13,7 @@ namespace Vortex {
 
 WriteStream::WriteStream()
 {
-	buffer_ = (uchar*)malloc(128);
+	buffer_ = (uint8_t*)malloc(128);
 	current_size_ = 0;
 	capacity_ = 128;
 	is_external_buffer_ = false;
@@ -22,7 +22,7 @@ WriteStream::WriteStream()
 
 WriteStream::WriteStream(void* out, int bytes)
 {
-	buffer_ = (uchar*)out;
+	buffer_ = (uint8_t*)out;
 	current_size_ = 0;
 	capacity_ = bytes;
 	is_external_buffer_ = true;
@@ -45,7 +45,7 @@ void WriteStream::write(const void* in, int bytes)
 	else if(!is_external_buffer_)
 	{
 		capacity_ = max(capacity_ << 1, newSize);
-		buffer_ = (uchar*)realloc(buffer_, capacity_);
+		buffer_ = (uint8_t*)realloc(buffer_, capacity_);
 		memcpy(buffer_ + current_size_, in, bytes);
 		current_size_ = newSize;
 	}
@@ -65,7 +65,7 @@ void WriteStream::write8(const void* val)
 	else if(!is_external_buffer_)
 	{
 		capacity_ <<= 1;
-		buffer_ = (uchar*)realloc(buffer_, capacity_);
+		buffer_ = (uint8_t*)realloc(buffer_, capacity_);
 		buffer_[current_size_] = *(const uint8_t*)val;
 		++current_size_;
 	}
@@ -86,7 +86,7 @@ void WriteStream::write16(const void* val)
 	else if(!is_external_buffer_)
 	{
 		capacity_ <<= 1;
-		buffer_ = (uchar*)realloc(buffer_, capacity_);
+		buffer_ = (uint8_t*)realloc(buffer_, capacity_);
 		*(uint16_t*)(buffer_ + current_size_) = *(const uint16_t*)val;
 		current_size_ = newSize;
 	}
@@ -107,7 +107,7 @@ void WriteStream::write32(const void* val)
 	else if(!is_external_buffer_)
 	{
 		capacity_ <<= 1;
-		buffer_ = (uchar*)realloc(buffer_, capacity_);
+		buffer_ = (uint8_t*)realloc(buffer_, capacity_);
 		*(uint32_t*)(buffer_ + current_size_) = *(const uint32_t*)val;
 		current_size_ = newSize;
 	}
@@ -128,7 +128,7 @@ void WriteStream::write64(const void* val)
 	else if(!is_external_buffer_)
 	{
 		capacity_ <<= 1;
-		buffer_ = (uchar*)realloc(buffer_, capacity_);
+		buffer_ = (uint8_t*)realloc(buffer_, capacity_);
 		*(uint64_t*)(buffer_ + current_size_) = *(const uint64_t*)val;
 		current_size_ = newSize;
 	}
@@ -138,7 +138,7 @@ void WriteStream::write64(const void* val)
 	}
 }
 
-void WriteStream::writeNum(uint num)
+void WriteStream::writeNum(uint32_t num)
 {
 	if(num < 0x80)
 	{
@@ -146,8 +146,8 @@ void WriteStream::writeNum(uint num)
 	}
 	else
 	{
-		uchar buf[8];
-		uint index = 0;
+		uint8_t buf[8];
+		uint32_t index = 0;
 		while(num >= 0x80)
 		{
 			buf[index] = (num & 0x7F) | 0x80;
@@ -170,7 +170,7 @@ void WriteStream::writeStr(StringRef str)
 
 ReadStream::ReadStream(const void* in, int bytes)
 {
-	read_position_ = (const uchar*)in;
+	read_position_ = (const uint8_t*)in;
 	end_position_ = read_position_ + bytes;
 	is_read_successful_ = true;
 }
@@ -270,7 +270,7 @@ void ReadStream::read64(void* out)
 	}
 }
 
-uint ReadStream::readNum()
+uint32_t ReadStream::readNum()
 {
 	uint32_t out;
 	if(read_position_ != end_position_)
@@ -283,7 +283,7 @@ uint ReadStream::readNum()
 		else
 		{
 			out = *read_position_ & 0x7F;
-			uint shift = 7;
+			uint32_t shift = 7;
 			while(true)
 			{
 				if(++read_position_ == end_position_)
@@ -292,7 +292,7 @@ uint ReadStream::readNum()
 					is_read_successful_ = false;
 					break;
 				}
-				uint byte = *read_position_;
+				uint32_t byte = *read_position_;
 				if((byte & 0x80) == 0)
 				{
 					out |= byte << shift;
@@ -315,7 +315,7 @@ uint ReadStream::readNum()
 String ReadStream::readStr()
 {
 	String out;
-	uint len = readNum();
+	uint32_t len = readNum();
 	auto newPos = read_position_ + len;
 	if(newPos <= end_position_)
 	{
@@ -328,7 +328,7 @@ String ReadStream::readStr()
 	return String();
 }
 
-void ReadStream::readNum(uint& num)
+void ReadStream::readNum(uint32_t& num)
 {
 	num = readNum();
 }

--- a/src/Core/ByteStream.h
+++ b/src/Core/ByteStream.h
@@ -19,7 +19,7 @@ public:
 	void write32(const void* val);
 	void write64(const void* val);
 
-	void writeNum(uint num);
+	void writeNum(uint32_t num);
 	void writeStr(StringRef str);
 
 	template <unsigned int S>
@@ -65,10 +65,10 @@ public:
 	int size() const { return current_size_; }
 
 	// Returns a pointer to the start of the written data.
-	const uchar* data() const { return buffer_; }
+	const uint8_t* data() const { return buffer_; }
 
 private:
-	uchar* buffer_;
+	uint8_t* buffer_;
 	int current_size_, capacity_;
 	bool is_external_buffer_, is_write_successful_;
 };
@@ -88,10 +88,10 @@ public:
 	void read32(void* out);
 	void read64(void* out);
 
-	uint readNum();
+	uint32_t readNum();
 	String readStr();
 
-	void readNum(uint& num);
+	void readNum(uint32_t& num);
 	void readStr(String& str);
 
 	template <size_t S>
@@ -148,10 +148,10 @@ public:
 	size_t bytesleft() const { return end_position_ - read_position_; }
 
 	// Returns the current read position.
-	const uchar* pos() const { return read_position_; }
+	const uint8_t* pos() const { return read_position_; }
 
 private:
-	const uchar* read_position_, *end_position_;
+	const uint8_t* read_position_, *end_position_;
 	bool is_read_successful_;
 };
 

--- a/src/Core/Canvas.cpp
+++ b/src/Core/Canvas.cpp
@@ -347,7 +347,7 @@ void Canvas::polygon(const float* x, const float* y, int vertexCount)
 
 Texture Canvas::createTexture(bool mipmap) const
 {
-	uchar* dst = (uchar*)malloc(canvas_width_*canvas_height_ * 4 * sizeof(uchar));
+	uint8_t* dst = (uint8_t*)malloc(canvas_width_*canvas_height_ * 4 * sizeof(uint8_t));
 	for(int i = 0; i < canvas_width_ * canvas_height_ * 4; ++i)
 	{
 		int v = (int)(canvas_data_[i] * 255.f + 0.5f);

--- a/src/Core/Core.h
+++ b/src/Core/Core.h
@@ -5,12 +5,6 @@
 
 namespace Vortex {
 
-typedef uint64_t  ulong;
-typedef uint32_t   uint;
-typedef uint16_t ushort;
-typedef uint8_t  uchar;
-typedef uint32_t   color32;
-
 template <typename T> struct vec2t { T x, y; };
 template <typename T> struct vec3t { T x, y, z; };
 template <typename T> struct rectt { T x, y, w, h; };

--- a/src/Core/Draw.cpp
+++ b/src/Core/Draw.cpp
@@ -29,9 +29,9 @@ const colorf Colorsf::white = {1, 1, 1, 1};
 const colorf Colorsf::black = {0, 0, 0, 1};
 const colorf Colorsf::blank = {0, 0, 0, 0};
 
-const color32 Colors::white = RGBAtoColor32(255, 255, 255, 255);
-const color32 Colors::black = RGBAtoColor32(0, 0, 0, 255);
-const color32 Colors::blank = RGBAtoColor32(0, 0, 0, 0);
+const uint32_t Colors::white = RGBAtoColor32(255, 255, 255, 255);
+const uint32_t Colors::black = RGBAtoColor32(0, 0, 0, 255);
+const uint32_t Colors::blank = RGBAtoColor32(0, 0, 0, 0);
 
 // ================================================================================================
 // TileBar.
@@ -99,7 +99,7 @@ TileBar::TileBar()
 {
 }
 
-void TileBar::draw(recti rect, color32 color, int flags) const
+void TileBar::draw(recti rect, uint32_t color, int flags) const
 {
 	int vp[24];
 	float vt[24];
@@ -111,11 +111,11 @@ void TileBar::draw(recti rect, color32 color, int flags) const
 	Renderer::drawQuads(3, vp, vt);
 }
 
-void TileBar::draw(QuadBatchTC* out, recti rect, color32 color, int flags) const
+void TileBar::draw(QuadBatchTC* out, recti rect, uint32_t color, int flags) const
 {
 	out->push(3);
 
-	color32* vc = out->col, *end = vc + 12;
+	uint32_t* vc = out->col, *end = vc + 12;
 	while(vc != end) { QCOL(color); }
 
 	TB_setVerts(*this, out->pos, out->uvs, rect, uvs, flags);
@@ -190,7 +190,7 @@ TileRect::TileRect()
 {
 }
 
-void TileRect::draw(recti rect, color32 color, int flags) const
+void TileRect::draw(recti rect, uint32_t color, int flags) const
 {
 	int vp[72];
 	float vt[72];
@@ -202,11 +202,11 @@ void TileRect::draw(recti rect, color32 color, int flags) const
 	Renderer::drawQuads(9, vp, vt);
 }
 
-void TileRect::draw(QuadBatchTC* out, recti rect, color32 color, int flags) const
+void TileRect::draw(QuadBatchTC* out, recti rect, uint32_t color, int flags) const
 {
 	out->push(9);
 
-	color32* vc = out->col, *end = vc + 36;
+	uint32_t* vc = out->col, *end = vc + 36;
 	while(vc != end) { QCOL(color); }
 
 	TR_setVerts(*this, out->pos, out->uvs, rect, uvs, flags);
@@ -262,7 +262,7 @@ static void TR2_setVerts(const TileRect2& rect, int* vp, float* vt, recti r, int
 	QUVS(s + bl, y, t + bl, z); QUVS(t, y, u, z); QUVS(u + br, y, v + br, z);
 }
 
-void TileRect2::draw(recti rect, int rounding, color32 color, int flags) const
+void TileRect2::draw(recti rect, int rounding, uint32_t color, int flags) const
 {
 	int vp[72];
 	float vt[72];
@@ -274,11 +274,11 @@ void TileRect2::draw(recti rect, int rounding, color32 color, int flags) const
 	Renderer::drawQuads(9, vp, vt);
 }
 
-void TileRect2::draw(QuadBatchTC* out, recti rect, int rounding, color32 color, int flags) const
+void TileRect2::draw(QuadBatchTC* out, recti rect, int rounding, uint32_t color, int flags) const
 {
 	out->push(9);
 
-	color32* vc = out->col, *end = vc + 36;
+	uint32_t* vc = out->col, *end = vc + 36;
 	while(vc != end) { QCOL(color); }
 
 	TR2_setVerts(*this, out->pos, out->uvs, rect, rounding, flags);
@@ -287,7 +287,7 @@ void TileRect2::draw(QuadBatchTC* out, recti rect, int rounding, color32 color, 
 // ================================================================================================
 // Rectangle drawing.
 
-void Draw::fill(recti r, color32 col)
+void Draw::fill(recti r, uint32_t col)
 {
 	// Vertex positions.
 	int pos[8], *vp = pos;
@@ -300,7 +300,7 @@ void Draw::fill(recti r, color32 col)
 	Renderer::drawQuads(1, pos);
 }
 
-void Draw::fill(QuadBatchC* out, recti r, color32 color)
+void Draw::fill(QuadBatchC* out, recti r, uint32_t color)
 {
 	out->push();
 
@@ -309,18 +309,18 @@ void Draw::fill(QuadBatchC* out, recti r, color32 color)
 	QPOS(r.x, r.y, r.x + r.w, r.y + r.h);
 	
 	// Vertex colors.
-	color32* vc = out->col;
+	uint32_t* vc = out->col;
 	QCOL(color);
 }
 
-void Draw::fill(recti r, color32 tl, color32 tr, color32 bl, color32 br, bool hsv)
+void Draw::fill(recti r, uint32_t tl, uint32_t tr, uint32_t bl, uint32_t br, bool hsv)
 {
 	// Vertex positions.
 	int pos[8], *vp = pos;
 	QPOS(r.x, r.y, r.x + r.w, r.y + r.h);
 
 	// Vertex colors.
-	color32 col[4], *vc = col;
+	uint32_t col[4], *vc = col;
 	QCOL4(tl, tr, bl, br);
 
 	// Render quad.
@@ -328,7 +328,7 @@ void Draw::fill(recti r, color32 tl, color32 tr, color32 bl, color32 br, bool hs
 	Renderer::drawQuads(1, pos, col);
 }
 
-void Draw::fill(recti r, color32 col, TextureHandle tex, Texture::Format fmt)
+void Draw::fill(recti r, uint32_t col, TextureHandle tex, Texture::Format fmt)
 {
 	// Vertex positions.
 	int pos[8], *vp = pos;
@@ -345,7 +345,7 @@ void Draw::fill(recti r, color32 col, TextureHandle tex, Texture::Format fmt)
 	Renderer::drawQuads(1, pos, uvs);
 }
 
-void Draw::fill(recti r, color32 col, TextureHandle tex, areaf uva, Texture::Format fmt)
+void Draw::fill(recti r, uint32_t col, TextureHandle tex, areaf uva, Texture::Format fmt)
 {
 	// Vertex positions.
 	int pos[8], *vp = pos;
@@ -362,9 +362,9 @@ void Draw::fill(recti r, color32 col, TextureHandle tex, areaf uva, Texture::For
 	Renderer::drawQuads(1, pos, uvs);
 }
 
-void Draw::outline(recti r, color32 col)
+void Draw::outline(recti r, uint32_t col)
 {
-	static const uint indices[24] =
+	static const uint32_t indices[24] =
 	{
 		0, 3, 1, 0, 2, 3, 4, 7, 5, 4, 6, 7, 0, 4, 2, 0, 6, 4, 3, 7, 1, 3, 5, 7
 	};
@@ -387,7 +387,7 @@ void Draw::outline(recti r, color32 col)
 	Renderer::drawTris(8, indices, vp);
 }
 
-void Draw::roundedBox(recti r, color32 c)
+void Draw::roundedBox(recti r, uint32_t c)
 {
 	Renderer::getRoundedBox().draw(r, c);
 }
@@ -400,7 +400,7 @@ void Draw::sprite(const Texture& tex, vec2i pos, int flags)
 	Draw::sprite(tex, pos, Colors::white, flags);
 }
 
-void Draw::sprite(const Texture& tex, vec2i pos, color32 col, int flags)
+void Draw::sprite(const Texture& tex, vec2i pos, uint32_t col, int flags)
 {
 	vec2i size = tex.size();
 	int w = size.x, x = pos.x - w / 2;

--- a/src/Core/Draw.h
+++ b/src/Core/Draw.h
@@ -18,10 +18,10 @@ constexpr int kColor32_GreenShift = 8;
 constexpr int kColor32_BlueShift = 16;
 constexpr int kColor32_AlphaShift = 24;
 
-// Inline function to create a color32 from 8-bit RGBA values.
-inline color32 RGBAtoColor32(int r, int g, int b, int a)
+// Inline function to create a uint32_t from 8-bit RGBA values.
+inline uint32_t RGBAtoColor32(int r, int g, int b, int a)
 {
-    return static_cast<color32>(
+    return static_cast<uint32_t>(
         ((a << kColor32_AlphaShift) & kColor32_AlphaMask) |
         ((b << kColor32_BlueShift) & kColor32_BlueMask)   |
         ((g << kColor32_GreenShift) & kColor32_GreenMask) |
@@ -29,17 +29,17 @@ inline color32 RGBAtoColor32(int r, int g, int b, int a)
     );
 }
 
-inline color32 Color32(int r, int g, int b, int a = 255)
+inline uint32_t Color32(int r, int g, int b, int a = 255)
 {
 	return RGBAtoColor32(r, g, b, a);
 }
 
-inline color32 Color32(int lum, int a = 255)
+inline uint32_t Color32(int lum, int a = 255)
 {
 	return RGBAtoColor32(lum, lum, lum, a);
 }
 
-inline color32 Color32a(color32 rgb, int a)
+inline uint32_t Color32a(uint32_t rgb, int a)
 {
 	return (rgb & ~kColor32_AlphaMask) | ((a << kColor32_AlphaShift) & kColor32_AlphaMask);
 }
@@ -48,7 +48,7 @@ inline color32 Color32a(color32 rgb, int a)
 struct Colorsf { static const colorf white, black, blank; };
 
 // Common colors (8-bit RGBA).
-struct Colors { static const color32 white, black, blank; };
+struct Colors { static const uint32_t white, black, blank; };
 
 // ================================================================================================
 // Drawing objects.
@@ -61,10 +61,10 @@ struct TileBar
 	TileBar();
 
 	void draw(recti rect,
-		color32 color = Colors::white, int flags = 0) const;
+		uint32_t color = Colors::white, int flags = 0) const;
 
 	void draw(QuadBatchTC* out, recti rect,
-		color32 color = Colors::white, int flags = 0) const;
+		uint32_t color = Colors::white, int flags = 0) const;
 
 	Texture texture;
 	areaf uvs;
@@ -79,10 +79,10 @@ struct TileRect
 	TileRect();
 
 	void draw(recti rect,
-		color32 color = Colors::white, int flags = 0) const;
+		uint32_t color = Colors::white, int flags = 0) const;
 
 	void draw(QuadBatchTC* out, recti rect,
-		color32 color = Colors::white, int flags = 0) const;
+		uint32_t color = Colors::white, int flags = 0) const;
 
 	Texture texture;
 	areaf uvs;
@@ -110,10 +110,10 @@ struct TileRect2
 	};
 
 	void draw(recti rect,
-		int rounding = ALL, color32 color = Colors::white, int flags = 0) const;
+		int rounding = ALL, uint32_t color = Colors::white, int flags = 0) const;
 
 	void draw(QuadBatchTC* out, recti rect,
-		int rounding = ALL, color32 color = Colors::white, int flags = 0) const;
+		int rounding = ALL, uint32_t color = Colors::white, int flags = 0) const;
 
 	Texture texture;
 	int border;
@@ -131,21 +131,21 @@ namespace Draw
 	};
 
 	/// Draws a filled rectangle.
-	void fill(recti r, color32 c);
-	void fill(QuadBatchC* batch, recti r, color32 c);
-	void fill(recti r, color32 tl, color32 tr, color32 bl, color32 br, bool hsv);
-	void fill(recti r, color32 c, TextureHandle t, Texture::Format fmt = Texture::RGBA);
-	void fill(recti r, color32 c, TextureHandle t, areaf uvs, Texture::Format fmt = Texture::RGBA);
+	void fill(recti r, uint32_t c);
+	void fill(QuadBatchC* batch, recti r, uint32_t c);
+	void fill(recti r, uint32_t tl, uint32_t tr, uint32_t bl, uint32_t br, bool hsv);
+	void fill(recti r, uint32_t c, TextureHandle t, Texture::Format fmt = Texture::RGBA);
+	void fill(recti r, uint32_t c, TextureHandle t, areaf uvs, Texture::Format fmt = Texture::RGBA);
 
 	/// Draws a rectangle outline.
-	void outline(recti r, color32 c);
+	void outline(recti r, uint32_t c);
 
 	/// Draws a rectangle with round corners of radius 4.
-	void roundedBox(recti r, color32 c);
+	void roundedBox(recti r, uint32_t c);
 
 	/// Draws a sprite.
 	void sprite(const Texture& t, vec2i pos, int flags = 0);
-	void sprite(const Texture& t, vec2i pos, color32 c, int flags = 0);
+	void sprite(const Texture& t, vec2i pos, uint32_t c, int flags = 0);
 };
 
 }; // namespace Vortex

--- a/src/Core/FontData.cpp
+++ b/src/Core/FontData.cpp
@@ -16,14 +16,14 @@ static const int CHANNELS = 1;
 static const Texture::Format FORMAT = Texture::ALPHA;
 
 // Creates a padded grayscale copy of a glyph bitmap.
-static uchar* CopyGlyphBitmap(int boxW, int boxH, FT_Bitmap bitmap)
+static uint8_t* CopyGlyphBitmap(int boxW, int boxH, FT_Bitmap bitmap)
 {
 	int srcW = bitmap.width, srcH = bitmap.rows, srcP = abs(bitmap.pitch);
-	uchar* out = (uchar*)calloc(boxW * boxH, 1);
+	uint8_t* out = (uint8_t*)calloc(boxW * boxH, 1);
 	for(int y = 0; y < srcH; ++y)
 	{
-		const uchar* src = bitmap.buffer + y * srcP;
-		uchar* dst = out + ((y + PADDING) * boxW + PADDING) * CHANNELS;
+		const uint8_t* src = bitmap.buffer + y * srcP;
+		uint8_t* dst = out + ((y + PADDING) * boxW + PADDING) * CHANNELS;
 		switch(bitmap.pixel_mode)
 		{
 		case FT_PIXEL_MODE_BGRA:
@@ -49,7 +49,7 @@ static uchar* CopyGlyphBitmap(int boxW, int boxH, FT_Bitmap bitmap)
 enum GlyphTraitBits { GTB_WHITESPACE = 1, GTB_NEWLINE = 2 };
 
 // Glyph traits of charcode values up to 32, values above 32 always have zero.
-static const uchar glyphTraits[33] =
+static const uint8_t glyphTraits[33] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 | 2, 1, 1, 1, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
@@ -59,7 +59,7 @@ static GlyphCache* CreateCache(FT_Face face, int size)
 {
 	int texW = 128, texH = 128;
 	while(texW < 1024 && texW < size * 8 + 64) texW *= 2;
-	std::vector<uchar> pixels(texW * texH, 0);
+	std::vector<uint8_t> pixels(texW * texH, 0);
 
 	auto* cache = new GlyphCache;
 	cache->tex = TextureManager::load(texW, texH, FORMAT, false, pixels.data());
@@ -215,7 +215,7 @@ static Glyph* PutGlyphInCache(GlyphCache* cache, FT_GlyphSlot slot)
 		}
 
 		// Copy the glyph pixels to the cache texture.
-		uchar* pixels = CopyGlyphBitmap(bitmapW, bitmapH, bitmap);
+		uint8_t* pixels = CopyGlyphBitmap(bitmapW, bitmapH, bitmap);
 		cache->tex->modify(glyph->box.x, glyph->box.y, bitmapW, bitmapH, pixels);
 		cache->shelfH = max(cache->shelfH, bitmapH);
 		free(pixels);
@@ -255,7 +255,7 @@ Glyph* RenderGlyph(FontData* font, GlyphCache* cache, int size, int charcode)
 
 	// Render the glyph as a bitmap using FreeType.
 	FT_Error error = 0;
-	uint index = FT_Get_Char_Index(face, charcode);
+	uint32_t index = FT_Get_Char_Index(face, charcode);
 	if(index) error = FT_Load_Glyph(face, index, font->loadflags);
 
 	// Check if the glyph is supported by the font face and was rendered correctly.

--- a/src/Core/FontData.h
+++ b/src/Core/FontData.h
@@ -17,17 +17,17 @@ struct FontData;
 
 struct Glyph
 {
-	uint hasPixels : 1;
-	uint hasAlphaTex : 1;
-	uint isWhitespace : 1;
-	uint isNewline : 1;
-	uint dummy : 28;
+	uint32_t hasPixels : 1;
+	uint32_t hasAlphaTex : 1;
+	uint32_t isWhitespace : 1;
+	uint32_t isNewline : 1;
+	uint32_t dummy : 28;
 	int advance;
 	areai ofs;
 	recti box;
 	areaf uvs;
 	int index;
-	uint charcode;
+	uint32_t charcode;
 	FontData* font;
 	Texture::Data* tex;
 	float timeSinceLastUse;

--- a/src/Core/FontManager.cpp
+++ b/src/Core/FontManager.cpp
@@ -43,7 +43,7 @@ static void CreatePlaceholderGlyphs(Glyph* out)
 	static const int b[8] = {1, 1,  1,  2,  2,  3,  3,  4};
 	static const int bufferSize = (22 + padding) * (44 + padding);
 
-	uchar tmp[bufferSize];
+	uint8_t tmp[bufferSize];
 	for(int i = 0; i < 8; ++i)
 	{
 		memset(tmp, 0, bufferSize);

--- a/src/Core/Gui.h
+++ b/src/Core/Gui.h
@@ -25,9 +25,9 @@ public:
 
 	// Functions that bind a read-only value to a slot.
 	virtual bool bind(StringRef slot, const int* v) = 0;
-	virtual bool bind(StringRef slot, const uint* v) = 0;
+	virtual bool bind(StringRef slot, const uint32_t* v) = 0;
 	virtual bool bind(StringRef slot, const long* v) = 0;
-	virtual bool bind(StringRef slot, const ulong* v) = 0;
+	virtual bool bind(StringRef slot, const uint64_t* v) = 0;
 	virtual bool bind(StringRef slot, const float* v) = 0;
 	virtual bool bind(StringRef slot, const double* v) = 0;
 	virtual bool bind(StringRef slot, const bool* v) = 0;
@@ -36,9 +36,9 @@ public:
 
 	// Functions that bind a read-write value to a slot.
 	virtual bool bind(StringRef slot, int* v) = 0;
-	virtual bool bind(StringRef slot, uint* v) = 0;
+	virtual bool bind(StringRef slot, uint32_t* v) = 0;
 	virtual bool bind(StringRef slot, long* v) = 0;
-	virtual bool bind(StringRef slot, ulong* v) = 0;
+	virtual bool bind(StringRef slot, uint64_t* v) = 0;
 	virtual bool bind(StringRef slot, float* v) = 0;
 	virtual bool bind(StringRef slot, double* v) = 0;
 	virtual bool bind(StringRef slot, bool* v) = 0;
@@ -147,7 +147,7 @@ protected:
 	recti rect_;
 	int width_;
 	int height_;
-	uint flags_;
+	uint32_t flags_;
 };
 
 // Base class for dialog objects.

--- a/src/Core/GuiContext.cpp
+++ b/src/Core/GuiContext.cpp
@@ -152,7 +152,7 @@ bool GuiContextImpl::bind(StringRef slot, const int* v)
 	return s != nullptr;
 }
 
-bool GuiContextImpl::bind(StringRef slot, const uint* v)
+bool GuiContextImpl::bind(StringRef slot, const uint32_t* v)
 {
 	auto s = Map::findVal(value_slots_, slot);
 	if(s) (*s)->bind(v);
@@ -166,7 +166,7 @@ bool GuiContextImpl::bind(StringRef slot, const long* v)
 	return s != nullptr;
 }
 
-bool GuiContextImpl::bind(StringRef slot, const ulong* v)
+bool GuiContextImpl::bind(StringRef slot, const uint64_t* v)
 {
 	auto s = Map::findVal(value_slots_, slot);
 	if(s) (*s)->bind(v);
@@ -215,7 +215,7 @@ bool GuiContextImpl::bind(StringRef slot, int* v)
 	return s != nullptr;
 }
 
-bool GuiContextImpl::bind(StringRef slot, uint* v)
+bool GuiContextImpl::bind(StringRef slot, uint32_t* v)
 {
 	auto s = Map::findVal(value_slots_, slot);
 	if(s) (*s)->bind(v);
@@ -229,7 +229,7 @@ bool GuiContextImpl::bind(StringRef slot, long* v)
 	return s != nullptr;
 }
 
-bool GuiContextImpl::bind(StringRef slot, ulong* v)
+bool GuiContextImpl::bind(StringRef slot, uint64_t* v)
 {
 	auto s = Map::findVal(value_slots_, slot);
 	if(s) (*s)->bind(v);

--- a/src/Core/GuiContext.h
+++ b/src/Core/GuiContext.h
@@ -27,9 +27,9 @@ public:
 	InputEvents& getEvents();
 
 	bool bind(StringRef slot, const int* v);
-	bool bind(StringRef slot, const uint* v);
+	bool bind(StringRef slot, const uint32_t* v);
 	bool bind(StringRef slot, const long* v);
-	bool bind(StringRef slot, const ulong* v);
+	bool bind(StringRef slot, const uint64_t* v);
 	bool bind(StringRef slot, const float* v);
 	bool bind(StringRef slot, const double* v);
 	bool bind(StringRef slot, const bool* v);
@@ -37,9 +37,9 @@ public:
 	bool bind(StringRef slot, const String* str);
 
 	bool bind(StringRef slot, int* v);
-	bool bind(StringRef slot, uint* v);
+	bool bind(StringRef slot, uint32_t* v);
 	bool bind(StringRef slot, long* v);
-	bool bind(StringRef slot, ulong* v);
+	bool bind(StringRef slot, uint64_t* v);
 	bool bind(StringRef slot, float* v);
 	bool bind(StringRef slot, double* v);
 	bool bind(StringRef slot, bool* v);

--- a/src/Core/GuiDialog.cpp
+++ b/src/Core/GuiDialog.cpp
@@ -343,7 +343,7 @@ void DialogData::draw()
 	{
 		if(is_closeable_)
 		{
-			color32 col = Color32((action == ACT_CLOSE) ? 200 : 100);
+			uint32_t col = Color32((action == ACT_CLOSE) ? 200 : 100);
 			Draw::sprite(icons.cross, {buttonX, r.y + FRAME_TITLEBAR_H / 2}, col);
 			buttonX -= FRAME_BUTTON_W;
 			titleTextW -= FRAME_BUTTON_W;
@@ -355,7 +355,7 @@ void DialogData::draw()
 		if(is_minimizable_)
 		{
 			auto& tex = minimized_state_ ? icons.plus : icons.minus;
-			color32 col = Color32((action == ACT_MINIMIZE) ? 200 : 100);
+			uint32_t col = Color32((action == ACT_MINIMIZE) ? 200 : 100);
 			Draw::sprite(tex, {buttonX, r.y + FRAME_TITLEBAR_H / 2}, col);
 			buttonX -= FRAME_BUTTON_W;
 			titleTextW -= FRAME_BUTTON_W;
@@ -368,7 +368,7 @@ void DialogData::draw()
 	if(is_pinnable_)
 	{
 		auto& tex = pinned_state_ ? icons.unpin : icons.pin;
-		color32 col = Color32((action == ACT_PIN) ? 200 : 100);
+		uint32_t col = Color32((action == ACT_PIN) ? 200 : 100);
 		Draw::sprite(tex, {buttonX, r.y + FRAME_TITLEBAR_H / 2}, col);
 		buttonX -= FRAME_BUTTON_W;
 		titleTextW -= FRAME_BUTTON_W;

--- a/src/Core/GuiDialog.h
+++ b/src/Core/GuiDialog.h
@@ -51,19 +51,19 @@ public:
 	GuiDialog* dialog_ptr_;
 	GuiContext* gui_;
 
-	uint is_pinnable_ : 1;
-	uint is_closeable_ : 1;
-	uint is_minimizable_ : 1;
-	uint is_horizontally_resizable_ : 1;
-	uint is_vertically_resizable_ : 1;
+	uint32_t is_pinnable_ : 1;
+	uint32_t is_closeable_ : 1;
+	uint32_t is_minimizable_ : 1;
+	uint32_t is_horizontally_resizable_ : 1;
+	uint32_t is_vertically_resizable_ : 1;
 
-	uint request_close_ : 1;
-	uint request_pin_ : 1;
-	uint request_minimize_ : 1;
-	uint request_move_to_top_ : 1;
+	uint32_t request_close_ : 1;
+	uint32_t request_pin_ : 1;
+	uint32_t request_minimize_ : 1;
+	uint32_t request_move_to_top_ : 1;
 
-	uint pinned_state_ : 1;
-	uint minimized_state_ : 1;
+	uint32_t pinned_state_ : 1;
+	uint32_t minimized_state_ : 1;
 
 private:
 	friend class GuiDialog;

--- a/src/Core/GuiDraw.cpp
+++ b/src/Core/GuiDraw.cpp
@@ -328,7 +328,7 @@ void GuiDraw::button(TileRect* tr, const recti& r, bool hover, bool focus)
 	}
 }
 
-void GuiDraw::checkerboard(recti r, color32 color)
+void GuiDraw::checkerboard(recti r, uint32_t color)
 {
 	// Vertex positions.
 	int vp[8];

--- a/src/Core/GuiDraw.h
+++ b/src/Core/GuiDraw.h
@@ -39,7 +39,7 @@ struct GuiDraw
 	struct Misc
 	{
 		Texture checkerboard;
-		color32 colDisabled;
+		uint32_t colDisabled;
 		TileRect imgSelect;
 	};
 
@@ -55,7 +55,7 @@ struct GuiDraw
 
 	static void button(TileRect* tr, const recti& r, bool hover, bool focus);
 
-	static void checkerboard(recti r, color32 color);
+	static void checkerboard(recti r, uint32_t color);
 };
 
 }; // namespace Vortex

--- a/src/Core/GuiWidget.cpp
+++ b/src/Core/GuiWidget.cpp
@@ -16,7 +16,7 @@ namespace Vortex {
 	recti rect_;
 	int width_;
 	int height_;
-	uint flags_;
+	uint32_t flags_;
 
 GuiWidget::GuiWidget(GuiContext* gui)
 	: gui_(gui)

--- a/src/Core/ImageLoader.h
+++ b/src/Core/ImageLoader.h
@@ -8,7 +8,7 @@ namespace Vortex {
 namespace ImageLoader
 {
 	enum Format { RGBA, RGB, LUMA, LUM, ALPHA };
-	struct Data { uchar* pixels; int width, height; };
+	struct Data { uint8_t* pixels; int width, height; };
 	Data load(const char* path, Format targetFormat);
 	void release(Data& data);
 };
@@ -16,8 +16,8 @@ namespace ImageLoader
 /// Functions related to zlib decompression.
 namespace Zlib
 {
-	struct Data { uchar* data; int numBytes; };
-	Data deflate(const uchar* compressedData, int numBytes);
+	struct Data { uint8_t* data; int numBytes; };
+	Data deflate(const uint8_t* compressedData, int numBytes);
 	void release(Data& data);
 };
 

--- a/src/Core/QuadBatch.cpp
+++ b/src/Core/QuadBatch.cpp
@@ -84,26 +84,26 @@ void BatchSprite::draw(QuadBatchT* out, int x, int y, int y2)
 	memcpy(out->uvs, uvs, sizeof(float) * 8);
 }
 
-void BatchSprite::draw(QuadBatchTC* out, int x, int y, uchar alpha)
+void BatchSprite::draw(QuadBatchTC* out, int x, int y, uint8_t alpha)
 {
-	draw(out, x, y, (color32)RGBAtoColor32(255, 255, 255, alpha));
+	draw(out, x, y, (uint32_t)RGBAtoColor32(255, 255, 255, alpha));
 }
 
-void BatchSprite::draw(QuadBatchTC* out, int x, int y, color32 col)
+void BatchSprite::draw(QuadBatchTC* out, int x, int y, uint32_t col)
 {
 	int w = width * DrawScale / 512;
 	int h = height * DrawScale / 512;
 
 	int vp[8] = {x - w, y - h, x + w, y - h, x - w, y + h, x + w, y + h};
-	uint vc[4] = {col, col, col, col};
+	uint32_t vc[4] = {col, col, col, col};
 
 	out->push();
 	memcpy(out->pos, vp, sizeof(int) * 8);
 	memcpy(out->uvs, uvs, sizeof(float) * 8);
-	memcpy(out->col, vc, sizeof(color32) * 4);
+	memcpy(out->col, vc, sizeof(uint32_t) * 4);
 }
 
-void BatchSprite::draw(QuadBatchTC* out, float x, float y, float rotation, float scale, uint color)
+void BatchSprite::draw(QuadBatchTC* out, float x, float y, float rotation, float scale, uint32_t color)
 {
 	float rsin = (float)sin(rotation);
 	float rcos = (float)cos(rotation);
@@ -120,8 +120,8 @@ void BatchSprite::draw(QuadBatchTC* out, float x, float y, float rotation, float
 		vp[j] = (int)(y + xy[i] * rsin + xy[j] * rcos);
 	}
 
-	uint vc[4] = {color, color, color, color};
-	memcpy(out->col, vc, sizeof(color32) * 4);
+	uint32_t vc[4] = {color, color, color, color};
+	memcpy(out->col, vc, sizeof(uint32_t) * 4);
 	memcpy(out->uvs, uvs, sizeof(float) * 8);
 }
 

--- a/src/Core/QuadBatch.h
+++ b/src/Core/QuadBatch.h
@@ -23,10 +23,10 @@ struct BatchSprite
 	void draw(QuadBatchT* batch, int x, int y);
 	void draw(QuadBatchT* batch, int x, int y, int y2);
 
-	void draw(QuadBatchTC* batch, int x, int y, uchar alpha);
-	void draw(QuadBatchTC* batch, int x, int y, color32 color);
+	void draw(QuadBatchTC* batch, int x, int y, uint8_t alpha);
+	void draw(QuadBatchTC* batch, int x, int y, uint32_t color);
 
-	void draw(QuadBatchTC* batch, float x, float y, float rotation, float scale = 1.f, uint color = 0xFFFFFFFF);
+	void draw(QuadBatchTC* batch, float x, float y, float rotation, float scale = 1.f, uint32_t color = 0xFFFFFFFF);
 
 	float uvs[8];
 	int width, height;

--- a/src/Core/Renderer.cpp
+++ b/src/Core/Renderer.cpp
@@ -13,9 +13,9 @@ namespace Vortex {
 
 static const int BATCH_QUAD_LIMIT = 256;
 
-static const int VB_POS_STRIDE = sizeof(uint) * 8;
+static const int VB_POS_STRIDE = sizeof(uint32_t) * 8;
 static const int VB_UVS_STRIDE = sizeof(float) * 8;
-static const int VB_COL_STRIDE = sizeof(uint) * 4;
+static const int VB_COL_STRIDE = sizeof(uint32_t) * 4;
 
 static const int VB_POS_SIZE = VB_POS_STRIDE * BATCH_QUAD_LIMIT;
 static const int VB_UVS_SIZE = VB_UVS_STRIDE * BATCH_QUAD_LIMIT;
@@ -30,11 +30,11 @@ struct RendererInstance
 {
 	Shader shaders[4];
 	Vector<recti> scissorStack;
-	uint* quadIndices;
+	uint32_t* quadIndices;
 
-	uchar* batchPos;
-	uchar* batchCol;
-	uchar* batchUvs;
+	uint8_t* batchPos;
+	uint8_t* batchCol;
+	uint8_t* batchUvs;
 	int quadsLeft;
 
 	TileRect roundedBox;
@@ -49,7 +49,7 @@ static RendererInstance* RI;
 
 static void createBatchData()
 {
-	RI->batchPos = (uchar*)malloc(VB_POS_SIZE + VB_UVS_SIZE + VB_COL_SIZE);
+	RI->batchPos = (uint8_t*)malloc(VB_POS_SIZE + VB_UVS_SIZE + VB_COL_SIZE);
 	RI->batchUvs = RI->batchPos + VB_POS_SIZE;
 	RI->batchCol = RI->batchUvs + VB_UVS_SIZE;
 	RI->quadsLeft = BATCH_QUAD_LIMIT;
@@ -57,8 +57,8 @@ static void createBatchData()
 
 static void createQuadIndices()
 {
-	RI->quadIndices = (uint*)malloc(sizeof(uint) * BATCH_QUAD_LIMIT * 6);
-	for(uint* p = RI->quadIndices, i = 0; i < BATCH_QUAD_LIMIT * 4; i += 4)
+	RI->quadIndices = (uint32_t*)malloc(sizeof(uint32_t) * BATCH_QUAD_LIMIT * 6);
+	for(uint32_t* p = RI->quadIndices, i = 0; i < BATCH_QUAD_LIMIT * 4; i += 4)
 	{
 		*p = i + 0; ++p;
 		*p = i + 3; ++p;
@@ -187,9 +187,9 @@ void Renderer::setColor(colorf color)
 	glColor4f(color.r, color.g, color.b, color.a);
 }
 
-void Renderer::setColor(color32 color)
+void Renderer::setColor(uint32_t color)
 {
-	uchar* c = (uchar*)&color;
+	uint8_t* c = (uint8_t*)&color;
 	glColor4ub(c[0], c[1], c[2], c[3]);
 }
 
@@ -250,7 +250,7 @@ void Renderer::popScissorRect()
 // Core rendering functions.
 
 static int FlushQuads(GLint vertexType, const void* pos,
-	const float* uvs = nullptr, const color32* col = nullptr)
+	const float* uvs = nullptr, const uint32_t* col = nullptr)
 {
 	glDrawElements(GL_TRIANGLES, BATCH_QUAD_LIMIT * 6, GL_UNSIGNED_INT, RI->quadIndices);
 	pos = (int*)pos + BATCH_QUAD_LIMIT * 8;
@@ -279,7 +279,7 @@ void Renderer::drawQuads(int numQuads, const int* pos)
 	glDrawElements(GL_TRIANGLES, numQuads * 6, GL_UNSIGNED_INT, RI->quadIndices);
 }
 
-void Renderer::drawQuads(int numQuads, const int* pos, const color32* col)
+void Renderer::drawQuads(int numQuads, const int* pos, const uint32_t* col)
 {
 	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 	glEnableClientState(GL_COLOR_ARRAY);
@@ -303,7 +303,7 @@ void Renderer::drawQuads(int numQuads, const int* pos, const float* uvs)
 	glDrawElements(GL_TRIANGLES, numQuads * 6, GL_UNSIGNED_INT, RI->quadIndices);
 }
 
-void Renderer::drawQuads(int numQuads, const int* pos, const float* uvs, const color32* col)
+void Renderer::drawQuads(int numQuads, const int* pos, const float* uvs, const uint32_t* col)
 {
 	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 	glEnableClientState(GL_COLOR_ARRAY);
@@ -316,7 +316,7 @@ void Renderer::drawQuads(int numQuads, const int* pos, const float* uvs, const c
 	glDrawElements(GL_TRIANGLES, numQuads * 6, GL_UNSIGNED_INT, RI->quadIndices);
 }
 
-void Renderer::drawQuads(int numQuads, const float* pos, const float* uvs, const color32* col)
+void Renderer::drawQuads(int numQuads, const float* pos, const float* uvs, const uint32_t* col)
 {
 	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 	glEnableClientState(GL_COLOR_ARRAY);
@@ -329,7 +329,7 @@ void Renderer::drawQuads(int numQuads, const float* pos, const float* uvs, const
 	glDrawElements(GL_TRIANGLES, numQuads * 6, GL_UNSIGNED_INT, RI->quadIndices);
 }
 
-void Renderer::drawTris(int numTris, const uint* indices, const int* pos)
+void Renderer::drawTris(int numTris, const uint32_t* indices, const int* pos)
 {
 	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 	glDisableClientState(GL_COLOR_ARRAY);
@@ -339,7 +339,7 @@ void Renderer::drawTris(int numTris, const uint* indices, const int* pos)
 	glDrawElements(GL_TRIANGLES, numTris * 3, GL_UNSIGNED_INT, indices);
 }
 
-void Renderer::drawTris(int numTris, const uint* indices, const int* pos, const float* uvs)
+void Renderer::drawTris(int numTris, const uint32_t* indices, const int* pos, const float* uvs)
 {
 	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 	glDisableClientState(GL_COLOR_ARRAY);
@@ -356,7 +356,7 @@ void Renderer::drawTris(int numTris, const uint* indices, const int* pos, const 
 static void FlushIC()
 {
 	Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft,
-		(int*)RI->batchPos, (color32*)RI->batchCol);
+		(int*)RI->batchPos, (uint32_t*)RI->batchCol);
 	RI->quadsLeft = BATCH_QUAD_LIMIT;
 }
 
@@ -370,7 +370,7 @@ static void FlushIT()
 static void FlushITC()
 {
 	Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft,
-		(int*)RI->batchPos, (float*)RI->batchUvs, (color32*)RI->batchCol);
+		(int*)RI->batchPos, (float*)RI->batchUvs, (uint32_t*)RI->batchCol);
 	RI->quadsLeft = BATCH_QUAD_LIMIT;
 }
 
@@ -381,7 +381,7 @@ void QuadBatchC::push(int numQuads)
 	RI->quadsLeft -= numQuads;
 
 	pos = (int*)(RI->batchPos + offset * VB_POS_STRIDE);
-	col = (color32*)(RI->batchCol + offset * VB_COL_STRIDE);
+	col = (uint32_t*)(RI->batchCol + offset * VB_COL_STRIDE);
 }
 
 void QuadBatchT::push(int numQuads)
@@ -402,7 +402,7 @@ void QuadBatchTC::push(int numQuads)
 
 	pos = (int*)(RI->batchPos + offset * VB_POS_STRIDE);
 	uvs = (float*)(RI->batchUvs + offset * VB_UVS_STRIDE);
-	col = (color32*)(RI->batchCol + offset * VB_COL_STRIDE);
+	col = (uint32_t*)(RI->batchCol + offset * VB_COL_STRIDE);
 }
 
 void QuadBatchC::flush()
@@ -422,7 +422,7 @@ void QuadBatchTC::flush()
 
 QuadBatchC Renderer::batchC()
 {
-	return {(int*)RI->batchPos, (color32*)RI->batchCol};
+	return {(int*)RI->batchPos, (uint32_t*)RI->batchCol};
 }
 
 QuadBatchT Renderer::batchT()
@@ -432,7 +432,7 @@ QuadBatchT Renderer::batchT()
 
 QuadBatchTC Renderer::batchTC()
 {
-	return {(int*)RI->batchPos, (float*)RI->batchUvs, (color32*)RI->batchCol};
+	return {(int*)RI->batchPos, (float*)RI->batchUvs, (uint32_t*)RI->batchCol};
 }
 
 const TileRect& Renderer::getRoundedBox()

--- a/src/Core/Renderer.h
+++ b/src/Core/Renderer.h
@@ -13,7 +13,7 @@ struct QuadBatchC
 	void flush();
 
 	int* pos;
-	color32* col;
+	uint32_t* col;
 };
 
 // Quad batch with vertices, and texture coordinates.
@@ -34,7 +34,7 @@ struct QuadBatchTC
 
 	int* pos;
 	float* uvs;
-	color32* col;
+	uint32_t* col;
 };
 
 namespace Renderer
@@ -59,7 +59,7 @@ namespace Renderer
 	void bindShader(DefaultShader shader);
 
 	void setColor(colorf color);
-	void setColor(color32 color);
+	void setColor(uint32_t color);
 	void resetColor();
 
 	void pushScissorRect(int x, int y, int w, int h);
@@ -68,12 +68,12 @@ namespace Renderer
 
 	void drawQuads(int numQuads, const int* pos);
 	void drawQuads(int numQuads, const int* pos, const float* uvs);
-	void drawQuads(int numQuads, const int* pos, const color32* col);
-	void drawQuads(int numQuads, const int* pos, const float* uvs, const color32* col);
-	void drawQuads(int numQuads, const float* pos, const float* uvs, const color32* col);
+	void drawQuads(int numQuads, const int* pos, const uint32_t* col);
+	void drawQuads(int numQuads, const int* pos, const float* uvs, const uint32_t* col);
+	void drawQuads(int numQuads, const float* pos, const float* uvs, const uint32_t* col);
 
-	void drawTris(int numTris, const uint* indices, const int* pos);
-	void drawTris(int numTris, const uint* indices, const int* pos, const float* uvs);
+	void drawTris(int numTris, const uint32_t* indices, const int* pos);
+	void drawTris(int numTris, const uint32_t* indices, const int* pos, const float* uvs);
 
 	QuadBatchC batchC();
 	QuadBatchT batchT();

--- a/src/Core/Shader.cpp
+++ b/src/Core/Shader.cpp
@@ -117,7 +117,7 @@ static bool Error(String& log, const char* desc, const char* name, const char* f
 	return false;
 }
 
-static void Destroy(uint& program, uint& vert, uint& frag)
+static void Destroy(uint32_t& program, uint32_t& vert, uint32_t& frag)
 {
 	if(program)
 	{

--- a/src/Core/Shader.h
+++ b/src/Core/Shader.h
@@ -32,7 +32,7 @@ public:
 	static void uniform4f(int loc, float x, float y, float z, float w);
 	static void uniform4f(int loc, const colorf& color);
 	
-	uint program_id_, vertex_shader_id_, fragment_shader_id_;
+	uint32_t program_id_, vertex_shader_id_, fragment_shader_id_;
 };
 
 }; // namespace Vortex

--- a/src/Core/Slot.cpp
+++ b/src/Core/Slot.cpp
@@ -200,10 +200,10 @@ void ValueSlot::bind(const int* v)
 	data_ = new ConstIntPtr<int>(v);
 }
 
-void ValueSlot::bind(const uint* v)
+void ValueSlot::bind(const uint32_t* v)
 {
 	ReleaseVal(data_);
-	data_ = new ConstIntPtr<uint>(v);
+	data_ = new ConstIntPtr<uint32_t>(v);
 }
 
 void ValueSlot::bind(const long* v)
@@ -212,10 +212,10 @@ void ValueSlot::bind(const long* v)
 	data_ = new ConstIntPtr<long>(v);
 }
 
-void ValueSlot::bind(const ulong* v)
+void ValueSlot::bind(const uint64_t* v)
 {
 	ReleaseVal(data_);
-	data_ = new ConstIntPtr<ulong>(v);
+	data_ = new ConstIntPtr<uint64_t>(v);
 }
 
 void ValueSlot::bind(const float* v)
@@ -242,10 +242,10 @@ void ValueSlot::bind(int* v)
 	data_ = new IntPtr<int>(v);
 }
 
-void ValueSlot::bind(uint* v)
+void ValueSlot::bind(uint32_t* v)
 {
 	ReleaseVal(data_);
-	data_ = new IntPtr<uint>(v);
+	data_ = new IntPtr<uint32_t>(v);
 }
 
 void ValueSlot::bind(long* v)
@@ -254,10 +254,10 @@ void ValueSlot::bind(long* v)
 	data_ = new IntPtr<long>(v);
 }
 
-void ValueSlot::bind(ulong* v)
+void ValueSlot::bind(uint64_t* v)
 {
 	ReleaseVal(data_);
-	data_ = new IntPtr<ulong>(v);
+	data_ = new IntPtr<uint64_t>(v);
 }
 
 void ValueSlot::bind(float* v)

--- a/src/Core/Slot.h
+++ b/src/Core/Slot.h
@@ -69,18 +69,18 @@ public:
 
 	/// Binds a read-only value.
 	void bind(const int* v);
-	void bind(const uint* v);
+	void bind(const uint32_t* v);
 	void bind(const long* v);
-	void bind(const ulong* v);
+	void bind(const uint64_t* v);
 	void bind(const float* v);
 	void bind(const double* v);
 	void bind(const bool* v);
 
 	/// Binds a read-write value.
 	void bind(int* v);
-	void bind(uint* v);
+	void bind(uint32_t* v);
 	void bind(long* v);
-	void bind(ulong* v);
+	void bind(uint64_t* v);
 	void bind(float* v);
 	void bind(double* v);
 	void bind(bool* v);

--- a/src/Core/StringUtils.cpp
+++ b/src/Core/StringUtils.cpp
@@ -243,7 +243,7 @@ int Str::readInt(StringRef s, int alt)
 	return alt;
 }
 
-uint Str::readUint(StringRef s, uint alt)
+uint32_t Str::readUint(StringRef s, uint32_t alt)
 {
 	read(s, &alt);
 	return alt;
@@ -299,10 +299,10 @@ bool Str::read(StringRef s, int* out)
 	return true;
 }
 
-bool Str::read(StringRef s, uint* out)
+bool Str::read(StringRef s, uint32_t* out)
 {
 	char* end;
-	uint v = strtoul(s.string_, &end, 10);
+	uint32_t v = strtoul(s.string_, &end, 10);
 	if(v == 0 && (*s.string_ == 0 || *end != 0)) return false;
 	*out = v;
 	return true;
@@ -675,7 +675,7 @@ static int PrintInt(char* buf, int v, int minDig, bool hex)
 	return (len < 0) ? DBL_BUFLEN : len;
 }
 
-static int PrintUint(char* buf, uint v, int minDig, bool hex)
+static int PrintUint(char* buf, uint32_t v, int minDig, bool hex)
 {
 	int len;
 	if(minDig <= 0)
@@ -727,7 +727,7 @@ String Str::val(int v, int minDig, bool hex)
 	return String(buf, PrintInt(buf, v, minDig, hex));
 }
 
-String Str::val(uint v, int minDig, bool hex)
+String Str::val(uint32_t v, int minDig, bool hex)
 {
 	char buf[INT_BUFLEN];
 	return String(buf, PrintUint(buf, v, minDig, hex));
@@ -751,7 +751,7 @@ void Str::appendVal(String& s, int v, int minDig, bool hex)
 	append(s, buf, PrintInt(buf, v, minDig, hex));
 }
 
-void Str::appendVal(String& s, uint v, int minDig, bool hex)
+void Str::appendVal(String& s, uint32_t v, int minDig, bool hex)
 {
 	char buf[INT_BUFLEN];
 	append(s, buf, PrintUint(buf, v, minDig, hex));
@@ -784,7 +784,7 @@ Fmt& Fmt::arg(int v, int minDig, bool hex)
 	return arg(buf, PrintInt(buf, v, minDig, hex));
 }
 
-Fmt& Fmt::arg(uint v, int minDig, bool hex)
+Fmt& Fmt::arg(uint32_t v, int minDig, bool hex)
 {
 	char buf[INT_BUFLEN];
 	return arg(buf, PrintUint(buf, v, minDig, hex));
@@ -872,15 +872,15 @@ Fmt& Fmt::arg(const char* s, int n)
 // ================================================================================================
 // Str:: expression parsing.
 
-static const uchar* ParseNestedExpression(const uchar* p, double& out);
+static const uint8_t* ParseNestedExpression(const uint8_t* p, double& out);
 
-inline const uchar* SkipWs(const uchar* p)
+inline const uint8_t* SkipWs(const uint8_t* p)
 {
 	while(*p == ' ' || *p == '\t') ++p;
 	return p;
 }
 
-static const uchar* ParseNumber(const uchar* p, double& out)
+static const uint8_t* ParseNumber(const uint8_t* p, double& out)
 {
 	// Digits leading up to the decimal-point.
 	uint64_t sum = 0;
@@ -928,7 +928,7 @@ static const uchar* ParseNumber(const uchar* p, double& out)
 	return SkipWs(p);
 }
 
-static const uchar* ParseOperandWithSign(const uchar* p, double& out)
+static const uint8_t* ParseOperandWithSign(const uint8_t* p, double& out)
 {
 	char sign = *p;
 	p = SkipWs(++p);
@@ -945,7 +945,7 @@ static const uchar* ParseOperandWithSign(const uchar* p, double& out)
 	return p;
 }
 
-static const uchar* ParseMultiplicationOperand(const uchar* p, double& out)
+static const uint8_t* ParseMultiplicationOperand(const uint8_t* p, double& out)
 {
 	if(*p == '(')
 	{
@@ -963,7 +963,7 @@ static const uchar* ParseMultiplicationOperand(const uchar* p, double& out)
 	return p;
 }
 
-static const uchar* ParseAdditionOperand(const uchar* p, double& out)
+static const uint8_t* ParseAdditionOperand(const uint8_t* p, double& out)
 {
 	p = ParseMultiplicationOperand(p, out);
 	while(*p == '*' || *p == '/')
@@ -976,7 +976,7 @@ static const uchar* ParseAdditionOperand(const uchar* p, double& out)
 	return p;
 }
 
-static const uchar* ParseNestedExpression(const uchar* p, double& out)
+static const uint8_t* ParseNestedExpression(const uint8_t* p, double& out)
 {
 	p = ParseAdditionOperand(p, out);
 	while(*p == '+' || *p == '-')
@@ -992,8 +992,8 @@ static const uchar* ParseNestedExpression(const uchar* p, double& out)
 bool Str::parse(const char* expr, double& out)
 {
 	double tmp = 0.0;
-	const uchar* begin = SkipWs((const uchar*)expr);
-	const uchar* p = ParseNestedExpression(begin, tmp);
+	const uint8_t* begin = SkipWs((const uint8_t*)expr);
+	const uint8_t* p = ParseNestedExpression(begin, tmp);
 	if(p > begin) out = tmp;
 	return (p > begin);
 }

--- a/src/Core/StringUtils.h
+++ b/src/Core/StringUtils.h
@@ -62,7 +62,7 @@ struct Str
 	static int readInt(StringRef s, int alt = 0);
 
 	/// Converts the string to an uinteger; returns alt on failure.
-	static uint readUint(StringRef s, uint alt = 0);
+	static uint32_t readUint(StringRef s, uint32_t alt = 0);
 
 	/// Converts the string to a float; returns alt on failure.
 	static float readFloat(StringRef s, float alt = 0);
@@ -85,7 +85,7 @@ struct Str
 
 	/// Converts the string to an uinteger; returns true on success.
 	/// On failure, out remains unchanged.
-	static bool read(StringRef s, uint* out);
+	static bool read(StringRef s, uint32_t* out);
 
 	/// Converts the string to a float; returns true on success.
 	/// On failure, out remains unchanged.
@@ -192,13 +192,13 @@ struct Str
 
 	/// Converts the given value to a string.
 	static String val(int v, int minDigits = 0, bool hex = false);
-	static String val(uint v, int minDigits = 0, bool hex = false);
+	static String val(uint32_t v, int minDigits = 0, bool hex = false);
 	static String val(float v, int minDecimalPlaces = 0, int maxDecimalPlaces = 6);
 	static String val(double v, int minDecimalPlaces = 0, int maxDecimalPlaces = 6);
 
 	/// Converts the given value and appends it to the string.
 	static void appendVal(String& s, int v, int minDigits = 0, bool hex = false);
-	static void appendVal(String& s, uint v, int minDigits = 0, bool hex = false);
+	static void appendVal(String& s, uint32_t v, int minDigits = 0, bool hex = false);
 	static void appendVal(String& s, float v, int minDecimalPlaces = 0, int maxDecimalPlaces = 6);
 	static void appendVal(String& s, double v, int minDecimalPlaces = 0, int maxDecimalPlaces = 6);
 
@@ -213,7 +213,7 @@ struct Str
 		fmt& arg(const char* s);
 		fmt& arg(const char* s, int n);
 		fmt& arg(int v, int minDigits = 0, bool hex = false);
-		fmt& arg(uint v, int minDigits = 0, bool hex = false);
+		fmt& arg(uint32_t v, int minDigits = 0, bool hex = false);
 		fmt& arg(float v, int minDecimals = 0, int maxDecimals = 6);
 		fmt& arg(double v, int minDecimals = 0, int maxDecimals = 6);
 

--- a/src/Core/Text.h
+++ b/src/Core/Text.h
@@ -138,9 +138,9 @@ struct TextStyle
 
 	Font font;
 	int fontSize;
-	uint textFlags;
-	color32 textColor;
-	color32 shadowColor;
+	uint32_t textFlags;
+	uint32_t textColor;
+	uint32_t shadowColor;
 };
 
 }; // namespace Vortex

--- a/src/Core/TextDraw.cpp
+++ b/src/Core/TextDraw.cpp
@@ -32,8 +32,8 @@ struct TextDrawData
 	ShaderData alphaShader;
 
 	// Markup properties.
-	color32 textColor;
-	color32 shadowColor;
+	uint32_t textColor;
+	uint32_t shadowColor;
 
 	// Vertex data.
 	int glyphCount;

--- a/src/Core/TextLayout.cpp
+++ b/src/Core/TextLayout.cpp
@@ -21,7 +21,7 @@ static LLayout* LD = nullptr;
 // ================================================================================================
 // Utility functions
 
-const uchar utf8TrailingBytes[256] =
+const uint8_t utf8TrailingBytes[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -33,7 +33,7 @@ const uchar utf8TrailingBytes[256] =
 	2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5,
 };
 
-const uint utf8MultibyteResidu[6] =
+const uint32_t utf8MultibyteResidu[6] =
 {
 	0x0, 0x3080, 0xE2080, 0x3C82080, 0xFA082080, 0x82082080
 };
@@ -50,7 +50,7 @@ static const Glyph* GetGlyph(int charcode);
 #define ID4(a, b, c, d)    ((ID3(a, b, c) << 8) | d)
 #define ID5(a, b, c, d, e) ((ID4(a, b, c, d) << 8) | e)
 
-static double ReadNumber(const uchar* p, int len)
+static double ReadNumber(const uint8_t* p, int len)
 {
 	bool negative = false;
 	double out = 0.0;
@@ -102,7 +102,7 @@ static int HexDigit(int c)
 	return 0;
 }
 
-static int ReadHexColor(uchar* out, const uchar* p, int n)
+static int ReadHexColor(uint8_t* out, const uint8_t* p, int n)
 {
 	int numComponents = 0;
 	switch(n)
@@ -129,9 +129,9 @@ static int ReadHexColor(uchar* out, const uchar* p, int n)
 	return numComponents;
 }
 
-static void ReadMarkupColor(color32& out, const uchar* param, int len, color32 base)
+static void ReadMarkupColor(uint32_t& out, const uint8_t* param, int len, uint32_t base)
 {
-	uchar channels[4];
+	uint8_t channels[4];
 	switch(ReadHexColor(channels, param, len))
 	{
 	case 2:
@@ -146,7 +146,7 @@ static void ReadMarkupColor(color32& out, const uchar* param, int len, color32 b
 	};
 }
 
-static void ReadTextColor(const uchar* param, int len)
+static void ReadTextColor(const uint8_t* param, int len)
 {
 	ReadMarkupColor(LD->textColor, param, len, LD->baseTextColor);
 	auto& item = LD->markup.append();
@@ -155,7 +155,7 @@ static void ReadTextColor(const uchar* param, int len)
 	item.setTextColor = LD->textColor;
 }
 
-static void ReadShadowColor(const uchar* param, int len)
+static void ReadShadowColor(const uint8_t* param, int len)
 {
 	ReadMarkupColor(LD->shadowColor, param, len, LD->baseShadowColor);
 	auto& item = LD->markup.append();
@@ -164,7 +164,7 @@ static void ReadShadowColor(const uchar* param, int len)
 	item.setShadowColor = LD->shadowColor;
 }
 
-static void ReadFontSize(const uchar* param, int len)
+static void ReadFontSize(const uint8_t* param, int len)
 {
 	int fontSize = (int)(ReadNumber(param, len) + 0.5);
 
@@ -184,7 +184,7 @@ static void ReadFontSize(const uchar* param, int len)
 	SetLineMetrics();
 }
 
-static void ReadFontChange(const uchar* param, int len)
+static void ReadFontChange(const uint8_t* param, int len)
 {
 	// Resolve the path of the font file (could be an asset name).
 	String path((const char*)param, len);
@@ -196,7 +196,7 @@ static void ReadFontChange(const uchar* param, int len)
 	SetLineMetrics();
 }
 
-static void ReadFgColor(const uchar* param, int len)
+static void ReadFgColor(const uint8_t* param, int len)
 {
 	if(LD->fgQuad.enabled)
 	{
@@ -207,7 +207,7 @@ static void ReadFgColor(const uchar* param, int len)
 		quad.w = LD->lineW - LD->fgQuad.x;
 		LD->fgQuad.enabled = false;
 	}
-	union { color32 color; uchar channels[4]; };
+	union { uint32_t color; uint8_t channels[4]; };
 	if(ReadHexColor(channels, param, len))
 	{
 		LD->fgQuad.enabled = true;
@@ -216,7 +216,7 @@ static void ReadFgColor(const uchar* param, int len)
 	}
 }
 
-static void ReadBgColor(const uchar* param, int len)
+static void ReadBgColor(const uint8_t* param, int len)
 {
 	if(LD->bgQuad.enabled)
 	{
@@ -227,7 +227,7 @@ static void ReadBgColor(const uchar* param, int len)
 		quad.w = LD->lineW - LD->bgQuad.x;
 		LD->bgQuad.enabled = false;
 	}
-	union { color32 color; uchar channels[4]; };
+	union { uint32_t color; uint8_t channels[4]; };
 	if(ReadHexColor(channels, param, len))
 	{
 		LD->bgQuad.enabled = true;
@@ -236,10 +236,10 @@ static void ReadBgColor(const uchar* param, int len)
 	}
 }
 
-static const Glyph* ReadMarkup(const uchar* str)
+static const Glyph* ReadMarkup(const uint8_t* str)
 {
 	// Keep reading tags until a glyph is returned.
-	const uchar* p = str + LD->nextCharIndex;
+	const uint8_t* p = str + LD->nextCharIndex;
 	while(p[0] == '{')
 	{
 		LD->charIndex = LD->nextCharIndex;
@@ -249,13 +249,13 @@ static const Glyph* ReadMarkup(const uchar* str)
 		if(undo) ++p;
 
 		// Read the tag name.
-		const uchar* name = ++p;
+		const uint8_t* name = ++p;
 		while(*p && *p != '}' && *p != ':') ++p;
 		int nameLen = p - name;
 		if(*p == ':') ++p;
 
 		// Read the tag parameters.
-		const uchar* param = p;
+		const uint8_t* param = p;
 		while(*p && *p != '}') ++p;
 		int paramLen = p - param;
 		if(*p == '}') ++p;
@@ -335,7 +335,7 @@ static void SetLineMetrics()
 	LD->lineBottom = max(LD->lineBottom, LD->fontSize / 4);
 }
 
-static const Glyph* ReadGlyph(const uchar* str)
+static const Glyph* ReadGlyph(const uint8_t* str)
 {
 	int charcode = str[LD->nextCharIndex];
 
@@ -357,7 +357,7 @@ static const Glyph* ReadGlyph(const uchar* str)
 	// Keep reading if the current character is multibyte UTF-8.
 	if(charcode >= 0x80)
 	{
-		const uchar* p = str + LD->nextCharIndex;
+		const uint8_t* p = str + LD->nextCharIndex;
 		int tb = utf8TrailingBytes[charcode];
 		for(int i = 0; i < tb && *p; ++i, ++p) charcode = (charcode << 6) + *p;
 		charcode -= utf8MultibyteResidu[tb];
@@ -536,7 +536,7 @@ static void CreateLayout(const char* str)
 	bool isMultiline = !(LD->flags & Text::SINGLE_LINE);
 	while(true)
 	{
-		auto glyph = ReadGlyph((const uchar*)str);
+		auto glyph = ReadGlyph((const uint8_t*)str);
 		if(!glyph) break;
 
 		// Apply glyph advance.

--- a/src/Core/TextLayout.h
+++ b/src/Core/TextLayout.h
@@ -10,10 +10,10 @@
 namespace Vortex {
 
 // Tells how many trailing bytes follow a given UTF-8 leading byte.
-extern const uchar utf8TrailingBytes[256];
+extern const uint8_t utf8TrailingBytes[256];
 
 // Used in UTF-8 multibyte decoding to cancel out the non-charcode bits.
-extern const uint utf8MultibyteResidu[6];
+extern const uint32_t utf8MultibyteResidu[6];
 
 // Character glyph in a text layout.
 struct LGlyph
@@ -38,8 +38,8 @@ struct LMarkup
 
 	union
 	{
-		color32 setTextColor;
-		color32 setShadowColor;
+		uint32_t setTextColor;
+		uint32_t setShadowColor;
 	};
 };
 
@@ -54,22 +54,22 @@ struct LLine
 struct LQuad
 {
 	int line, x, w;
-	color32 color;
+	uint32_t color;
 };
 
 // Contains the entire text layout.
 struct LLayout
 {
-	struct QuadData { bool enabled; int x; color32 color; };
+	struct QuadData { bool enabled; int x; uint32_t color; };
 
 	const Glyph* previousGlyph;
 
 	FontData* baseFont, *font;
 	int baseFontSize, fontSize;
-	color32 baseTextColor, textColor;
-	color32 baseShadowColor, shadowColor;
+	uint32_t baseTextColor, textColor;
+	uint32_t baseShadowColor, shadowColor;
 
-	uint flags;
+	uint32_t flags;
 	Text::Align align;
 	bool useKerning;
 

--- a/src/Core/Texture.h
+++ b/src/Core/Texture.h
@@ -33,10 +33,10 @@ public:
 	Texture(const char* path, bool mipmap = false, Format fmt = RGBA);
 
 	/// Creates a texture from a buffer of [w * h * channels] pixel values.
-	Texture(int w, int h, const uchar* pixeldata, bool mipmap = false, Format fmt = RGBA);
+	Texture(int w, int h, const uint8_t* pixeldata, bool mipmap = false, Format fmt = RGBA);
 
 	/// Updates a region of the texture with a buffer of [w * h * channels] pixel values.
-	void modify(int x, int y, int w, int h, const uchar* pixeldata);
+	void modify(int x, int y, int w, int h, const uint8_t* pixeldata);
 
 	/// Sets UV wrapping mode to repeat on true, or clamp on false; default is clamp.
 	void setWrapping(bool repeat);

--- a/src/Core/TextureImpl.h
+++ b/src/Core/TextureImpl.h
@@ -7,15 +7,15 @@ namespace Vortex {
 struct Texture::Data
 {
 	~Data();
-	Data(int w, int h, Texture::Format fmt, const uchar* pixels, bool mipmap);
+	Data(int w, int h, Texture::Format fmt, const uint8_t* pixels, bool mipmap);
 
 	void clear();
-	void modify(int x, int y, int w, int h, const uchar* pixels);
+	void modify(int x, int y, int w, int h, const uint8_t* pixels);
 	void increaseHeight(int newHeight);
 	void setFiltering(bool linear);
 	void setWrapping(bool repeat);
 
-	uint handle;
+	uint32_t handle;
 	int w, h;
 	float rw, rh;
 	int refs;
@@ -30,7 +30,7 @@ static void create();
 static void destroy();
 
 static Texture::Data* load(const char* path, Texture::Format fmt, bool mipmap);
-static Texture::Data* load(int w, int h, Texture::Format fmt, bool mipmap, const uchar* pixels);
+static Texture::Data* load(int w, int h, Texture::Format fmt, bool mipmap, const uint8_t* pixels);
 
 static void release(Texture::Data* tex);
 

--- a/src/Core/Utils.h
+++ b/src/Core/Utils.h
@@ -299,30 +299,30 @@ inline colorf ToColor(float l, float a = 1.0f)
 	return {l, l, l, a};
 }
 
-inline colorf ToColorf(color32 color)
+inline colorf ToColorf(uint32_t color)
 {
-	union { uchar c[4]; color32 c32; };
+	union { uint8_t c[4]; uint32_t c32; };
 	c32 = color;
 	return{c[0] / 255.0f, c[1] / 255.0f, c[2] / 255.0f, c[3] / 255.0f};
 }
 
-inline color32 ToColor32(const colorf& c)
+inline uint32_t ToColor32(const colorf& c)
 {
-	union { uchar u8[4]; color32 u32; };
-	u8[0] = (uchar)min(max(0, (int)(c.r * 255.0f)), 255);
-	u8[1] = (uchar)min(max(0, (int)(c.g * 255.0f)), 255);
-	u8[2] = (uchar)min(max(0, (int)(c.b * 255.0f)), 255);
-	u8[3] = (uchar)min(max(0, (int)(c.a * 255.0f)), 255);
+	union { uint8_t u8[4]; uint32_t u32; };
+	u8[0] = (uint8_t)min(max(0, (int)(c.r * 255.0f)), 255);
+	u8[1] = (uint8_t)min(max(0, (int)(c.g * 255.0f)), 255);
+	u8[2] = (uint8_t)min(max(0, (int)(c.b * 255.0f)), 255);
+	u8[3] = (uint8_t)min(max(0, (int)(c.a * 255.0f)), 255);
 	return u32;
 }
 
-inline color32 ToColor32(float r, float g, float b, float a)
+inline uint32_t ToColor32(float r, float g, float b, float a)
 {
-	union { uchar u8[4]; color32 u32; };
-	u8[0] = (uchar)min(max(0, (int)(r * 255.0f)), 255);
-	u8[1] = (uchar)min(max(0, (int)(g * 255.0f)), 255);
-	u8[2] = (uchar)min(max(0, (int)(b * 255.0f)), 255);
-	u8[3] = (uchar)min(max(0, (int)(a * 255.0f)), 255);
+	union { uint8_t u8[4]; uint32_t u32; };
+	u8[0] = (uint8_t)min(max(0, (int)(r * 255.0f)), 255);
+	u8[1] = (uint8_t)min(max(0, (int)(g * 255.0f)), 255);
+	u8[2] = (uint8_t)min(max(0, (int)(b * 255.0f)), 255);
+	u8[3] = (uint8_t)min(max(0, (int)(a * 255.0f)), 255);
 	return u32;
 }
 

--- a/src/Core/WideString.cpp
+++ b/src/Core/WideString.cpp
@@ -200,12 +200,12 @@ bool operator == (const WideString& a, const WideString& b)
 
 namespace {
 
-static const uint utf8Offsets[6] =
+static const uint32_t utf8Offsets[6] =
 {
 	0x00000000, 0x00003080, 0x000E2080, 0x03C82080, 0xFA082080, 0x82082080
 };
 
-static const uchar utf8TrailingBytes[256] =
+static const uint8_t utf8TrailingBytes[256] =
 {
 	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -217,14 +217,14 @@ static const uchar utf8TrailingBytes[256] =
 	2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5
 };
 
-static const uchar utf8LeadingByte[7] =
+static const uint8_t utf8LeadingByte[7] =
 {
 	0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC
 };
 
-static uint ReadU8(const uchar*& p, const uchar* end)
+static uint32_t ReadU8(const uint8_t*& p, const uint8_t* end)
 {
-	uint c = *p; ++p;
+	uint32_t c = *p; ++p;
 	if(c >= 0x80)
 	{
 		int numBytes = utf8TrailingBytes[c];
@@ -245,9 +245,9 @@ static uint ReadU8(const uchar*& p, const uchar* end)
 	return c;
 }
 
-static uint ReadU16(const ushort*& p, const ushort* end)
+static uint32_t ReadU16(const uint16_t*& p, const uint16_t* end)
 {
-	uint c = *p; ++p;
+	uint32_t c = *p; ++p;
 	if(c >= 0xD800 && c <= 0xDBFF && p < end)
 	{
 		c = ((c - 0xD800) << 10) + (*p - 0xDC00) + 0x0010000; ++p;
@@ -255,7 +255,7 @@ static uint ReadU16(const ushort*& p, const ushort* end)
 	return c;
 }
 
-static void WriteU8(String& str, uint c)
+static void WriteU8(String& str, uint32_t c)
 {
 	if(c < 0x80)
 	{
@@ -268,7 +268,7 @@ static void WriteU8(String& str, uint c)
 	else
 	{
 		int numBytes = (c < 0x800) ? 2 : ((c < 0x10000) ? 3 : 4);
-		uchar buffer[4];
+		uint8_t buffer[4];
 		switch(numBytes)
 		{
 		case 4: buffer[3] = (c | 0x80) & 0xBF; c >>= 6;
@@ -280,15 +280,15 @@ static void WriteU8(String& str, uint c)
 	}
 }
 
-static void WriteU16(WideString& str, uint c)
+static void WriteU16(WideString& str, uint32_t c)
 {
-	if(c < 0xFFFF) str.push_back((ushort)c);
+	if(c < 0xFFFF) str.push_back((uint16_t)c);
 	else if(c > 0x10FFFF) str.push_back(L'~');
 	else
 	{
 		c -= 0x10000;
-		str.push_back((ushort)(c >> 10) + 0xD800);
-		str.push_back((ushort)(c & 0x3FFUL) + 0xDC00);
+		str.push_back((uint16_t)(c >> 10) + 0xD800);
+		str.push_back((uint16_t)(c & 0x3FFUL) + 0xDC00);
 	}
 }
 
@@ -297,14 +297,14 @@ static void WriteU16(WideString& str, uint c)
 String Narrow(const wchar_t* s, int len)
 {
 	String out;
-	if(sizeof(wchar_t) == sizeof(ushort))
+	if(sizeof(wchar_t) == sizeof(uint16_t))
 	{
-		for(auto p = (const ushort*)s, end = p + len; p != end;)
+		for(auto p = (const uint16_t*)s, end = p + len; p != end;)
 			WriteU8(out, ReadU16(p, end));
 	}
-	else if(sizeof(wchar_t) == sizeof(uint))
+	else if(sizeof(wchar_t) == sizeof(uint32_t))
 	{
-		for(auto p = (const uint*)s, end = p + len; p != end;)
+		for(auto p = (const uint32_t*)s, end = p + len; p != end;)
 			WriteU8(out, *p);
 	}
 	return out;
@@ -313,14 +313,14 @@ String Narrow(const wchar_t* s, int len)
 WideString Widen(const char* s, int len)
 {
 	WideString out;
-	if(sizeof(wchar_t) == sizeof(ushort))
+	if(sizeof(wchar_t) == sizeof(uint16_t))
 	{
-		for(auto p = (const uchar*)s, end = p + len; p != end;)
+		for(auto p = (const uint8_t*)s, end = p + len; p != end;)
 			WriteU16(out, ReadU8(p, end));
 	}
-	else if(sizeof(wchar_t) == sizeof(uint))
+	else if(sizeof(wchar_t) == sizeof(uint32_t))
 	{
-		for(auto p = (const uchar*)s, end = p + len; p != end;)
+		for(auto p = (const uint8_t*)s, end = p + len; p != end;)
 			out.push_back(ReadU8(p, end));
 	}
 	return out;

--- a/src/Core/Widgets.h
+++ b/src/Core/Widgets.h
@@ -114,11 +114,11 @@ public:
 protected:
 	void ScrollbarUpdateValue(int v);
 	int scrollbar_end_, scrollbar_page_;
-	uint scrollbar_action_ : 9;
-	uint scrollbar_grab_position_ : 16;
+	uint32_t scrollbar_action_ : 9;
+	uint32_t scrollbar_grab_position_ : 16;
 
 private:
-	uint GetScrollbarActionAtPosition(int x, int y);
+	uint32_t GetScrollbarActionAtPosition(int x, int y);
 };
 
 /// Base scroll region widgets.
@@ -152,17 +152,17 @@ protected:
 	void PostTick();
 	void ClampScrollPositions();
 
-	uint scroll_type_horizontal_ : 2;
-	uint scroll_type_vertical_ : 2;
-	uint is_horizontal_scrollbar_active_ : 1;
-	uint is_vertical_scrollbar_active_ : 1;
-	uint scroll_region_action_ : 9;
-	uint scroll_region_grab_position_ : 16;
+	uint32_t scroll_type_horizontal_ : 2;
+	uint32_t scroll_type_vertical_ : 2;
+	uint32_t is_horizontal_scrollbar_active_ : 1;
+	uint32_t is_vertical_scrollbar_active_ : 1;
+	uint32_t scroll_region_action_ : 9;
+	uint32_t scroll_region_grab_position_ : 16;
 	int scroll_width_, scroll_height_;
 	int scroll_position_x_, scroll_position_y_;
 
 private:
-	uint getScrollRegionActionAt_(int x, int y);
+	uint32_t getScrollRegionActionAt_(int x, int y);
 };
 
 // Vertical Scrollbar GuiWidget.
@@ -213,8 +213,8 @@ protected:
 	WgScrollbarV* scrollbar_;
 	Vector<String> selectlist_items_;
 	int scroll_position_;
-	uint is_interacted_ : 1;
-	uint show_background_ : 1;
+	uint32_t is_interacted_ : 1;
+	uint32_t show_background_ : 1;
 };
 
 /// Vertical Drop Down List GuiWidget.
@@ -300,10 +300,10 @@ private:
 	int lineedit_max_length_, lineedit_drag_;
 	vec2i lineedit_cursor_;
 	float lineedit_blink_time_, lineedit_scroll_offset_;
-	uint is_numerical_ : 1;
-	uint is_editable_ : 1;
-	uint force_scroll_update_ : 1;
-	uint lineedit_show_background_ : 1;
+	uint32_t is_numerical_ : 1;
+	uint32_t is_editable_ : 1;
+	uint32_t force_scroll_update_ : 1;
+	uint32_t lineedit_show_background_ : 1;
 	TextStyle lineedit_style_;
 };
 

--- a/src/Core/WidgetsColor.cpp
+++ b/src/Core/WidgetsColor.cpp
@@ -190,8 +190,8 @@ void WgColorPicker::Expanded::draw()
 	Draw::fill({rect_.x - 8, rect_.y + rect_.h / 2 - 8, 16, 16}, Colors::white, dlg.vshape.handle());
 
 	recti ar = getAr();
-	color32 t = ToColor32(HSVtoRGB(myCol, 1.0f));
-	color32 b = ToColor32(HSVtoRGB(myCol, 0.0f));
+	uint32_t t = ToColor32(HSVtoRGB(myCol, 1.0f));
+	uint32_t b = ToColor32(HSVtoRGB(myCol, 0.0f));
 	GuiDraw::checkerboard(ar, Colors::white);
 	Draw::fill(ar, t, t, b, b, false);
 
@@ -206,8 +206,8 @@ void WgColorPicker::Expanded::draw()
 	}
 
 	recti sr = getSr();
-	color32 tl = ToColor32({myCol.h, 0, 1, 1}), tr = ToColor32({myCol.h, 1, 1, 1});
-	color32 bl = ToColor32({myCol.h, 0, 0, 1}), br = ToColor32({myCol.h, 1, 0, 1});
+	uint32_t tl = ToColor32({myCol.h, 0, 1, 1}), tr = ToColor32({myCol.h, 1, 1, 1});
+	uint32_t bl = ToColor32({myCol.h, 0, 0, 1}), br = ToColor32({myCol.h, 1, 0, 1});
 	Draw::fill(sr, tl, tr, bl, br, true);
 
 	int sx = sr.x + (int)(sr.w * myCol.s);

--- a/src/Core/WidgetsLayout.cpp
+++ b/src/Core/WidgetsLayout.cpp
@@ -11,16 +11,16 @@ namespace Vortex {
 
 struct RowLayout::Col
 {
-	uint width : 30;
-	uint adjust : 1;
-	uint expand : 1;
+	uint32_t width : 30;
+	uint32_t adjust : 1;
+	uint32_t expand : 1;
 };
 
 struct RowLayout::Row
 {
 	Row() : expand(0) {}
 
-	uint expand : 1;
+	uint32_t expand : 1;
 
 	Vector<RowLayout::Col> cols;
 	Vector<GuiWidget*> widgets;
@@ -83,7 +83,7 @@ void RowLayout::onUpdateSize()
 				h = max(h, size.y);
 				if(cols[c].adjust)
 				{
-					cols[c].width = max(cols[c].width, (uint)size.x);
+					cols[c].width = max(cols[c].width, (uint32_t)size.x);
 				}
 			}
 

--- a/src/Core/WidgetsScroll.cpp
+++ b/src/Core/WidgetsScroll.cpp
@@ -132,7 +132,7 @@ void WgScrollbar::onMousePress(MousePress& evt)
 	{
 		if(isEnabled() && evt.button == Mouse::LMB && evt.unhandled())
 		{
-			uint action = GetScrollbarActionAtPosition(evt.x, evt.y);
+			uint32_t action = GetScrollbarActionAtPosition(evt.x, evt.y);
 			if(action)
 			{
 				startCapturingMouse();
@@ -178,7 +178,7 @@ void WgScrollbar::onTick()
 void WgScrollbar::onDraw()
 {
 	vec2i mpos = gui_->getMousePos();
-	uint action = GetScrollbarActionAtPosition(mpos.x, mpos.y);
+	uint32_t action = GetScrollbarActionAtPosition(mpos.x, mpos.y);
 
 	if(isVertical())
 	{
@@ -200,7 +200,7 @@ void WgScrollbar::ScrollbarUpdateValue(int v)
 	if(value.get() != prev) onChange.call();
 }
 
-uint WgScrollbar::GetScrollbarActionAtPosition(int x, int y)
+uint32_t WgScrollbar::GetScrollbarActionAtPosition(int x, int y)
 {
 	if(scrollbar_action_) return scrollbar_action_;
 	if(!IsInside(rect_, x, y)) return ACT_NONE;
@@ -290,7 +290,7 @@ void WgScrollRegion::onMousePress(MousePress& evt)
 	{
 		if(isEnabled() && evt.button == Mouse::LMB && evt.unhandled())
 		{
-			uint action = getScrollRegionActionAt_(evt.x, evt.y);
+			uint32_t action = getScrollRegionActionAt_(evt.x, evt.y);
 			if(action)
 			{
 				startCapturingMouse();
@@ -329,7 +329,7 @@ void WgScrollRegion::onTick()
 void WgScrollRegion::onDraw()
 {
 	vec2i mpos = gui_->getMousePos();
-	uint action = getScrollRegionActionAt_(mpos.x, mpos.y);
+	uint32_t action = getScrollRegionActionAt_(mpos.x, mpos.y);
 
 	int viewW = getViewWidth();
 	int viewH = getViewHeight();
@@ -420,7 +420,7 @@ void WgScrollRegion::PostTick()
 	GuiWidget::onTick();
 }
 
-uint WgScrollRegion::getScrollRegionActionAt_(int x, int y)
+uint32_t WgScrollRegion::getScrollRegionActionAt_(int x, int y)
 {
 	if(scroll_region_action_) return scroll_region_action_;
 

--- a/src/Core/WidgetsSelect.cpp
+++ b/src/Core/WidgetsSelect.cpp
@@ -140,7 +140,7 @@ void WgSelectList::onDraw()
 		int mo = HoveredItem(mpos.x, mpos.y);
 		if(mo != item && mo >= 0 && mo < numItems)
 		{
-			color32 col = Color32(255, 255, 255, isEnabled() ? 128 : 0);
+			uint32_t col = Color32(255, 255, 255, isEnabled() ? 128 : 0);
 			misc.imgSelect.draw({r.x, r.y - scroll_position_ + mo * ITEM_H, r.w, ITEM_H}, col);
 		}
 	}
@@ -421,10 +421,10 @@ void WgCycleButton::onDraw()
 	int mouseX = gui_->getMousePos().x - CenterX(rect_);
 	if(!isMouseOver()) mouseX = 0;
 
-	color32 colL = (isEnabled() && mouseX < 0) ? Colors::white : misc.colDisabled;
+	uint32_t colL = (isEnabled() && mouseX < 0) ? Colors::white : misc.colDisabled;
 	Draw::sprite(icons.arrow, {r.x + 10, r.y + r.h / 2}, colL, Draw::FLIP_H);
 
-	color32 colR = (isEnabled() && mouseX > 0) ? Colors::white : misc.colDisabled;
+	uint32_t colR = (isEnabled() && mouseX > 0) ? Colors::white : misc.colDisabled;
 	Draw::sprite(icons.arrow, {r.x + r.w - 10, r.y + r.h / 2}, colR);
 
 	// Draw the button text.

--- a/src/Core/WidgetsText.cpp
+++ b/src/Core/WidgetsText.cpp
@@ -546,7 +546,7 @@ void WgSpinner::onDraw()
 		}
 	}
 
-	color32 col = Color32(isEnabled() ? 255 : 128);
+	uint32_t col = Color32(isEnabled() ? 255 : 128);
 	
 	Draw::sprite(icons.arrow, {r.x + r.w / 2, r.y + r.h * 1 / 4}, col, Draw::ROT_90 | Draw::FLIP_H);
 	Draw::sprite(icons.arrow, {r.x + r.w / 2, r.y + r.h * 3 / 4}, col, Draw::ROT_90);

--- a/src/Core/Xmr.cpp
+++ b/src/Core/Xmr.cpp
@@ -92,7 +92,7 @@ static bool IsWhiteSpace(char c)
 // Valid chars: all characters except '\0', '{', '}', ';', ',', '\n', '='.
 static bool IsNameChar(char c)
 {
-	static const uint b[4] = {0xFFFFFBFE, 0xD7FFEFFF, 0xFFFFFFFF, 0xD7FFFFFF};
+	static const uint32_t b[4] = {0xFFFFFBFE, 0xD7FFEFFF, 0xFFFFFFFF, 0xD7FFFFFF};
 	return ((unsigned char)c < 128) ? ((b[c >> 5] & (1 << (c & 31))) != 0) : true;
 }
 
@@ -283,11 +283,11 @@ XmrResult XmrReader::load(const char* buffer, XmrDoc& doc)
 		int line = 1, pos = 1;
 		for(p = buffer; *p && p < xmrErrorPosition_; ++p)
 		{
-			if((uchar)(*p) == 0xA)
+			if((uint8_t)(*p) == 0xA)
 				++line, pos = 1; // newline character.
-			else if((uchar)(*p) < 128)
+			else if((uint8_t)(*p) < 128)
 				++pos; // single-byte character.
-			else if(((uchar)(*p) & 192) == 192)
+			else if(((uint8_t)(*p) & 192) == 192)
 				++pos; // first byte of multi-byte character.
 		}
 
@@ -943,7 +943,7 @@ XmrResult XmrDoc::loadString(const char* str)
 	SetError(this, nullptr);
 
 	// Skip the BOM character if there is one.
-	const uchar bom[] = {0xEF, 0xBB, 0xBF};
+	const uint8_t bom[] = {0xEF, 0xBB, 0xBF};
 	if(memcmp(str, bom, 3) == 0) str += 3;
 
 	// Parse the document.

--- a/src/Dialogs/ChartList.cpp
+++ b/src/Dialogs/ChartList.cpp
@@ -74,7 +74,7 @@ void onDraw() override
 	{
 		// Draw the left-side colored bar with difficulty and meter.
 		recti left = {rect_.x, rect_.y, min(r.w, 128), 20};
-		color32 color = ToColor(chart->difficulty);
+		uint32_t color = ToColor(chart->difficulty);
 		myBar->draw(left, 0, color);
 
 		Text::arrange(Text::ML, textStyle, GetDifficultyName(chart->difficulty));

--- a/src/Dialogs/DancingBot.cpp
+++ b/src/Dialogs/DancingBot.cpp
@@ -61,7 +61,7 @@ struct FeetPlanner
 	struct NotePair { const ExpandedNote* a, *b; };
 	bool footswitch, crossover;
 	NotePair curNote, nextNote[4];
-	uint* outBits;
+	uint32_t* outBits;
 	const Style* style;
 	const ExpandedNote* noteBegin;
 	vec2i curFeetPos[2];
@@ -409,7 +409,7 @@ void DialogDancingBot::onDraw()
 			{
 				int tile = myPadLayout[y * style->padWidth + x];
 				vec2i pos = myGetDrawPos({x, y});
-				myPadSpr[tile].draw(&batch, pos.x, pos.y, (uchar)255);
+				myPadSpr[tile].draw(&batch, pos.x, pos.y, (uint8_t)255);
 				if(tile == TT_BUTTON) myPushArrow(&batch, x, y);
 			}
 		}
@@ -423,7 +423,7 @@ void DialogDancingBot::onDraw()
 			if(alpha > 0)
 			{
 				vec2i pos = myGetDrawPos(style->padColPositions[col]);
-				myPadSpr[2].draw(&batch, pos.x, pos.y, (uchar)alpha);
+				myPadSpr[2].draw(&batch, pos.x, pos.y, (uint8_t)alpha);
 			}
 		}
 		batch.flush();
@@ -434,7 +434,7 @@ void DialogDancingBot::onDraw()
 		BatchSprite::setScale(160);
 		for(int p = 0; p < gStyle->getNumPlayers(); ++p)
 		{
-			uint color = p ? ToColor32({.5f, .5f, 1, 1}) : ToColor32({1, .5f, .5f, 1});
+			uint32_t color = p ? ToColor32({.5f, .5f, 1, 1}) : ToColor32({1, .5f, .5f, 1});
 
 			// Get current and target note for each foot.
 			vec3f feetPos[2];
@@ -526,7 +526,7 @@ void DialogDancingBot::myAssignFeetToNotes()
 	if(numNotes > 0 && style && style->padWidth > 0)
 	{
 		myFeetBits.resize(numNotes / 32 + 1);
-		memset(myFeetBits.data(), 0, sizeof(uint) * myFeetBits.size());
+		memset(myFeetBits.data(), 0, sizeof(uint32_t) * myFeetBits.size());
 		for(int pn = 0; pn != gStyle->getNumPlayers(); ++pn)
 		{
 			FeetPlanner planner;

--- a/src/Dialogs/DancingBot.h
+++ b/src/Dialogs/DancingBot.h
@@ -33,7 +33,7 @@ private:
 	void myGetFeetPositions(vec3f* out, int player);
 
 	Vector<int> myPadLayout;
-	Vector<uint> myFeetBits;
+	Vector<uint32_t> myFeetBits;
 	BatchSprite myPadSpr[6];
 	BatchSprite myFeetSpr[2];
 	Texture myPadTex, myFeetTex;

--- a/src/Editor/Common.cpp
+++ b/src/Editor/Common.cpp
@@ -17,12 +17,12 @@ namespace Vortex {
 // Clipboard functions.
 
 static const int a85shift[4] = {24, 16, 8, 0};
-static const uint a85div[5] = {85 * 85 * 85 * 85, 85 * 85 * 85, 85 * 85, 85, 1};
+static const uint32_t a85div[5] = {85 * 85 * 85 * 85, 85 * 85 * 85, 85 * 85, 85, 1};
 
-static void Ascii85enc(String& out, const uchar* in, int size)
+static void Ascii85enc(String& out, const uint8_t* in, int size)
 {
 	// Convert to 32-bit integers (big endian) and pad with zeroes.
-	Vector<uint> blocks((size + 3) / 4, 0);
+	Vector<uint32_t> blocks((size + 3) / 4, 0);
 	for(int i = 0; i < size; ++i)
 	{
 		blocks[i / 4] += in[i] << a85shift[i & 3];
@@ -46,7 +46,7 @@ static void Ascii85enc(String& out, const uchar* in, int size)
 	Str::truncate(out, out.len() - padding);
 }
 
-static void Ascii85dec(Vector<uchar>& out, const char* in)
+static void Ascii85dec(Vector<uint8_t>& out, const char* in)
 {
 	// Convert from base 85 to 32-bit integers.
 	int padding = 0;
@@ -85,16 +85,16 @@ bool HasClipboardData(StringRef tag)
 	return Str::startsWith(text, prefix.str());
 }
 
-void SetClipboardData(StringRef tag, const uchar* data, int size)
+void SetClipboardData(StringRef tag, const uint8_t* data, int size)
 {
 	String text = "ArrowVortex:" + tag + ":";
 	Ascii85enc(text, data, size);
 	gSystem->setClipboardText(text);
 }
 
-Vector<uchar> GetClipboardData(StringRef tag)
+Vector<uint8_t> GetClipboardData(StringRef tag)
 {
-	Vector<uchar> buffer;
+	Vector<uint8_t> buffer;
 	String text = gSystem->getClipboardText();
 	String prefix = "ArrowVortex:" + tag + ":";
 	if(Str::startsWith(text, prefix.str()))
@@ -107,7 +107,7 @@ Vector<uchar> GetClipboardData(StringRef tag)
 // ================================================================================================
 // Utility functions.
 
-color32 ToColor(Difficulty dt)
+uint32_t ToColor(Difficulty dt)
 {
 	switch(dt)
 	{

--- a/src/Editor/Common.h
+++ b/src/Editor/Common.h
@@ -132,10 +132,10 @@ enum BackgroundStyle
 bool HasClipboardData(StringRef tag);
 
 // Encodes the given data to an ascii85 string and sends it to the clipboard.
-void SetClipboardData(StringRef tag, const uchar* data, int size);
+void SetClipboardData(StringRef tag, const uint8_t* data, int size);
 
 // Reads a string from the clipboard and decodes it using ascii85.
-Vector<uchar> GetClipboardData(StringRef tag);
+Vector<uint8_t> GetClipboardData(StringRef tag);
 
 // Returns a text representation of the given snap type.
 const char* ToString(SnapType st);
@@ -144,7 +144,7 @@ const char* ToString(SnapType st);
 const String OrdinalSuffix(int i);
 
 // Returns the color representation of the given difficulty type.
-color32 ToColor(Difficulty dt);
+uint32_t ToColor(Difficulty dt);
 
 // Translates a row index to a row type.
 RowType ToRowType(int rowIndex);

--- a/src/Editor/ConvertToOgg.cpp
+++ b/src/Editor/ConvertToOgg.cpp
@@ -71,15 +71,15 @@ struct OggConversionPipe : public System::CommandPipe
 			samples[p++] = *srcR++;
 		}
 		framesLeft -= numFrames;
-		*progress = (uchar)(100 - (uint64_t)(100 * framesLeft / totalFrames));
+		*progress = (uint8_t)(100 - (uint64_t)(100 * framesLeft / totalFrames));
 		return numFrames * 4;
 	}
-	uchar* progress;
+	uint8_t* progress;
 	bool firstChunk;
 	int totalFrames, framesLeft;
 	const short* srcL, *srcR;
 	short samples[4096 * 2];
-	uchar* terminateFlag;
+	uint8_t* terminateFlag;
 };
 
 }; // Anonymous namepspace.

--- a/src/Editor/ConvertToOgg.h
+++ b/src/Editor/ConvertToOgg.h
@@ -10,7 +10,7 @@ namespace Vortex {
 struct OggConversionThread : public BackgroundThread
 {
 	OggConversionThread();
-	uchar progress;
+	uint8_t progress;
 	String outPath, error;
 	void exec() override;
 };

--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -34,7 +34,7 @@ enum TweakMode { TWEAK_NONE, TWEAK_BPM, TWEAK_OFS };
 
 enum PlaceMode { PLACE_NONE, PLACE_NEW, PLACE_AFTER_REMOVE};
 
-struct PlacingNote { int player, startRow, endRow; PlaceMode mode; uint quant; };
+struct PlacingNote { int player, startRow, endRow; PlaceMode mode; uint32_t quant; };
 
 static int KeyToCol(Key::Code code)
 {
@@ -168,7 +168,7 @@ void onKeyPress(KeyPress& evt) override
 			}
 			NoteEdit edit;
 			auto note = gNotes->getNoteAt(row, col);
-			uint quant = gView->getSnapQuant();
+			uint32_t quant = gView->getSnapQuant();
 			if(note)
 			{
 				if(gMusic->isPaused())
@@ -180,7 +180,7 @@ void onKeyPress(KeyPress& evt) override
 			}
 			else
 			{
-				edit.add.append({row, row, (uint)col, (uint)myCurPlayer, NOTE_STEP_OR_HOLD, quant});
+				edit.add.append({row, row, (uint32_t)col, (uint32_t)myCurPlayer, NOTE_STEP_OR_HOLD, quant});
 				if(evt.keyflags & Keyflag::SHIFT)
 				{
 					edit.add.begin()->type = NOTE_MINE;
@@ -343,7 +343,7 @@ void finishNotePlacement(int col)
 			{
 				if((int)note.row > hold->row && (int)note.row <= hold->endrow && (int)note.endrow > hold->endrow)
 				{
-					note.row = (uint)hold->row;
+					note.row = (uint32_t)hold->row;
 				}
 			}
 		}
@@ -589,7 +589,7 @@ void changePlayerNumber()
 }
 
 template <typename T>
-static T readFromBuffer(Vector<uchar>& buffer, int& pos)
+static T readFromBuffer(Vector<uint8_t>& buffer, int& pos)
 {
 	if(pos + (int)sizeof(T) <= buffer.size())
 	{
@@ -605,7 +605,7 @@ void pasteNotePatterns()
 	/* TODO?
 	NoteList out = gSelection->getSelectedNotes();
 
-	Vector<uchar> buffer = GetClipboardData("notes");
+	Vector<uint8_t> buffer = GetClipboardData("notes");
 	if(buffer.empty()) return;
 
 	int readPos = 0;

--- a/src/Editor/FindTempo.cpp
+++ b/src/Editor/FindTempo.cpp
@@ -45,7 +45,7 @@ struct SerializedTempo
 	int samplerate;
 	int numFrames;
 	int numThreads;
-	uchar* terminate;
+	uint8_t* terminate;
 	std::atomic_int progress;
 	TempoResults result;
 };

--- a/src/Editor/History.cpp
+++ b/src/Editor/History.cpp
@@ -33,11 +33,11 @@ struct Entry
 
 struct EntryData
 {
-	uint id;
+	uint32_t id;
 	Chart* chart;
 	Tempo* tempo;
-	uint size;
-	const uchar* data;
+	uint32_t size;
+	const uint8_t* data;
 };
 
 struct EntryList
@@ -76,7 +76,7 @@ struct EntryList
 // ================================================================================================
 // HistoryImpl :: helper functions.
 
-static Entry* CreateEntry(EditId id, const void* data, uint size, Chart* c, Tempo* t)
+static Entry* CreateEntry(EditId id, const void* data, uint32_t size, Chart* c, Tempo* t)
 {
 	bool hasChart = (c != nullptr);
 	bool hasTempo = (t != nullptr);
@@ -84,7 +84,7 @@ static Entry* CreateEntry(EditId id, const void* data, uint size, Chart* c, Temp
 	WriteStream header;
 	header.write<Entry>({nullptr});
 
-	uint flags = (id << 2) | (hasTempo << 1) | (hasChart << 0);
+	uint32_t flags = (id << 2) | (hasTempo << 1) | (hasChart << 0);
 	header.writeNum(flags);
 	if(hasChart) header.write(c);
 	if(hasTempo) header.write(t);
@@ -97,7 +97,7 @@ static Entry* CreateEntry(EditId id, const void* data, uint size, Chart* c, Temp
 		hasTempo ? 'y' : 'n');
 #endif
 
-	uchar* mem = (uchar*)malloc(header.size() + size);
+	uint8_t* mem = (uint8_t*)malloc(header.size() + size);
 	memcpy(mem, header.data(), header.size());
 	memcpy(mem + header.size(), data, size);
 
@@ -112,7 +112,7 @@ static EntryData DecodeEntry(const Entry* in)
 
 	EntryData out = {0, nullptr, nullptr, 0, nullptr};
 
-	uint flags;
+	uint32_t flags;
 	header.readNum(flags);
 	if(flags & 1) header.read(out.chart);
 	if(flags & 2) header.read(out.tempo);
@@ -128,7 +128,7 @@ static Entry* Advance(Entry* it, Bindings& bound)
 {
 	ReadStream header(it + 1, INT_MAX);
 
-	uint flags;
+	uint32_t flags;
 	header.readNum(flags);
 	if(flags & 1) header.read(bound.chart);
 	if(flags & 2) header.read(bound.tempo);
@@ -221,7 +221,7 @@ void pushEntry(Entry* entry)
 	if(msg.len()) HudNote("%s", msg.str());
 }
 
-void addEntry(EditId id, const void* data, uint size, Chart* targetChart, Tempo* targetTempo)
+void addEntry(EditId id, const void* data, uint32_t size, Chart* targetChart, Tempo* targetTempo)
 {
 	if(id == 0 || id > (size_t)myCallbacks.size())
 	{
@@ -251,17 +251,17 @@ void addEntry(EditId id, const void* data, uint size, Chart* targetChart, Tempo*
 	}
 }
 
-void addEntry(EditId id, const void* data, uint size)
+void addEntry(EditId id, const void* data, uint32_t size)
 {
 	addEntry(id, data, size, nullptr, nullptr);
 }
 
-void addEntry(EditId id, const void* data, uint size, Tempo* targetTempo)
+void addEntry(EditId id, const void* data, uint32_t size, Tempo* targetTempo)
 {
 	addEntry(id, data, size, nullptr, targetTempo);
 }
 
-void addEntry(EditId id, const void* data, uint size, Chart* targetChart)
+void addEntry(EditId id, const void* data, uint32_t size, Chart* targetChart)
 {
 	addEntry(id, data, size, targetChart, nullptr);
 }

--- a/src/Editor/History.h
+++ b/src/Editor/History.h
@@ -15,7 +15,7 @@ struct History : public InputHandler
 		Tempo* tempo;
 	};
 
-	typedef uint EditId;
+	typedef uint32_t EditId;
 
 	typedef void (*ReleaseFunc)(ReadStream& in, bool hasBeenApplied);
 	typedef String(*ApplyFunc)(ReadStream& in, Bindings bound, bool undo, bool redo);
@@ -25,9 +25,9 @@ struct History : public InputHandler
 
 	virtual EditId addCallback(ApplyFunc apply, ReleaseFunc release = nullptr) = 0;
 
-	virtual void addEntry(EditId id, const void* data, uint size) = 0;
-	virtual void addEntry(EditId id, const void* data, uint size, Tempo* targetTempo) = 0;
-	virtual void addEntry(EditId id, const void* data, uint size, Chart* targetChart) = 0;
+	virtual void addEntry(EditId id, const void* data, uint32_t size) = 0;
+	virtual void addEntry(EditId id, const void* data, uint32_t size, Tempo* targetTempo) = 0;
+	virtual void addEntry(EditId id, const void* data, uint32_t size, Chart* targetChart) = 0;
 
 	virtual void startChain() = 0;
 	virtual void finishChain(String message) = 0;

--- a/src/Editor/LoadMp3.cpp
+++ b/src/Editor/LoadMp3.cpp
@@ -13,7 +13,7 @@ namespace {
 // ================================================================================================
 // ID3 tag parsing.
 
-typedef ulong id3_length_t;
+typedef uint64_t id3_length_t;
 
 enum ID3Tagtype
 {
@@ -23,7 +23,7 @@ enum ID3Tagtype
 	TAGTYPE_ID3V2_FOOTER
 };
 
-static ID3Tagtype ID3GetTagtype(const uchar *data, id3_length_t length)
+static ID3Tagtype ID3GetTagtype(const uint8_t *data, id3_length_t length)
 {
 	if(length >= 3 &&
 		data[0] == 'T' && data[1] == 'A' && data[2] == 'G')
@@ -39,9 +39,9 @@ static ID3Tagtype ID3GetTagtype(const uchar *data, id3_length_t length)
 	return TAGTYPE_NONE;
 }
 
-static ulong ID3ParseUint(const uchar **ptr, uint bytes)
+static uint64_t ID3ParseUint(const uint8_t **ptr, uint32_t bytes)
 {
-	ulong value = 0;
+	uint64_t value = 0;
 	switch(bytes)
 	{
 		case 4: value = (value << 8) | *(*ptr)++;
@@ -52,9 +52,9 @@ static ulong ID3ParseUint(const uchar **ptr, uint bytes)
 	return value;
 }
 
-static ulong ID3ParseSyncsafe(const uchar **ptr, uint bytes)
+static uint64_t ID3ParseSyncsafe(const uint8_t **ptr, uint32_t bytes)
 {
-	ulong value = 0;
+	uint64_t value = 0;
 	switch(bytes)
 	{
 	case 5:
@@ -68,7 +68,7 @@ static ulong ID3ParseSyncsafe(const uchar **ptr, uint bytes)
 	return value;
 }
 
-static void ID3ParseHeader(const uchar **ptr, uint *version, int *flags, id3_length_t *size)
+static void ID3ParseHeader(const uint8_t **ptr, uint32_t *version, int *flags, id3_length_t *size)
 {
 	*ptr += 3;
 	*version = ID3ParseUint(ptr, 2);
@@ -76,9 +76,9 @@ static void ID3ParseHeader(const uchar **ptr, uint *version, int *flags, id3_len
 	*size = ID3ParseSyncsafe(ptr, 4);
 }
 
-static long ID3TagQuery(const uchar *data, id3_length_t length)
+static long ID3TagQuery(const uint8_t *data, id3_length_t length)
 {
-	uint version;
+	uint32_t version;
 	int flags;
 	id3_length_t size;
 	switch(ID3GetTagtype(data, length))
@@ -124,8 +124,8 @@ enum XingFlags
 
 static int XingParse(XingHeader* xing, struct mad_bitptr ptr, unsigned int bitlen)
 {
-	const uint XING_MAGIC = (('X' << 24) | ('i' << 16) | ('n' << 8) | 'g');
-	const uint INFO_MAGIC = (('I' << 24) | ('n' << 16) | ('f' << 8) | 'o');
+	const uint32_t XING_MAGIC = (('X' << 24) | ('i' << 16) | ('n' << 8) | 'g');
+	const uint32_t INFO_MAGIC = (('I' << 24) | ('n' << 16) | ('f' << 8) | 'o');
 	unsigned data;
 	if(bitlen < 64)
 		goto fail;
@@ -213,7 +213,7 @@ struct MP3Loader : public SoundSource
 	int numChannels;
 	int frequency;
 
-	uchar fileBuf[16384];
+	uint8_t fileBuf[16384];
 	short synthBuf[8192];
 	int synthNumSamples;
 	int synthBufPos;

--- a/src/Editor/Minimap.cpp
+++ b/src/Editor/Minimap.cpp
@@ -32,7 +32,7 @@ static const int MAP_WIDTH = 16;
 static const int TEXTURE_SIZE = 256; //sqrt(MAP_HEIGHT_MAX * MAP_WIDTH)
 static const int NUM_PIECES = MAP_HEIGHT / TEXTURE_SIZE;
 
-static const color32 arrowcol[9] =
+static const uint32_t arrowcol[9] =
 {
 	RGBAtoColor32(255,   0,   0, 255), // Red.
 	RGBAtoColor32( 12,  74, 206, 255), // Blue.
@@ -44,40 +44,40 @@ static const color32 arrowcol[9] =
 	RGBAtoColor32(  0, 198,   0, 255), // Green.
 	RGBAtoColor32(132, 132, 132, 255), // Gray.
 };
-static const color32 freezecol =
+static const uint32_t freezecol =
 {
 	RGBAtoColor32(64, 128, 0, 255) // Green
 };
-static const color32 rollcol =
+static const uint32_t rollcol =
 {
 	RGBAtoColor32(96, 96, 128, 255), // Blue gray
 };
-static const color32 minecol =
+static const uint32_t minecol =
 {
 	RGBAtoColor32(192, 192, 192, 255), // Light gray
 };
 
 struct SetPixelData
 {
-	uint* pixels;
+	uint32_t* pixels;
 	int noteW;
 	double pixPerOfs, startOfs;
 };
 
-static void SetPixels(const SetPixelData& spd, int x, double tor, color32 color)
+static void SetPixels(const SetPixelData& spd, int x, double tor, uint32_t color)
 {
 	int y = clamp((int)((tor - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
-	uint* dst = spd.pixels + y * MAP_WIDTH + x;
+	uint32_t* dst = spd.pixels + y * MAP_WIDTH + x;
 	for(int i = 0; i < spd.noteW; ++i, ++dst) *dst = color;
 }
 
-static void SetPixels(const SetPixelData& spd, int x, double tor, double end, color32 color)
+static void SetPixels(const SetPixelData& spd, int x, double tor, double end, uint32_t color)
 {
 	int yt = clamp((int)((tor - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
 	int yb = clamp((int)((end - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
 	for(int y = yt; y <= yb; ++y)
 	{
-		uint* dst = spd.pixels + y * MAP_WIDTH + x;
+		uint32_t* dst = spd.pixels + y * MAP_WIDTH + x;
 		for(int i = 0; i < spd.noteW; ++i, ++dst) *dst = color;
 	}
 }
@@ -134,10 +134,10 @@ void renderNotes(SetPixelData& spd, const int* colx)
 			int rowtype = ToRowType(note.row);
 			if(note.endrow > note.row)
 			{
-				color32 color = (note.isRoll) ? rollcol : freezecol;
+				uint32_t color = (note.isRoll) ? rollcol : freezecol;
 				SetPixels(spd, colx[note.col], note.time, note.endtime, color);
 			}
-			color32 color;
+			uint32_t color;
 			if(note.isSelected)
 			{
 				color = RGBAtoColor32(255, 255, 255, 255);
@@ -156,10 +156,10 @@ void renderNotes(SetPixelData& spd, const int* colx)
 			int rowtype = ToRowType(note.row);
 			if(note.endrow > note.row)
 			{
-				color32 color = (note.isRoll) ? rollcol : freezecol;
+				uint32_t color = (note.isRoll) ? rollcol : freezecol;
 				SetPixels(spd, colx[note.col], note.row, note.endrow, color);
 			}
-			color32 color;
+			uint32_t color;
 			if(note.isSelected)
 			{
 				color = RGBAtoColor32(255, 255, 255, 255);
@@ -178,9 +178,9 @@ static int BlendI32(int a, int b, int f)
 	return a + (((b - a) * f) >> 8);
 }
 
-static void SetDensityRow(uint* pixels, int y, double density)
+static void SetDensityRow(uint32_t* pixels, int y, double density)
 {
-	static const uchar colors[] =
+	static const uint8_t colors[] =
 	{
 		 64, 192, 192,
 		128, 255,  64,
@@ -194,10 +194,10 @@ static void SetDensityRow(uint* pixels, int y, double density)
 	int r = BlendI32(colors[ci + 0], colors[ci + 3], bf);
 	int g = BlendI32(colors[ci + 1], colors[ci + 4], bf);
 	int b = BlendI32(colors[ci + 2], colors[ci + 5], bf);
-	uint col = Color32(r, g, b);
+	uint32_t col = Color32(r, g, b);
 
 	int w = clamp((int)(density * 0.05), 4, MAP_WIDTH) / 2;
-	uint* dst = pixels + y * MAP_WIDTH + MAP_WIDTH / 2 - w;
+	uint32_t* dst = pixels + y * MAP_WIDTH + MAP_WIDTH / 2 - w;
 	for(int i = -w; i < w; ++i, ++dst) *dst = col;
 }
 
@@ -297,7 +297,7 @@ void onChanges(int changes)
 
 	if((changes & bits) == 0) return;
 
-	Vector<uint> buffer(MAP_HEIGHT * MAP_WIDTH, 0);
+	Vector<uint32_t> buffer(MAP_HEIGHT * MAP_WIDTH, 0);
 
 	// The height of the chart region is based on the time elapsed between the first and last row.
 	double timeStart = gTempo->rowToTime(0);
@@ -343,8 +343,8 @@ void onChanges(int changes)
 	// Update the texture strips.
 	for(int i = 0; i < NUM_PIECES; ++i)
 	{
-		uint* buf = buffer.data();
-		auto src = (const uchar*)(buf + i * MAP_WIDTH * TEXTURE_SIZE);
+		uint32_t* buf = buffer.data();
+		auto src = (const uint8_t*)(buf + i * MAP_WIDTH * TEXTURE_SIZE);
 		myImage.modify(i * MAP_WIDTH, 0, MAP_WIDTH, TEXTURE_SIZE, src);
 	}
 }
@@ -383,7 +383,7 @@ void tick()
 	}
 }
 
-void drawRegion(int x, int w, double ofsA, double ofsB, color32 color)
+void drawRegion(int x, int w, double ofsA, double ofsB, uint32_t color)
 {
 	recti chartRect = myGetMapRect();
 	double pixPerOfs = (double)chartRect.h / (myChartEndOfs - myChartBeginOfs);

--- a/src/Editor/Notefield.cpp
+++ b/src/Editor/Notefield.cpp
@@ -125,7 +125,7 @@ BatchSprite myNoteLabels[2];
 
 Reference<TweakInfoBox> myTweakInfoBox;
 
-color32 mySongBgColor;
+uint32_t mySongBgColor;
 int myBgBrightness;
 
 int myColX[SIM_MAX_COLUMNS], myCX, myX, myY, myW;
@@ -184,7 +184,7 @@ void onChanges(int changes)
 			}
 			else
 			{
-				const uchar* src = img.pixels;
+				const uint8_t* src = img.pixels;
 				int64_t rsum = 0, gsum = 0, bsum = 0;
 				int numPixels = img.width * img.height;
 				for(int i = 0; i < numPixels; ++i)
@@ -383,8 +383,8 @@ void drawBeatLines()
 
 	// Start drawing measures and beat lines.
 	auto batch = Renderer::batchC();
-	color32 halfColor = ToColor32({1, 1, 1, 0.4f});
-	color32 fullColor = ToColor32({1, 1, 1, 0.7f});
+	uint32_t halfColor = ToColor32({1, 1, 1, 0.4f});
+	uint32_t fullColor = ToColor32({1, 1, 1, 0.7f});
 	DrawPosHelper drawPos;
 	while(it != end && row < drawEndRow)
 	{
@@ -469,7 +469,7 @@ void drawStopsAndWarps()
 				int b = (int)(oy + dy * it->rowTime);
 				if(validSegmentRegion(t, b, viewTop, viewBtm))
 				{
-					color32 col = RGBAtoColor32(26, 128, 128, 128);
+					uint32_t col = RGBAtoColor32(26, 128, 128, 128);
 					Draw::fill(&batch, {myX, t, myW, b - t}, col);
 				}
 			}
@@ -479,7 +479,7 @@ void drawStopsAndWarps()
 				int b = (int)(oy + dy * it->endTime);
 				if(validSegmentRegion(t, b, viewTop, viewBtm))
 				{
-					color32 col = RGBAtoColor32(128, 128, 51, 128);
+					uint32_t col = RGBAtoColor32(128, 128, 51, 128);
 					Draw::fill(&batch, {myX, t, myW, b - t}, col);
 				}
 			}
@@ -495,7 +495,7 @@ void drawStopsAndWarps()
 				int b = (int)(oy + dy * (it + 1)->row);
 				if(validSegmentRegion(t, b, viewTop, viewBtm))
 				{
-					color32 col = RGBAtoColor32(128, 26, 51, 128);
+					uint32_t col = RGBAtoColor32(128, 26, 51, 128);
 					Draw::fill(&batch, {myX, t, myW, b - t}, col);
 				}
 			}
@@ -521,13 +521,13 @@ void drawReceptors()
 		// Calculate the beat pulse value for the receptors.
 		double beat = gTempo->timeToBeat(gView->getCursorTime());
 		float beatfrac = (float)(beat - floor(beat));
-		uchar beatpulse = (uchar)min(max((int)((2 - beatfrac * 4)*255), 0), 255);
+		uint8_t beatpulse = (uint8_t)min(max((int)((2 - beatfrac * 4)*255), 0), 255);
 
 		// Draw the receptors.
 		auto batch = Renderer::batchTC();
 		for(int c = 0; c < cols; ++c)
 		{
-			noteskin->recepOff[c].draw(&batch, myColX[c], myY, (uchar)255);
+			noteskin->recepOff[c].draw(&batch, myColX[c], myY, (uint8_t)255);
 			noteskin->recepOn[c].draw(&batch, myColX[c], myY, beatpulse);
 		}
 		batch.flush();
@@ -563,7 +563,7 @@ void drawReceptorGlow()
 		if(note->isMine | note->isWarped | (note->type == NOTE_FAKE)) continue;
 
 		double lum = 1.5 - (time - note->endtime) * 6.0;
-		uchar alpha = (uchar)clamp((int)(lum * 255.0), 0, 255);
+		uint8_t alpha = (uint8_t)clamp((int)(lum * 255.0), 0, 255);
 		if(alpha > 0)
 		{
 			noteskin->recepGlow[c].draw(&batch, myColX[c], myY, alpha);

--- a/src/Editor/Selection.cpp
+++ b/src/Editor/Selection.cpp
@@ -271,7 +271,7 @@ void drawRegionSelection()
 	// Draw area selection box.
 	if(myIsSelectingRegion || myRegion.beginRow != myRegion.endRow)
 	{
-		color32 outline = RGBAtoColor32(153, 255, 153, 153);
+		uint32_t outline = RGBAtoColor32(153, 255, 153, 153);
 		auto coords = gView->getReceptorCoords();
 		int x = coords.xl, w = coords.xr - coords.xl;
 		if(myIsSelectingRegion)
@@ -298,8 +298,8 @@ void drawSelectionBox()
 		vec2i start = {myDragSelectionX, gView->offsetToY(myDragSelectionTor)};
 
 		// Selection rectangle.
-		color32 outline = RGBAtoColor32(255, 191, 128, 128);
-		color32 fill = RGBAtoColor32(255, 191, 128, 89);
+		uint32_t outline = RGBAtoColor32(255, 191, 128, 128);
+		uint32_t fill = RGBAtoColor32(255, 191, 128, 89);
 
 		int x = start.x, x2 = mpos.x;
 		int y = start.y, y2 = mpos.y;

--- a/src/Editor/Sound.cpp
+++ b/src/Editor/Sound.cpp
@@ -84,7 +84,7 @@ public:
 	void exec();
 	bool readBlock();
 	void cleanup();
-	uchar progress() { return myProgress; }
+	uint8_t progress() { return myProgress; }
 	double elapsedTime() { return Debug::getElapsedTime(myStartTime); }
 
 private:
@@ -93,7 +93,7 @@ private:
 	short* myBuffer;
 	int myCurrentFrame;
 	int myReservedFrames;
-	uchar myProgress;
+	uint8_t myProgress;
 	std::chrono::steady_clock::time_point myStartTime;
 };
 
@@ -175,7 +175,7 @@ bool Sound::Thread::readBlock()
 
 		if(mySound->myIsAllocated)
 		{
-			myProgress = (uchar)((uint64_t)100 * myCurrentFrame / mySound->myNumFrames);
+			myProgress = (uint8_t)((uint64_t)100 * myCurrentFrame / mySound->myNumFrames);
 		}
 	}
 

--- a/src/Editor/StreamGenerator.cpp
+++ b/src/Editor/StreamGenerator.cpp
@@ -281,7 +281,7 @@ void StreamGenerator::generate(int row, int endRow, SnapType spacing)
 	{
 		// Generate an arrow for the current row.
 		int col = stream.getNextCol();
-		edit.add.append({row, row, (uint)col, 0, NOTE_STEP_OR_HOLD, 192});
+		edit.add.append({row, row, (uint32_t)col, 0, NOTE_STEP_OR_HOLD, 192});
 
 		// Store the current facing.
 		int yl = stream.pad[stream.feet[FOOT_L].curCol].y;

--- a/src/Editor/TempoBoxes.cpp
+++ b/src/Editor/TempoBoxes.cpp
@@ -244,7 +244,7 @@ int performSelection(SelectModifier mod, Predicate pred)
 	{
 		for(; box != end; ++box)
 		{
-			uint set = pred(box);
+			uint32_t set = pred(box);
 			numSelected += set;
 			box->isSelected = set;
 		}
@@ -253,7 +253,7 @@ int performSelection(SelectModifier mod, Predicate pred)
 	{
 		for(; box != end; ++box)
 		{
-			uint set = pred(box);
+			uint32_t set = pred(box);
 			numSelected += set & (box->isSelected ^ 1);
 			box->isSelected |= set;
 		}
@@ -262,7 +262,7 @@ int performSelection(SelectModifier mod, Predicate pred)
 	{
 		for(; box != end; ++box)
 		{
-			uint set = pred(box);
+			uint32_t set = pred(box);
 			numSelected += set & box->isSelected;
 			box->isSelected &= set ^ 1;
 		}
@@ -374,7 +374,7 @@ void draw()
 		int flags = side * TileBar::FLIP_H;
 		recti r = {x, y - 16, (int)box.width, 32};
 
-		color32 color = Segment::meta[box.type]->color;
+		uint32_t color = Segment::meta[box.type]->color;
 		myBoxBar.draw(&batch, r, color, flags);
 		if(box.isSelected) myBoxHl.draw(&batch, r, Colors::white, flags);
 

--- a/src/Editor/TempoBoxes.h
+++ b/src/Editor/TempoBoxes.h
@@ -11,8 +11,8 @@ struct TempoBox
 	int row;
 	Segment::Type type;
 	signed int x : 16;
-	uint width : 15;
-	uint isSelected : 1;
+	uint32_t width : 15;
+	uint32_t isSelected : 1;
 };
 
 struct TempoBoxes

--- a/src/Editor/TextOverlay.cpp
+++ b/src/Editor/TextOverlay.cpp
@@ -30,8 +30,8 @@ struct Shortcut { String a, b; bool isHeader; };
 
 static const int NUM_ICONS = 16;
 
-static uchar supportLink[] = "https://discord.gg/GCNAyDmjqy";
-static uchar githubLink[] = "https://github.com/uvcat7/ArrowVortex";
+static uint8_t supportLink[] = "https://discord.gg/GCNAyDmjqy";
+static uint8_t githubLink[] = "https://github.com/uvcat7/ArrowVortex";
 
 static const char* iconNames[NUM_ICONS] = {
 	"up one",

--- a/src/Editor/Waveform.cpp
+++ b/src/Editor/Waveform.cpp
@@ -99,7 +99,7 @@ struct WaveformImpl : public Waveform {
 Vector<WaveBlock*> waveformBlocks_;
 
 WaveFilter* waveformFilter_;
-Vector<uchar> waveformTextureBuffer_;
+Vector<uint8_t> waveformTextureBuffer_;
 
 int waveformBlockWidth_, waveformSpacing_;
 
@@ -326,7 +326,7 @@ int getAntiAliasing()
 // ================================================================================================
 // Waveform :: luminance functions.
 
-struct WaveEdge { int l, r; uchar lum; };
+struct WaveEdge { int l, r; uint8_t lum; };
 
 void edgeLumUniform(WaveEdge* edge, int h)
 {
@@ -349,7 +349,7 @@ void edgeLumAmplitude(WaveEdge* edge, int w, int h)
 // ================================================================================================
 // Waveform :: edge shape functions.
 
-void edgeShapeRectified(uchar* dst, const WaveEdge* edge, int w, int h)
+void edgeShapeRectified(uint8_t* dst, const WaveEdge* edge, int w, int h)
 {
 	int cx = w / 2;
 	for(int y = 0; y < h; ++y, dst += w, ++edge)
@@ -361,7 +361,7 @@ void edgeShapeRectified(uchar* dst, const WaveEdge* edge, int w, int h)
 	}
 }
 
-void edgeShapeSigned(uchar* dst, const WaveEdge* edge, int w, int h)
+void edgeShapeSigned(uint8_t* dst, const WaveEdge* edge, int w, int h)
 {
 	int cx = w / 2;
 	for(int y = 0; y < h; ++y, dst += w, ++edge)
@@ -375,15 +375,15 @@ void edgeShapeSigned(uchar* dst, const WaveEdge* edge, int w, int h)
 // ================================================================================================
 // Waveform :: anti-aliasing functions.
 
-void antiAlias2x(uchar* dst, int w, int h)
+void antiAlias2x(uint8_t* dst, int w, int h)
 {
 	int newW = w / 2, newH = h / 2;
 	for(int y = 0; y < newH; ++y)
 	{
-		uchar* line = waveformTextureBuffer_.begin() + (y * 2) * w;
+		uint8_t* line = waveformTextureBuffer_.begin() + (y * 2) * w;
 		for(int x = 0; x < newW; ++x, ++dst)
 		{
-			uchar* a = line + (x * 2), *b = a + w;
+			uint8_t* a = line + (x * 2), *b = a + w;
 			int sum = 0;
 			sum += a[0] + a[1];
 			sum += b[0] + b[1];
@@ -392,16 +392,16 @@ void antiAlias2x(uchar* dst, int w, int h)
 	}
 }
 
-void antiAlias3x(uchar* dst, int w, int h)
+void antiAlias3x(uint8_t* dst, int w, int h)
 {
 	int newW = w / 3, newH = h / 3;
 	for(int y = 0; y < newH; ++y)
 	{
-		uchar* line = waveformTextureBuffer_.begin() + (y * 3) * w;
+		uint8_t* line = waveformTextureBuffer_.begin() + (y * 3) * w;
 		for(int x = 0; x < newW; ++x, ++dst)
 		{
-			uchar* a = line + (x * 3);
-			uchar* b = a + w, *c = b + w;
+			uint8_t* a = line + (x * 3);
+			uint8_t* b = a + w, *c = b + w;
 			int sum = 0;
 			sum += a[0] + a[1] + a[2];
 			sum += b[0] + b[1] + b[2];
@@ -411,16 +411,16 @@ void antiAlias3x(uchar* dst, int w, int h)
 	}
 }
 
-void antiAlias4x(uchar* dst, int w, int h)
+void antiAlias4x(uint8_t* dst, int w, int h)
 {
 	int newW = w / 4, newH = h / 4;
 	for(int y = 0; y < newH; ++y)
 	{
-		uchar* line = waveformTextureBuffer_.begin() + (y * 4) * w;
+		uint8_t* line = waveformTextureBuffer_.begin() + (y * 4) * w;
 		for(int x = 0; x < newW; ++x, ++dst)
 		{
-			uchar* a = line + (x * 4), *b = a + w;
-			uchar* c = b + w, *d = c + w;
+			uint8_t* a = line + (x * 4), *b = a + w;
+			uint8_t* c = b + w, *d = c + w;
 			int sum = 0;
 			sum += a[0] + a[1] + a[2] + a[3];
 			sum += b[0] + b[1] + b[2] + b[3];
@@ -504,7 +504,7 @@ void sampleEdges(WaveEdge* edges, int w, int h, int channel, int blockId, bool f
 
 void renderWaveform(Texture* textures, WaveEdge* edgeBuf, int w, int h, int blockId, bool filtered)
 {
-	uchar* texBuf = waveformTextureBuffer_.begin();
+	uint8_t* texBuf = waveformTextureBuffer_.begin();
 	for(int channel = 0; channel < 2; ++channel)
 	{
 		memset(texBuf, 0, w * h);
@@ -672,7 +672,7 @@ void drawPeaks()
 		TextureHandle texL = block->tex[0].handle();
 		TextureHandle texR = block->tex[1].handle();
 
-		color32 waveCol = ToColor32(waveformColorScheme_.wave);
+		uint32_t waveCol = ToColor32(waveformColorScheme_.wave);
 		Draw::fill({xl - pw, y, pw * 2, TEX_H}, waveCol, texL, uvs, Texture::ALPHA);
 		Draw::fill({xr - pw, y, pw * 2, TEX_H}, waveCol, texR, uvs, Texture::ALPHA);
 
@@ -681,7 +681,7 @@ void drawPeaks()
 			TextureHandle texL = block->tex[2].handle();
 			TextureHandle texR = block->tex[3].handle();
 
-			color32 filterCol = ToColor32(waveformColorScheme_.filter);
+			uint32_t filterCol = ToColor32(waveformColorScheme_.filter);
 			Draw::fill({xl - pw, y, pw * 2, TEX_H}, filterCol, texL, uvs, Texture::ALPHA);
 			Draw::fill({xr - pw, y, pw * 2, TEX_H}, filterCol, texR, uvs, Texture::ALPHA);
 		}

--- a/src/Managers/NoteMan.cpp
+++ b/src/Managers/NoteMan.cpp
@@ -132,7 +132,7 @@ void myUpdateNoteTimes()
 
 void myUpdateWarpedNotes()
 {
-	uint insideWarp = 0;
+	uint32_t insideWarp = 0;
 	auto note = myNotes.begin(), noteEnd = myNotes.end();
 	auto& events = gTempo->getTimingData().events;
 	auto it = events.begin(), end = events.end();
@@ -557,7 +557,7 @@ int performSelection(SelectModifier mod, Predicate pred)
 	{
 		for(; note != end; ++note)
 		{
-			uint set = pred(note);
+			uint32_t set = pred(note);
 			numSelected += set;
 			note->isSelected = set;
 		}
@@ -566,7 +566,7 @@ int performSelection(SelectModifier mod, Predicate pred)
 	{
 		for(; note != end; ++note)
 		{
-			uint set = pred(note);
+			uint32_t set = pred(note);
 			numSelected += set & (note->isSelected ^ 1);
 			note->isSelected |= set;
 		}
@@ -575,7 +575,7 @@ int performSelection(SelectModifier mod, Predicate pred)
 	{
 		for(; note != end; ++note)
 		{
-			uint set = pred(note);
+			uint32_t set = pred(note);
 			numSelected += set & note->isSelected;
 			note->isSelected &= set ^ 1;
 		}
@@ -791,7 +791,7 @@ void copyToClipboard(bool timeBased)
 	if(numNotes > 0)
 	{
 		WriteStream stream;
-		stream.write<uchar>(timeBased);
+		stream.write<uint8_t>(timeBased);
 		if(timeBased)
 		{
 			notes.encode(stream, gTempo->getTimingData(), true);
@@ -807,11 +807,11 @@ void copyToClipboard(bool timeBased)
 
 void pasteFromClipboard(bool insert)
 {
-	Vector<uchar> buffer = GetClipboardData(clipboardTag);
+	Vector<uint8_t> buffer = GetClipboardData(clipboardTag);
 	ReadStream stream(buffer.data(), buffer.size());
 
 	// Check if the note data is time-based.
-	bool timeBased = (stream.read<uchar>() != 0);
+	bool timeBased = (stream.read<uint8_t>() != 0);
 
 	// Read the note data.
 	NoteEdit edit;

--- a/src/Managers/NoteskinMan.cpp
+++ b/src/Managers/NoteskinMan.cpp
@@ -42,7 +42,7 @@ static bool LoadTexture(StringRef path, StringRef dir, Texture& out)
 	out = Texture((dir + path).str());
 	if(out.handle()) return true;
 
-	uchar dummyTex[4] = {255, 0, 255, 255};
+	uint8_t dummyTex[4] = {255, 0, 255, 255};
 	out = Texture(1, 1, dummyTex);
 	return false;
 }

--- a/src/Managers/TempoMan.cpp
+++ b/src/Managers/TempoMan.cpp
@@ -605,7 +605,7 @@ void pasteFromClipboard(bool insert)
 	SegmentEdit clipboard;
 
 	// Decode the clipboard data.	
-	Vector<uchar> data = GetClipboardData(clipboardTag);
+	Vector<uint8_t> data = GetClipboardData(clipboardTag);
 	ReadStream stream(data.begin(), data.size());
 	clipboard.add.decode(stream);
 	if(stream.success() == false || stream.bytesleft() > 0)

--- a/src/Simfile/Common.h
+++ b/src/Simfile/Common.h
@@ -40,6 +40,6 @@ struct RowCol { int row, col; };
 struct Property { String tag, val; };
 
 /// Represents a single note.
-struct Note { int row, endrow; uint col : 8; uint player : 4; uint type : 4; uint quant : 8; };
+struct Note { int row, endrow; uint32_t col : 8; uint32_t player : 4; uint32_t type : 4; uint32_t quant : 8; };
 
 }; // namespace Vortex

--- a/src/Simfile/Encoding.cpp
+++ b/src/Simfile/Encoding.cpp
@@ -18,21 +18,21 @@ void EncodeNote(WriteStream& out, const Note& in)
 {
 	if(in.row == in.endrow && in.player == 0 && in.type == 0)
 	{
-		out.write<uchar>(in.col);
+		out.write<uint8_t>(in.col);
 		out.writeNum(in.row);
 	}
 	else
 	{
-		out.write<uchar>(in.col | 0x80);
+		out.write<uint8_t>(in.col | 0x80);
 		out.writeNum(in.row);
 		out.writeNum(in.endrow);
-		out.write<uchar>((in.player << 4) | in.type);
+		out.write<uint8_t>((in.player << 4) | in.type);
 	}
 }
 
 void DecodeNote(ReadStream& in, Note& out)
 {
-	uchar col = in.read<uchar>();
+	uint8_t col = in.read<uint8_t>();
 	if((col & 0x80) == 0)
 	{
 		int row = in.readNum();
@@ -43,7 +43,7 @@ void DecodeNote(ReadStream& in, Note& out)
 		out.col = col & 0x7F;
 		out.row = in.readNum();
 		out.endrow = in.readNum();
-		uint v = in.read<uchar>();
+		uint32_t v = in.read<uint8_t>();
 		out.player = v >> 4;
 		out.type = v & 0xF;
 	}
@@ -56,21 +56,21 @@ void EncodeNoteWithTime(WriteStream& out, const ExpandedNote& in)
 {
 	if(in.time == in.endtime && in.player == 0 && in.type == 0)
 	{
-		out.write<uchar>(in.col);
+		out.write<uint8_t>(in.col);
 		out.write(in.time);
 	}
 	else
 	{
-		out.write<uchar>(in.col | 0x80);
+		out.write<uint8_t>(in.col | 0x80);
 		out.write(in.time);
 		out.write(in.endtime);
-		out.write<uchar>((in.player << 4) | in.type);
+		out.write<uint8_t>((in.player << 4) | in.type);
 	}
 }
 
 void DecodeNoteWithTime(ReadStream& in, ExpandedNote& out)
 {
-	uchar col = in.read<uchar>();
+	uint8_t col = in.read<uint8_t>();
 	if((col & 0x80) == 0)
 	{
 		double time = in.read<double>();
@@ -80,7 +80,7 @@ void DecodeNoteWithTime(ReadStream& in, ExpandedNote& out)
 		out.col = col & 0x7F;
 		in.read(out.time);
 		in.read(out.endtime);
-		uint v = in.read<uchar>();
+		uint32_t v = in.read<uint8_t>();
 		out.player = v >> 4;
 		out.type = v & 0xF;
 	}
@@ -101,8 +101,8 @@ void EncodeNotes(WriteStream& out, const Note* in, int num)
 void DecodeNotes(ReadStream& in, Vector<Note>& out)
 {
 	Note note;
-	uint num = in.readNum();
-	for(uint i = 0; i < num; ++i)
+	uint32_t num = in.readNum();
+	for(uint32_t i = 0; i < num; ++i)
 	{
 		DecodeNote(in, note);
 		out.push_back(note);

--- a/src/Simfile/LoadDwi.cpp
+++ b/src/Simfile/LoadDwi.cpp
@@ -144,7 +144,7 @@ static char* ReadNoteRow(char* p, NoteList& out, int row, const int* map, int* h
 			}
 			else
 			{
-				out.append({row, row, (uint)col, 0, NOTE_STEP_OR_HOLD, (uint) quantization});
+				out.append({row, row, (uint32_t)col, 0, NOTE_STEP_OR_HOLD, (uint32_t) quantization});
 				if(cols[col] & HOLD_BIT)
 				{
 					holds[col] = out.size();

--- a/src/Simfile/LoadOsu.cpp
+++ b/src/Simfile/LoadOsu.cpp
@@ -509,11 +509,11 @@ static void ConvertNotes(Simfile* sim, OsuFile& osu, Chart& chart)
 		if(hitObject.endtime > hitObject.time)
 		{
 			int endrow = timing.timeToRow(hitObject.endtime);
-			chart.notes.append({row, endrow, (uint)col, 0, NOTE_STEP_OR_HOLD, 192});
+			chart.notes.append({row, endrow, (uint32_t)col, 0, NOTE_STEP_OR_HOLD, 192});
 		}
 		else
 		{
-			chart.notes.append({row, row, (uint)col, 0, NOTE_STEP_OR_HOLD, 192});
+			chart.notes.append({row, row, (uint32_t)col, 0, NOTE_STEP_OR_HOLD, 192});
 		}
 	}
 }
@@ -545,7 +545,7 @@ static bool ParseOsz(Vector<OsuFile*>& out, StringRef path, String& err)
 	// Read the files.
 	String str;
 	char buffer[512];
-	for(uint i = 0; i < global_info.number_entry; ++i)
+	for(uint32_t i = 0; i < global_info.number_entry; ++i)
 	{
 		unz_file_info file_info;
 		if(unzGetCurrentFileInfo(zip, &file_info, buffer, 512, 0, 0, 0, 0) == UNZ_OK)

--- a/src/Simfile/LoadSm.cpp
+++ b/src/Simfile/LoadSm.cpp
@@ -384,11 +384,11 @@ static void ReadNoteRow(ReadNoteData& data, int row, char* p, int quantization)
 		}
 		else if(*p == '1')
 		{
-			data.notes->append({row, row, (uint)col, (uint)data.player, NOTE_STEP_OR_HOLD, (uint) quantization});
+			data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player, NOTE_STEP_OR_HOLD, (uint32_t) quantization});
 		}
 		else if(*p == '2' || *p == '4')
 		{
-			data.notes->append({row, row, (uint)col, (uint)data.player, NOTE_STEP_OR_HOLD, (uint) quantization});
+			data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player, NOTE_STEP_OR_HOLD, (uint32_t) quantization});
 			data.holdType[col] = (*p == '2') ? NOTE_STEP_OR_HOLD : NOTE_ROLL;
 			data.holdPos[col] = data.notes->size();
 		}
@@ -405,15 +405,15 @@ static void ReadNoteRow(ReadNoteData& data, int row, char* p, int quantization)
 		}
 		else if(*p == 'M')
 		{
-			data.notes->append({row, row, (uint)col, (uint)data.player, NOTE_MINE, (uint) quantization});
+			data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player, NOTE_MINE, (uint32_t) quantization});
 		}
 		else if(*p == 'L')
 		{
-			data.notes->append({row, row, (uint)col, (uint)data.player, NOTE_LIFT, (uint) quantization});
+			data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player, NOTE_LIFT, (uint32_t) quantization});
 		}
 		else if(*p == 'F')
 		{
-			data.notes->append({row, row, (uint)col, (uint)data.player, NOTE_FAKE, (uint) quantization});
+			data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player, NOTE_FAKE, (uint32_t) quantization});
 		}
 	}
 }

--- a/src/Simfile/NoteList.cpp
+++ b/src/Simfile/NoteList.cpp
@@ -232,18 +232,18 @@ void NoteList::sanitize(const Chart* chart)
 
 	Vector<int> endrowVec(numCols, -1);
 	int* endrows = endrowVec.data();
-	uint col = -1;
+	uint32_t col = -1;
 	int row = -1;
 
 	// Make sure all notes are valid, sorted, and do not overlap.
 	for(auto& note : *this)
 	{
-		if(note.col >= (uint)numCols)
+		if(note.col >= (uint32_t)numCols)
 		{
 			++numInvalidCols;
 			note.row = -1;
 		}
-		else if(note.player >= (uint)numPlayers)
+		else if(note.player >= (uint32_t)numPlayers)
 		{
 			++numInvalidPlayers;
 			note.row = -1;
@@ -473,17 +473,17 @@ static void EncodeNote(WriteStream& out, const Note& in, int offsetRows)
 {
 	if(in.row == in.endrow && in.player == 0 && in.type == 0)
 	{
-		out.write<uchar>(in.col);
+		out.write<uint8_t>(in.col);
 		out.writeNum(in.row + offsetRows);
-		out.write<uchar>(in.quant);
+		out.write<uint8_t>(in.quant);
 	}
 	else
 	{
-		out.write<uchar>(in.col | 0x80);
+		out.write<uint8_t>(in.col | 0x80);
 		out.writeNum(in.row + offsetRows);
 		out.writeNum(in.endrow + offsetRows);
-		out.write<uchar>((in.player << 4) | in.type);
-		out.write<uchar>(in.quant);
+		out.write<uint8_t>((in.player << 4) | in.type);
+		out.write<uint8_t>(in.quant);
 	}
 }
 
@@ -492,17 +492,17 @@ static void EncodeNote(WriteStream& out, const Note& in, TempoTimeTracker& track
 	double time = tracker.advance(in.row);
 	if(in.row == in.endrow && in.player == 0 && in.type == 0)
 	{
-		out.write<uchar>(in.col);
+		out.write<uint8_t>(in.col);
 		out.write<double>(time + offsetTime);
-		out.write<uchar>(in.quant);
+		out.write<uint8_t>(in.quant);
 	}
 	else
 	{
-		out.write<uchar>(in.col | 0x80);
+		out.write<uint8_t>(in.col | 0x80);
 		out.write<double>(time + offsetTime);
 		out.write<double>(tracker.lookAhead(in.endrow) + offsetTime);
-		out.write<uchar>((in.player << 4) | in.type);
-		out.write<uchar>(in.quant);
+		out.write<uint8_t>((in.player << 4) | in.type);
+		out.write<uint8_t>(in.quant);
 	}
 }
 
@@ -531,11 +531,11 @@ static void ApplyQuantOffset(Note& out, int offsetRows)
 
 static void DecodeNote(ReadStream& in, Note& out, int offsetRows)
 {
-	uchar col = in.read<uchar>();
+	uint8_t col = in.read<uint8_t>();
 	if((col & 0x80) == 0)
 	{
 		int row = in.readNum() + offsetRows;
-		uchar quant = in.read<uchar>();
+		uint8_t quant = in.read<uint8_t>();
 		out = { row, row, col, 0, 0, quant };
 	}
 	else
@@ -543,23 +543,23 @@ static void DecodeNote(ReadStream& in, Note& out, int offsetRows)
 		out.col = col & 0x7F;
 		out.row = in.readNum() + offsetRows;
 		out.endrow = in.readNum() + offsetRows;
-		uint v = in.read<uchar>();
+		uint32_t v = in.read<uint8_t>();
 		out.player = v >> 4;
 		out.type = v & 0xF;
-		out.quant = in.read<uchar>();
+		out.quant = in.read<uint8_t>();
 	}
 	ApplyQuantOffset(out, offsetRows);
 }
 
 static void DecodeNote(ReadStream& in, Note& out, TempoRowTracker& tracker, double offsetTime)
 {
-	uchar col = in.read<uchar>();
+	uint8_t col = in.read<uint8_t>();
 	int offsetRows = tracker.lookAhead(offsetTime);
 	if((col & 0x80) == 0)
 	{
 		double time = in.read<double>() + offsetTime;
 		int row = tracker.advance(time);
-		uchar quant = in.read<uchar>();
+		uint8_t quant = in.read<uint8_t>();
 		out = {row, row, col, 0, 0, quant};
 	}
 	else
@@ -569,10 +569,10 @@ static void DecodeNote(ReadStream& in, Note& out, TempoRowTracker& tracker, doub
 		out.row = tracker.advance(time);
 		double endTime = in.read<double>() + offsetTime;
 		out.endrow = tracker.lookAhead(time);
-		uint v = in.read<uchar>();
+		uint32_t v = in.read<uint8_t>();
 		out.player = v >> 4;
 		out.type = v & 0xF;
-		out.quant = in.read<uchar>();
+		out.quant = in.read<uint8_t>();
 	}
 	ApplyQuantOffset(out, offsetRows);
 }
@@ -609,8 +609,8 @@ void NoteList::encode(WriteStream& out, const TimingData& timing, bool removeOff
 void NoteList::decode(ReadStream& in, int offsetRows)
 {
 	Note note;
-	uint num = in.readNum();
-	for(uint i = 0; i < num; ++i)
+	uint32_t num = in.readNum();
+	for(uint32_t i = 0; i < num; ++i)
 	{
 		DecodeNote(in, note, offsetRows);
 		append(note);
@@ -621,8 +621,8 @@ void NoteList::decode(ReadStream& in, const TimingData& timing, double offsetTim
 {
 	TempoRowTracker tracker(timing);
 	Note note;
-	uint num = in.readNum();
-	for(uint i = 0; i < num; ++i)
+	uint32_t num = in.readNum();
+	for(uint32_t i = 0; i < num; ++i)
 	{
 		DecodeNote(in, note, tracker, offsetTime);
 		append(note);

--- a/src/Simfile/Notes.cpp
+++ b/src/Simfile/Notes.cpp
@@ -11,38 +11,38 @@ void EncodeNote(WriteStream& out, const Note& in)
 {
 	if(in.row == in.endrow && in.player == 0 && in.type == 0)
 	{
-		out.write<uchar>(in.col);
+		out.write<uint8_t>(in.col);
 		out.writeNum(in.row);
-		out.write<uchar>(in.quant);
+		out.write<uint8_t>(in.quant);
 	}
 	else
 	{
-		out.write<uchar>(in.col | 0x80);
+		out.write<uint8_t>(in.col | 0x80);
 		out.writeNum(in.row);
 		out.writeNum(in.endrow);
-		out.write<uchar>((in.player << 4) | in.type);
-		out.write<uchar>(in.quant);
+		out.write<uint8_t>((in.player << 4) | in.type);
+		out.write<uint8_t>(in.quant);
 	}
 }
 
 void DecodeNote(ReadStream& in, Note& out)
 {
-	uchar col = in.read<uchar>();
+	uint8_t col = in.read<uint8_t>();
 	if((col & 0x80) == 0)
 	{
 		int row = in.readNum();
 		out = {row, row, col, 0, 0, 0};
-		out.quant = in.read<uchar>();
+		out.quant = in.read<uint8_t>();
 	}
 	else
 	{
 		out.col = col & 0x7F;
 		out.row = in.readNum();
 		out.endrow = in.readNum();
-		uint v = in.read<uchar>();
+		uint32_t v = in.read<uint8_t>();
 		out.player = v >> 4;
 		out.type = v & 0xF;
-		out.quant = in.read<uchar>();
+		out.quant = in.read<uint8_t>();
 	}
 }
 
@@ -53,37 +53,37 @@ void EncodeNoteWithTime(WriteStream& out, const ExpandedNote& in)
 {
 	if(in.time == in.endtime && in.player == 0 && in.type == 0)
 	{
-		out.write<uchar>(in.col);
+		out.write<uint8_t>(in.col);
 		out.write(in.time);
-		out.write<uchar>(in.quant);
+		out.write<uint8_t>(in.quant);
 	}
 	else
 	{
-		out.write<uchar>(in.col | 0x80);
+		out.write<uint8_t>(in.col | 0x80);
 		out.write(in.time);
 		out.write(in.endtime);
-		out.write<uchar>((in.player << 4) | in.type);
-		out.write<uchar>(in.quant);
+		out.write<uint8_t>((in.player << 4) | in.type);
+		out.write<uint8_t>(in.quant);
 	}
 }
 
 void DecodeNoteWithTime(ReadStream& in, ExpandedNote& out)
 {
-	uchar col = in.read<uchar>();
+	uint8_t col = in.read<uint8_t>();
 	if((col & 0x80) == 0)
 	{
 		double time = in.read<double>();
-		out.quant = in.read<uchar>();
+		out.quant = in.read<uint8_t>();
 	}
 	else
 	{
 		out.col = col & 0x7F;
 		in.read(out.time);
 		in.read(out.endtime);
-		uint v = in.read<uchar>();
+		uint32_t v = in.read<uint8_t>();
 		out.player = v >> 4;
 		out.type = v & 0xF;
-		out.quant = in.read<uchar>();
+		out.quant = in.read<uint8_t>();
 	}
 }
 

--- a/src/Simfile/Notes.h
+++ b/src/Simfile/Notes.h
@@ -37,31 +37,31 @@ struct ExpandedNote
 	double endtime;
 
 	/// 1 indicates a mine, 0 indicates a step or hold. 
-	uint isMine : 1;
+	uint32_t isMine : 1;
 
 	/// 1 indicates a roll, 0 indicates a freeze.
-	uint isRoll : 1;
+	uint32_t isRoll : 1;
 
 	/// 1 indicates a warped note, 0 indicates a regular note.
-	uint isWarped : 1;
+	uint32_t isWarped : 1;
 
 	/// 1 indicates selected, 0 indicates not selected.
-	uint isSelected : 1;
+	uint32_t isSelected : 1;
 
 	/// One of the values in NoteType, indicates what kind of note it is.
-	uint type : 4;
+	uint32_t type : 4;
 
 	/// Indicates which player the note belongs to in routine modes.
-	uint player : 24;
+	uint32_t player : 24;
 
 	/// Indicates the quantization of the note, if it is nonstandard
-	uint quant : 8;
+	uint32_t quant : 8;
 };
 
 // Converts and expanded note to a compact note.
 inline Note CompressNote(const ExpandedNote& note)
 {
-	return {note.row, note.endrow, (uint)note.col, (uint)note.player, (uint)note.type, (uint) note.quant};
+	return {note.row, note.endrow, (uint32_t)note.col, (uint32_t)note.player, (uint32_t)note.type, (uint32_t) note.quant};
 }
 
 // Encodes a single note and writes it to a bytestream.

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -393,7 +393,7 @@ static void WriteBgChanges(ExportData& data, const char* tag, const Vector<BgCha
 // ================================================================================================
 // Chart writing functions.
 
-static char GetNoteChar(uint type)
+static char GetNoteChar(uint32_t type)
 {
 	if(type == NOTE_STEP_OR_HOLD)
 	{
@@ -414,7 +414,7 @@ static char GetNoteChar(uint type)
 	return '0';
 }
 
-static char GetHoldChar(uint type)
+static char GetHoldChar(uint32_t type)
 {
 	return (type == NOTE_STEP_OR_HOLD) ? '2' : '4';
 }
@@ -470,12 +470,12 @@ static int gcd(int a, int b)
 	}
 }
 
-static void GetSectionCompression(const char* section, int width, std::list<uint> quantVec, int& count, int& pitch)
+static void GetSectionCompression(const char* section, int width, std::list<uint32_t> quantVec, int& count, int& pitch)
 {
 	// Determines the best compression for the given section.
 	int best = ROWS_PER_NOTE_SECTION;
 	String zeroline(width, '0');
-	std::list<uint>::iterator it;
+	std::list<uint32_t>::iterator it;
 	int lcm = 1;
 	for (it = quantVec.begin(); it != quantVec.end(); it++)
 	{
@@ -565,7 +565,7 @@ static void WriteSections(ExportData& data)
 		Vector<const Note*> holdVec(numCols, nullptr);
 		const Note** holds = holdVec.begin();
 
-		std::list<uint> quantVec;
+		std::list<uint32_t> quantVec;
 
 		const Note* it = chart->notes.begin();
 		const Note* end = chart->notes.end();

--- a/src/Simfile/SegmentGroup.cpp
+++ b/src/Simfile/SegmentGroup.cpp
@@ -110,7 +110,7 @@ void SegmentGroup::encode(WriteStream& out) const
 		{
 			auto meta = Segment::meta[type];
 			out.writeNum(list.size());
-			out.write<uchar>(type);
+			out.write<uint8_t>(type);
 			for(auto it = list.begin(), end = list.end(); it != end; ++it)
 			{
 				meta->encode(out, it.ptr);
@@ -122,10 +122,10 @@ void SegmentGroup::encode(WriteStream& out) const
 
 void SegmentGroup::decode(ReadStream& in)
 {
-	uint num = in.readNum();
+	uint32_t num = in.readNum();
 	while(num > 0)
 	{
-		uchar type = in.read<uchar>();
+		uint8_t type = in.read<uint8_t>();
 		if(type < Segment::NUM_TYPES)
 		{
 			auto meta = Segment::meta[type];
@@ -139,7 +139,7 @@ void SegmentGroup::decode(ReadStream& in)
 	}
 }
 
-static String GetSegmentDescription(uint num, const char* singular, const char* plural)
+static String GetSegmentDescription(uint32_t num, const char* singular, const char* plural)
 {
 	switch(num)
 	{

--- a/src/Simfile/SegmentList.cpp
+++ b/src/Simfile/SegmentList.cpp
@@ -14,17 +14,17 @@ namespace {
 
 inline Segment* ofs(void* pos, int offset)
 {
-	return (Segment*)(((uchar*)pos) + offset);
+	return (Segment*)(((uint8_t*)pos) + offset);
 }
 
 inline const Segment* ofs(const void* pos, int offset)
 {
-	return (const Segment*)(((const uchar*)pos) + offset);
+	return (const Segment*)(((const uint8_t*)pos) + offset);
 }
 
 inline int diff(const Segment* begin, const Segment* end)
 {
-	return ((const uchar*)end) - ((const uchar*)begin);
+	return ((const uint8_t*)end) - ((const uint8_t*)begin);
 }
 
 }; // anonymous namespace.
@@ -109,7 +109,7 @@ void SegmentList::clear()
 		auto meta = Segment::meta[myType];
 		for(int i = 0; i < myNum; ++i)
 		{
-			uchar* seg = mySegs + i * myStride;
+			uint8_t* seg = mySegs + i * myStride;
 			meta->destruct((Segment*)seg);
 		}
 	}
@@ -500,42 +500,42 @@ void SegmentList::prepareEdit(const List& inAdd, const List& inRem,
 
 SegmentIter SegmentList::begin()
 {
-	return {(Segment*)mySegs, (uint)myStride};
+	return {(Segment*)mySegs, (uint32_t)myStride};
 }
 
 SegmentConstIter SegmentList::begin() const
 {
-	return {(const Segment*)mySegs, (uint)myStride};
+	return {(const Segment*)mySegs, (uint32_t)myStride};
 }
 
 SegmentIter SegmentList::end()
 {
-	return {(Segment*)(mySegs + myNum * myStride), (uint)myStride};
+	return {(Segment*)(mySegs + myNum * myStride), (uint32_t)myStride};
 }
 
 SegmentConstIter SegmentList::end() const
 {
-	return {(const Segment*)(mySegs + myNum * myStride), (uint)myStride};
+	return {(const Segment*)(mySegs + myNum * myStride), (uint32_t)myStride};
 }
 
 SegmentIter SegmentList::rbegin()
 {
-	return{(Segment*)(mySegs + (myNum - 1) * myStride), (uint)myStride};
+	return{(Segment*)(mySegs + (myNum - 1) * myStride), (uint32_t)myStride};
 }
 
 SegmentConstIter SegmentList::rbegin() const
 {
-	return{(const Segment*)(mySegs + (myNum - 1) * myStride), (uint)myStride};
+	return{(const Segment*)(mySegs + (myNum - 1) * myStride), (uint32_t)myStride};
 }
 
 SegmentIter SegmentList::rend()
 {
-	return{(Segment*)(mySegs - myStride), (uint)myStride};
+	return{(Segment*)(mySegs - myStride), (uint32_t)myStride};
 }
 
 SegmentConstIter SegmentList::rend() const
 {
-	return{(const Segment*)(mySegs - myStride), (uint)myStride};
+	return{(const Segment*)(mySegs - myStride), (uint32_t)myStride};
 }
 
 // ================================================================================================
@@ -546,7 +546,7 @@ const Segment* SegmentList::find(int row) const
 	if(myNum == 0) return nullptr;
 
 	int step, count = myNum;
-	const uchar* it = mySegs, *mid;
+	const uint8_t* it = mySegs, *mid;
 	while(count > 1)
 	{
 		step = count >> 1;
@@ -575,7 +575,7 @@ void SegmentList::myReserve(int num)
 	if(myCap < numBytes)
 	{
 		myCap = max(numBytes, myCap << 1);
-		mySegs = (uchar*)realloc(mySegs, myCap);
+		mySegs = (uint8_t*)realloc(mySegs, myCap);
 	}
 }
 

--- a/src/Simfile/SegmentList.h
+++ b/src/Simfile/SegmentList.h
@@ -13,11 +13,11 @@ struct SegmentIter
 {
 	inline void operator -- ()
 	{
-		ptr = (Segment*)(((uchar*)ptr) - stride);
+		ptr = (Segment*)(((uint8_t*)ptr) - stride);
 	}
 	inline void operator ++ ()
 	{
-		ptr = (Segment*)(((uchar*)ptr) + stride);
+		ptr = (Segment*)(((uint8_t*)ptr) + stride);
 	}
 	inline bool operator != (const SegmentIter& other)
 	{
@@ -32,18 +32,18 @@ struct SegmentIter
 		return ptr;
 	}
 	Segment* ptr;
-	uint stride;
+	uint32_t stride;
 };
 
 struct SegmentConstIter
 {
 	inline void operator -- ()
 	{
-		ptr = (const Segment*)(((const uchar*)ptr) - stride);
+		ptr = (const Segment*)(((const uint8_t*)ptr) - stride);
 	}
 	inline void operator ++ ()
 	{
-		ptr = (const Segment*)(((const uchar*)ptr) + stride);
+		ptr = (const Segment*)(((const uint8_t*)ptr) + stride);
 	}
 	inline bool operator != (const SegmentConstIter& other)
 	{
@@ -58,7 +58,7 @@ struct SegmentConstIter
 		return ptr;
 	}
 	const Segment* ptr;
-	uint stride;
+	uint32_t stride;
 };
 
 // ================================================================================================
@@ -132,10 +132,10 @@ private:
 	friend class SegmentGroup;
 
 	// Returns a pointer to the begin of the segment data.
-	const uchar* rawBegin() const { return mySegs; }
+	const uint8_t* rawBegin() const { return mySegs; }
 
 	// Returns a pointer to the end of the segment data.
-	const uchar* rawEnd() const { return mySegs + myNum * myStride; }
+	const uint8_t* rawEnd() const { return mySegs + myNum * myStride; }
 
 	// Replaces the contents with a copy of the given list.
 	void assign(const List& other);
@@ -162,7 +162,7 @@ private:
 private:
 	void myReserve(int num);
 
-	uchar* mySegs;
+	uint8_t* mySegs;
 	int myNum, myStride, myCap;
 	Segment::Type myType;
 };

--- a/src/Simfile/Segments.h
+++ b/src/Simfile/Segments.h
@@ -26,7 +26,7 @@ struct SegmentMeta
 	const char* singular;
 	const char* plural;
 	const char* help;
-	color32 color;
+	uint32_t color;
 	DisplaySide side;
 
 	New construct;

--- a/src/Simfile/Testing.cpp
+++ b/src/Simfile/Testing.cpp
@@ -33,7 +33,7 @@ static bool Check(const char* name, int a, int b)
 	return (a == b);
 }
 
-static bool Check(const char* name, uint a, uint b)
+static bool Check(const char* name, uint32_t a, uint32_t b)
 {
 	if(a != b) HudError("%s: %i | %i", name, (int)a, (int)b);
 	return (a == b);

--- a/src/System/Thread.cpp
+++ b/src/System/Thread.cpp
@@ -22,7 +22,7 @@ struct BackgroundThreadData
 {
 	BackgroundThread* owner;
 	HANDLE handle;
-	uchar done;
+	uint8_t done;
 };
 
 struct BackgroundThreadParam

--- a/src/System/Thread.h
+++ b/src/System/Thread.h
@@ -30,7 +30,7 @@ public:
 	virtual void exec() = 0;
 
 protected:
-	uchar terminationFlag_;
+	uint8_t terminationFlag_;
 private:
 	void* data_;  // TODO: replace with a more descriptive variable name.
 };


### PR DESCRIPTION
Removes the following typedefs from Core.h, so that only standard types are used:

typedef uint64_t  ulong
typedef uint32_t   uint
typedef uint16_t ushort
typedef uint8_t  uchar
typedef uint32_t   color32

Also the Windows macro UINT is used in the code base so it just makes things a  bit cleaner to explicitly use uint32_t instead of lowercase uint.

Note I don't find much value in the color32 typedef (I prefer knowing it's a 32 bit unsigned), but if others prefer it being color32, I don't feel super strongly about it.