### PR TITLE
Fix bugs with loading/saving holds, save .sm to 6 decimals, custom snap improvements

### DIFF
--- a/src/Core/Utils.h
+++ b/src/Core/Utils.h
@@ -326,6 +326,25 @@ inline color32 ToColor32(float r, float g, float b, float a)
 	return u32;
 }
 
+static int gcd(int a, int b)
+{
+	if (a == 0)
+	{
+		return b;
+	}
+	if (b == 0)
+	{
+		return a;
+	}
+	if (a > b)
+	{
+		return gcd(a - b, b);
+	}
+	else
+	{
+		return gcd(a, b - a);
+	}
+}
 }; // namespace Vortex
 
 #undef TT

--- a/src/Dialogs/AdjustSync.cpp
+++ b/src/Dialogs/AdjustSync.cpp
@@ -69,12 +69,10 @@ void DialogAdjustSync::myCreateWidgets()
 	WgSpinner* offset = myCreateWidgetRow("Music offset", myOffset, ACT_SET_OFS, ACT_TWEAK_OFS,
 		"Music start time relative to the first beat, in seconds", "Tweak the music offset");
 	offset->setRange(-100.0, 100.0);
-	offset->setPrecision(3, 6);
 	offset->setStep(0.001);
 
 	WgSpinner* bpm = myCreateWidgetRow("Initial BPM", myInitialBPM, ACT_SET_BPM, ACT_TWEAK_BPM,
 		"Music tempo at the first beat, in beats per minute", "Tweak the initial BPM");
-	bpm->setPrecision(3, 6);
 	bpm->setRange(VC_MIN_BPM, VC_MAX_BPM);
 	bpm->setStep(1.0);
 

--- a/src/Dialogs/AdjustSync.cpp
+++ b/src/Dialogs/AdjustSync.cpp
@@ -69,10 +69,12 @@ void DialogAdjustSync::myCreateWidgets()
 	WgSpinner* offset = myCreateWidgetRow("Music offset", myOffset, ACT_SET_OFS, ACT_TWEAK_OFS,
 		"Music start time relative to the first beat, in seconds", "Tweak the music offset");
 	offset->setRange(-100.0, 100.0);
+	offset->setPrecision(3, 6);
 	offset->setStep(0.001);
 
 	WgSpinner* bpm = myCreateWidgetRow("Initial BPM", myInitialBPM, ACT_SET_BPM, ACT_TWEAK_BPM,
 		"Music tempo at the first beat, in beats per minute", "Tweak the initial BPM");
+	bpm->setPrecision(3, 6);
 	bpm->setRange(VC_MIN_BPM, VC_MAX_BPM);
 	bpm->setStep(1.0);
 

--- a/src/Dialogs/AdjustSync.cpp
+++ b/src/Dialogs/AdjustSync.cpp
@@ -50,7 +50,7 @@ WgSpinner* DialogAdjustSync::myCreateWidgetRow(StringRef label, double& val, int
 {
 	WgSpinner* spinner = myLayout.add<WgSpinner>(label);
 	spinner->value.bind(&val);
-	spinner->setPrecision(3, 3);
+	spinner->setPrecision(3, 6);
 	spinner->onChange.bind(this, &DialogAdjustSync::onAction, setAction);
 	spinner->setTooltip(tooltip1);
 

--- a/src/Dialogs/AdjustTempo.cpp
+++ b/src/Dialogs/AdjustTempo.cpp
@@ -91,10 +91,12 @@ void DialogAdjustTempo::myCreateWidgets()
 
 	WgSpinner* bpm = myCreateWidgetRow("BPM", 0, myBPM, ACT_BPM_SET);
 	bpm->setRange(VC_MIN_BPM, VC_MAX_BPM);
+	bpm->setPrecision(3, 6);
 	bpm->setStep(1.0);
 
 	WgSpinner* stop = myCreateWidgetRow("Stop", 28, myStop, ACT_STOP_SET);
 	stop->setRange(VC_MIN_STOP, VC_MAX_STOP);
+	stop->setPrecision(3, 6);
 	stop->setStep(0.001);
 
 	myLayout.row().col(242);

--- a/src/Dialogs/AdjustTempoSM5.cpp
+++ b/src/Dialogs/AdjustTempoSM5.cpp
@@ -61,7 +61,7 @@ void DialogAdjustTempoSM5::myCreateWidgets()
 
 	WgSpinner* spinner = myLayout.add<WgSpinner>("Delay");
 	spinner->value.bind(&myDelay);
-	spinner->setPrecision(3, 3);
+	spinner->setPrecision(3, 6);
 	spinner->setStep(0.001);
 	spinner->setRange(0, 1000);
 	spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction, (int)ACT_DELAY_SET);
@@ -70,7 +70,7 @@ void DialogAdjustTempoSM5::myCreateWidgets()
 	myLayout.row().col(84).col(154);
 	spinner = myLayout.add<WgSpinner>("Warp");
 	spinner->value.bind(&myWarp);
-	spinner->setPrecision(3, 3);
+	spinner->setPrecision(3, 6);
 	spinner->setRange(0, 1000);
 	spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction, (int)ACT_WARP_SET);
 	spinner->setTooltip("Warp length at the current beat, in beats");
@@ -120,7 +120,7 @@ void DialogAdjustTempoSM5::myCreateWidgets()
 
 	spinner = myLayout.add<WgSpinner>("Speed");
 	spinner->value.bind(&mySpeedRatio);
-	spinner->setPrecision(2, 2);
+	spinner->setPrecision(2, 6);
 	spinner->setStep(0.1);
 	spinner->setRange(0, 1000);
 	spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction, (int)ACT_SPEED_SET);
@@ -128,7 +128,7 @@ void DialogAdjustTempoSM5::myCreateWidgets()
 
 	spinner = myLayout.add<WgSpinner>();
 	spinner->value.bind(&mySpeedDelay);
-	spinner->setPrecision(2, 2);
+	spinner->setPrecision(2, 6);
 	spinner->setStep(0.1);
 	spinner->setRange(0, 1000);
 	spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction, (int)ACT_SPEED_SET);
@@ -145,7 +145,7 @@ void DialogAdjustTempoSM5::myCreateWidgets()
 
 	spinner = myLayout.add<WgSpinner>("Scroll");
 	spinner->value.bind(&myScrollRatio);
-	spinner->setPrecision(2, 2);
+	spinner->setPrecision(2, 6);
 	spinner->setStep(0.1);
 	spinner->setRange(0, 1000);
 	spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction, (int)ACT_SCROLL_SET);
@@ -153,7 +153,7 @@ void DialogAdjustTempoSM5::myCreateWidgets()
 
 	spinner = myLayout.add<WgSpinner>("Fakes");
 	spinner->value.bind(&myFakeBeats);
-	spinner->setPrecision(3, 3);
+	spinner->setPrecision(3, 6);
 	spinner->setRange(0, 1000);
 	spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction, (int)ACT_FAKE_SET);
 	spinner->setTooltip("Fake region, in beats");

--- a/src/Dialogs/CustomSnap.cpp
+++ b/src/Dialogs/CustomSnap.cpp
@@ -26,17 +26,16 @@ namespace Vortex {
 		WgSpinner* scol = myLayout.add<WgSpinner>("Snapping");
 		scol->value.bind(&myCustomSnap);
 		scol->onChange.bind(this, &DialogCustomSnap::onChange);
-		scol->setRange(1.0, 192.0);
+		scol->setRange(4.0, 192.0);
 		scol->setPrecision(0, 0);
 		scol->startCapturingText();
 	}
 
 	void DialogCustomSnap::onChange()
 	{
-		if (myCustomSnap > 0 && myCustomSnap <= 192)
+		if (myCustomSnap >= 4 && myCustomSnap <= 192)
 		{
 			gView->setCustomSnap(myCustomSnap);
-			//requestClose();
 		}
 	}
 }; // namespace Vortex

--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -327,6 +327,26 @@ void onChanges(int changes)
 // ================================================================================================
 // EditingImpl :: member functions.
 
+static int gcd(int a, int b)
+{
+	if (a == 0)
+	{
+		return b;
+	}
+	if (b == 0)
+	{
+		return a;
+	}
+	if (a > b)
+	{
+		return gcd(a - b, b);
+	}
+	else
+	{
+		return gcd(a, b - a);
+	}
+}
+
 void finishNotePlacement(int col)
 {
 	auto& pnote = myPlacingNotes[col];
@@ -348,6 +368,14 @@ void finishNotePlacement(int col)
 			}
 		}
 
+		if (note.quant > 0 && note.quant <= 192)
+		{
+			note.quant = min(192u, note.quant * gView->getSnapQuant() / gcd(note.quant, gView->getSnapQuant()));
+		}
+		else
+		{
+			note.quant = 192;
+		}
 		NoteEdit edit;
 		edit.add.append(note);
 		gNotes->modify(edit, false);

--- a/src/Editor/View.cpp
+++ b/src/Editor/View.cpp
@@ -71,7 +71,7 @@ ViewImpl()
 	, myZoomLevel(8)
 	, myScaleLevel(4)
 	, mySnapType(ST_NONE)
-	, myCustomSnap(1)
+	, myCustomSnap(20)
 	, myUseTimeBasedView(true)
 	, myUseReverseScroll(false)
 	, myUseChartPreview(false)
@@ -100,7 +100,7 @@ void loadSettings(XmrNode& settings)
 		view->get("receptorX", &myReceptorX);
 		view->get("receptorY", &myReceptorY);
 
-		myCustomSnap = min(max(myCustomSnap, 1), 192);
+		myCustomSnap = min(max(myCustomSnap, 5), 191);
 		myZoomLevel = min(max(myZoomLevel, -2.0), 16.0);
 		myScaleLevel = min(max(myScaleLevel, 1.0), 10.0);
 	}
@@ -441,7 +441,7 @@ void setSnapType(int type)
 
 void setCustomSnap(int size)
 {
-	if (size < 1) size = 1;
+	if (size < 4) size = 4;
 	if (size > 192) size = 192;
 	// If the custom snap is a non-custom value, set the snap to that value instead
 	for (int i = 0; i < ST_CUSTOM; i++)

--- a/src/Managers/TempoMan.cpp
+++ b/src/Managers/TempoMan.cpp
@@ -470,7 +470,7 @@ static bool Differs(const BpmRange& a, const BpmRange& b)
 
 static double ClampAndRound(double val, double min, double max)
 {
-	return round(clamp(val, min, max) * 1000.0) / 1000.0;
+	return round(clamp(val, min, max) * 1000000.0) / 1000000.0;
 }
 
 void modify(const SegmentEdit& edit)

--- a/src/Simfile/LoadSm.cpp
+++ b/src/Simfile/LoadSm.cpp
@@ -5,6 +5,7 @@
 #include <numeric>
 
 #include <Core/StringUtils.h>
+#include <Core/Utils.h>
 
 #include <System/Debug.h>
 #include <System/File.h>
@@ -376,26 +377,6 @@ struct ReadNoteData
 	Vector<int> quants;
 };
 
-static int gcd(int a, int b)
-{
-	if (a == 0)
-	{
-		return b;
-	}
-	if (b == 0)
-	{
-		return a;
-	}
-	if (a > b)
-	{
-		return gcd(a - b, b);
-	}
-	else
-	{
-		return gcd(a, b - a);
-	}
-}
-
 static void ReadNoteRow(ReadNoteData& data, int row, char* p, int quantization)
 {
 	for(int col = 0; col < data.numCols; ++col, ++p)
@@ -426,7 +407,7 @@ static void ReadNoteRow(ReadNoteData& data, int row, char* p, int quantization)
 				// Make sure we set the note to its largest quantization to avoid data loss
 				if (data.quants[col] > 0 && hold->quant > 0)
 				{
-					hold->quant = quantization * hold->quant / gcd(quantization, hold->quant);
+					hold->quant = min(192u, quantization * hold->quant / gcd(quantization, hold->quant));
 				}
 				else // There was some error, so always play safe and use 192
 				{

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -508,7 +508,8 @@ static bool GetSectionCompression(const char* section, int width, std::list<uint
 		for (int i = 4; i <= lcm / 2; i++)
 		{
 			// Skip anything that isn't a lcm factor
-			if (lcm % i > 0) continue;
+			// Skipping 6 is a special case, since it's a factor of 192 but not a standard snap
+			if (lcm % i > 0 || i == 6) continue;
 
 			// The first (smallest) match is always the best
 			if (TestSectionCompression(section, width, i))

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -508,8 +508,7 @@ static bool GetSectionCompression(const char* section, int width, std::list<uint
 		for (int i = 4; i <= lcm / 2; i++)
 		{
 			// Skip anything that isn't a lcm factor
-			// Skipping 6 is a special case, since it's a factor of 192 but not a standard snap
-			if (lcm % i > 0 || i == 6) continue;
+			if (lcm % i > 0) continue;
 
 			// The first (smallest) match is always the best
 			if (TestSectionCompression(section, width, i))
@@ -538,6 +537,11 @@ static bool GetSectionCompression(const char* section, int width, std::list<uint
 	if (ROWS_PER_NOTE_SECTION % count != 0)
 	{
 		count = ROWS_PER_NOTE_SECTION;
+	}
+	// Yes it is weird... but we don't save 6ths even though they factor into 192 evenly.
+	if (count == 6)
+	{
+		count = 12;
 	}
 	pitch = (ROWS_PER_NOTE_SECTION * width) / count;
 	return error;

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -473,7 +473,7 @@ static void GetSectionCompression(const char* section, int width, int& count, in
 	count = ROWS_PER_NOTE_SECTION;
 	// Determines the best compression for the given section.
 	// We actually don't care about custom snaps for this at all, since we want to save 192nds for non-standard-compressible snaps.
-	for (int i = 1; i < NUM_MEASURE_SUBDIV - 1; i++)
+	for (int i = 0; i < NUM_MEASURE_SUBDIV - 1; i++)
 	{
 		if (TestSectionCompression(section, width, MEASURE_SUBDIV[i]))
 		{

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -81,7 +81,7 @@ static void WriteTag(ExportData& data, const char* tag, double value, ForceWrite
 {
 	if(ShouldWrite(data, when, value != 0, sscOnly))
 	{
-		data.file.printf("#%s:%.3f;\n", tag, value);
+		data.file.printf("#%s:%.6f;\n", tag, value);
 	}
 }
 
@@ -182,7 +182,7 @@ static void WriteBpms(ExportData& data, const Tempo* tempo)
 	WriteSegments<BpmChange>(data, "BPMS", tempo, START_OF_LINE, ',', SONG_ONLY, false,
 	[&](const BpmChange& change)
 	{
-		data.file.printf("%.3f=%.6f",
+		data.file.printf("%.6f=%.6f",
 			ToBeat(change.row), change.bpm);
 	});
 }
@@ -192,7 +192,7 @@ static void WriteStops(ExportData& data, const Tempo* tempo)
 	WriteSegments<Stop>(data, "STOPS", tempo, START_OF_LINE, ',', SONG_ONLY, false,
 	[&](const Stop& stop)
 	{
-		data.file.printf("%.3f=%.3f",
+		data.file.printf("%.6f=%.6f",
 			ToBeat(stop.row), stop.seconds);
 	});
 }
@@ -202,7 +202,7 @@ static void WriteDelays(ExportData& data, const Tempo* tempo)
 	WriteSegments<Delay>(data, "DELAYS", tempo, END_OF_LINE, ',', NEVER, true,
 	[&](const Delay& delay)
 	{
-		data.file.printf("%.3f=%.3f",
+		data.file.printf("%.6f=%.6f",
 			ToBeat(delay.row), delay.seconds);
 	});
 }
@@ -212,7 +212,7 @@ static void WriteWarps(ExportData& data, const Tempo* tempo)
 	WriteSegments<Warp>(data, "WARPS", tempo, END_OF_LINE, ',', NEVER, true,
 	[&](const Warp& warp)
 	{
-		data.file.printf("%.3f=%.3f",
+		data.file.printf("%.6f=%.6f",
 			ToBeat(warp.row), ToBeat(warp.numRows));
 	});
 }
@@ -222,7 +222,7 @@ static void WriteSpeeds(ExportData& data, const Tempo* tempo)
 	WriteSegments<Speed>(data, "SPEEDS", tempo, END_OF_LINE, ',', NEVER, true,
 	[&](const Speed& speed)
 	{
-		data.file.printf("%.3f=%.3f=%.3f=%i",
+		data.file.printf("%.6f=%.6f=%.6f=%i",
 			ToBeat(speed.row), speed.ratio, speed.delay, speed.unit);
 	});
 }
@@ -232,7 +232,7 @@ static void WriteScrolls(ExportData& data, const Tempo* tempo)
 	WriteSegments<Scroll>(data, "SCROLLS", tempo, END_OF_LINE, ',', NEVER, true,
 	[&](const Scroll& scroll)
 	{
-		data.file.printf("%.3f=%.3f",
+		data.file.printf("%.6f=%.6f",
 			ToBeat(scroll.row), scroll.ratio);
 	});
 }
@@ -242,7 +242,7 @@ static void WriteTickCounts(ExportData& data, const Tempo* tempo)
 	WriteSegments<TickCount>(data, "TICKCOUNTS", tempo, END_OF_LINE, ',', NEVER, true,
 	[&](const TickCount& tick)
 	{
-		data.file.printf("%.3f=%i",
+		data.file.printf("%.6f=%i",
 			ToBeat(tick.row), tick.ticks);
 	});
 }
@@ -252,7 +252,7 @@ static void WriteTimeSignatures(ExportData& data, const Tempo* tempo)
 	WriteSegments<TimeSignature>(data, "TIMESIGNATURES", tempo, END_OF_LINE, ',', NEVER, true,
 	[&](const TimeSignature& sig)
 	{
-		data.file.printf("%.3f=%i=%i",
+		data.file.printf("%.6f=%i=%i",
 			ToBeat(sig.row), (int)ToBeat(sig.rowsPerMeasure), sig.beatNote);
 	});
 }
@@ -262,7 +262,7 @@ static void WriteLabels(ExportData& data, const Tempo* tempo)
 	WriteSegments<Label>(data, "LABELS", tempo, END_OF_LINE, ',', NEVER, true,
 	[&](const Label& label)
 	{
-		data.file.printf("%.3f=%s",
+		data.file.printf("%.6f=%s",
 			ToBeat(label.row), label.str.str());
 	});
 }
@@ -272,8 +272,8 @@ static void WriteAttacks(ExportData& data, const Tempo* tempo)
 	WriteTag(data, "ATTACKS", tempo->attacks, START_OF_LINE, ':', NEVER, true,
 	[&](const Attack& attack)
 	{
-		data.file.printf("TIME=%.3f:", attack.time);
-		data.file.printf((attack.unit == ATTACK_END) ? "END=%.3f:" : "LEN=%.3f:", attack.duration);
+		data.file.printf("TIME=%.6f:", attack.time);
+		data.file.printf((attack.unit == ATTACK_END) ? "END=%.6f:" : "LEN=%.6f:", attack.duration);
 		data.file.printf("MODS=%s", attack.mods.str());
 	});
 }
@@ -292,7 +292,7 @@ static void WriteCombos(ExportData& data, const Tempo* tempo)
 	WriteSegments<Combo>(data, "COMBOS", tempo, END_OF_LINE, ',', NEVER, true,
 	[&](const Combo& combo)
 	{
-		data.file.printf("%.3f=%i", ToBeat(combo.row), combo.hitCombo);
+		data.file.printf("%.6f=%i", ToBeat(combo.row), combo.hitCombo);
 		if(combo.hitCombo != combo.missCombo)
 		{
 			data.file.printf("=%i", combo.missCombo);
@@ -305,7 +305,7 @@ static void WriteFakes(ExportData& data, const Tempo* tempo)
 	WriteSegments<Fake>(data, "FAKES", tempo, END_OF_LINE, ',', NEVER, true,
 	[&](const Fake& fake)
 	{
-		data.file.printf("%.3f=%.3f",
+		data.file.printf("%.6f=%.6f",
 			ToBeat(fake.row), ToBeat(fake.numRows));
 	});
 }
@@ -368,14 +368,14 @@ static void WriteBgChanges(ExportData& data, const char* tag, const Vector<BgCha
 	{
 		if(bg.effect.empty() && bg.file2.empty() && bg.transition.empty() && bg.color.empty() && bg.color2.empty())
 		{
-			data.file.printf("%.3f=%s=%.3f=0=0=1",
+			data.file.printf("%.6f=%s=%.6f=0=0=1",
 				bg.startBeat,
 				bg.file.str(),
 				bg.rate);
 		}
 		else
 		{
-			data.file.printf("%.3f=%s=%.3f=%d=%d=%d=%s=%s=%s=%s=%s",
+			data.file.printf("%.6f=%s=%.6f=%d=%d=%d=%s=%s=%s=%s=%s",
 				bg.startBeat,
 				bg.file.str(),
 				bg.rate,

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -480,10 +480,12 @@ static bool GetSectionCompression(const char* section, int width, std::list<uint
 	int lcm = 1;
 	for (it = quantVec.begin(); it != quantVec.end(); it++)
 	{
-		if (*it <= 0)
+		if (*it <= 0 || *it > 192)
 		{
+			// If there's a quantization error assume nothing
 			error = true;
-			continue;
+			lcm = ROWS_PER_NOTE_SECTION;
+			break;
 		}
 		lcm = lcm * *it / gcd(lcm, *it);
 		if (lcm > ROWS_PER_NOTE_SECTION)

--- a/src/Simfile/Segments.cpp
+++ b/src/Simfile/Segments.cpp
@@ -191,7 +191,7 @@ static void Decode(ReadStream& in, Stop& seg)
 template <>
 static bool IsRedundant(const Stop& seg, const Stop* prev)
 {
-	return (fabs(seg.seconds) < 0.0005) || (prev && prev->row == seg.row);
+	return (fabs(seg.seconds) < 0.0000005) || (prev && prev->row == seg.row);
 }
 
 template <>


### PR DESCRIPTION
* Loading .sm/.ssc now correctly pulls quantizations for holds that go across measure boundaries.
* Swapping quantizations while stepping holds set the note quantization to the LCM.
* Saving .sm/.ssc now does not use quantization at all and instead just tries the old section compression.
* .sm/.ssc double fields are now saved to six decimal places.
* Custom snaps can only be set between 4 and 192. The default with no settings.txt is 20.