### PR TITLE
Fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,8 @@
 name: Windows Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow, the `contents: read` permission is sufficient for most actions, and no write permissions are required. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by [Copilot Autofix](https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/responsible-use-autofix-code-scanning#about-copilot-autofix-for-code-scanning). Review carefully before merging._
