### PR TITLE
Refactor pathing in workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,40 +10,31 @@ jobs:
   windows:
     name: "Build Windows x64"
     runs-on: windows-2022
-    defaults:
-      run:
-        working-directory: ${{github.workspace}}/main
     permissions:
       contents: read
     steps:
       - name: Get AV
         uses: actions/checkout@v3
-        with:
-          path: main
       - name: Get MSBuild
         uses: microsoft/setup-msbuild@v2
       - name: Obtain oggenc2.exe
         run: >
           curl https://www.rarewares.org/files/ogg/oggenc2.88-1.3.7-x64.zip --output oggenc.zip &&
           unzip oggenc.zip -d .
+        shell: bash
       - name: Build AV
         run: msbuild build\VisualStudio\ArrowVortex.vcxproj /p:Configuration=Release /p:Platform=x64         
       - name: Collect into a directory
         if: github.ref_name == 'beta'
         run: |
           mkdir AV
-          cd AV
-          cp -r ../bin/assets .
-          cp -r ../bin/noteskins .
-          cp -r ../bin/settings .
-          cp ../bin/ArrowVortex.exe .
-          cp ../oggenc2.exe .
-          cd ..
-          7z.exe a -tzip av.zip AV
+          cp -r bin/{assets,noteskins,settings} AV
+          cp bin/ArrowVortex.exe oggenc2.exe AV
+        shell: bash
       - name: Upload artifact
         if: github.ref_name == 'beta'
         uses: actions/upload-artifact@v4
         with:
           name: AV
-          path: main/AV/
+          path: AV/
           if-no-files-found: error


### PR DESCRIPTION
The workflow currently works in and creates additional directories, this proposes refactoring with default paths to clean things up a bit. Also refactors the 'Collect into a directory' step a bit, notably removing usage of `7z` as actions/upload-artifact compresses the path by default https://github.com/actions/upload-artifact?tab=readme-ov-file#altering-compressions-level-speed-v-size

Example run in my fork - https://github.com/ScottBrenner/ArrowVortex/actions/runs/16231746598