### PR TITLE
Upload bin/ directory as artifact

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,21 +20,14 @@ jobs:
       - name: Obtain oggenc2.exe
         run: >
           curl https://www.rarewares.org/files/ogg/oggenc2.88-1.3.7-x64.zip --output oggenc.zip &&
-          unzip oggenc.zip -d .
+          unzip oggenc.zip -d bin/
         shell: bash
       - name: Build AV
         run: msbuild build\VisualStudio\ArrowVortex.vcxproj /p:Configuration=Release /p:Platform=x64         
-      - name: Collect into a directory
-        if: github.ref_name == 'beta'
-        run: |
-          mkdir AV
-          cp -r bin/{assets,noteskins,settings} AV
-          cp bin/ArrowVortex.exe oggenc2.exe AV
-        shell: bash
       - name: Upload artifact
         if: github.ref_name == 'beta'
         uses: actions/upload-artifact@v4
         with:
           name: AV
-          path: AV/
+          path: bin/
           if-no-files-found: error

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,5 +29,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: AV
-          path: bin/
+          path: |
+            bin/assets
+            bin/noteskins
+            bin/settings
+            bin/ArrowVortex.exe
+            bin/oggenc2.exe
           if-no-files-found: error


### PR DESCRIPTION
If  `oggenc` is unzipped into the `bin/` directory the path can be directly referenced with https://github.com/actions/upload-artifact?tab=readme-ov-file#upload-an-entire-directory rather than copying things around

Example on my fork - https://github.com/ScottBrenner/ArrowVortex/actions/runs/16242320240