### PR TITLE
Minor updates that makes L4M32 more friendly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,19 @@
 cmake_minimum_required(VERSION 3.30)
 
+# If you're on Linux, you're probably not going to be building
+# with normal tools anytime soon. We'll just assume you have
+# W64-MinGW32.
 if (LINUX)
 	set(CMAKE_SYSTEM_NAME Windows)
 
 	set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
 	set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
 
-	set(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
+	if (NOT DEFINED CMAKE_FIND_ROOT_PATH)
+		set(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
+	endif()
+
+	set(MINGW_BASED true)
 
 	option(VCPKG "Use vcpkg for dependencies" ON)
 endif()

--- a/README.md
+++ b/README.md
@@ -69,23 +69,34 @@ Some new features were introduced as well when preparing this release, and some 
 
 ## Building ArrowVortex
 
-### Windows
+### Windows:
 
 In order to compile ArrowVortex on your own PC, Visual Studio is required. It is recommended to use Visual Studio 2022 with the "Desktop development for C++" components installed.
 
 Simply open `build/VisualStudio/ArrowVortex.sln` in Visual Studio, and build the project.
 
-### Linux
+### Linux:
 
-Compiling for Linux requires that you have `vcpkg`, `powershell`, and `cmake`.
+Compiling for Linux requires that you have `vcpkg`, `powershell`, `cmake`, and most importantly `w64-mingw32`.
 
-Once you have those set up, run `export VCPKG_ROOT={where your vcpkg contents is}`.
+You may find `w64-mingw32` for your Linux distribution at:
+* AUR, as `mingw-w64-tools`
+* Debian/Ubuntu, as `g++-mingw-w64-x86-64` and `gcc-mingw-w64-x86-64`
+* Fedora, as `mingw64-gcc-c++`
 
-This command is needed as to find and define vcpkg's root and use it when building with cmake.
+You may find installation info of `vcpkg` at [vcpkg's getting-started documentation](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-bash).
+
+You may find binaries of `powershell` at [PowerShell's repository](https://github.com/PowerShell/PowerShell) or the AUR.
+
+You will likely already have `cmake`, but if needed, you will find it in your package manager.
+
+Once you have those set up, run `export VCPKG_ROOT=[where your vcpkg directory is]`.
+
+This command is needed to define vcpkg's root directory and use it when building with cmake.
 
 Now you may run this: `cmake -B build -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake`
 
-This command specifies that you are using a MinGW environment that is statically linked and targets 64-bit, and for cmake to account for vcpkg.
+This command specifies that you are using a MinGW environment that is statically linked and targets 64-bit, and for CMake to use vcpkg's buildsystem.
 
 This command also requires powershell as it is used for vcpkg's copy tools, and will fail to compile if it isn't installed.
 

--- a/src/System/CMakeLists.txt
+++ b/src/System/CMakeLists.txt
@@ -10,5 +10,24 @@ add_custom_command(
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 		${PROJECT_SOURCE_DIR}/bin
 		$<TARGET_FILE_DIR:ArrowVortex>)
-target_link_libraries(ArrowVortex PRIVATE System ${CMAKE_FIND_ROOT_PATH}/lib/libgcc_s.a ${CMAKE_FIND_ROOT_PATH}/lib/libwinpthread.a ${CMAKE_FIND_ROOT_PATH}/lib/libstdc++.a)
-file(COPY ${CMAKE_FIND_ROOT_PATH}/bin/libgcc_s_seh-1.dll ${CMAKE_FIND_ROOT_PATH}/bin/libwinpthread-1.dll DESTINATION .)
+
+if (MINGW_BASED)
+	# This imports important static libraries needed by MinGW builders.
+	list(
+		APPEND MINGW_ESSENTIAL_LIBS
+		${CMAKE_FIND_ROOT_PATH}/lib/libgcc_s.a
+		${CMAKE_FIND_ROOT_PATH}/lib/libwinpthread.a
+		${CMAKE_FIND_ROOT_PATH}/lib/libstdc++.a
+	)
+
+	# This copies the two most important DLLs ever to run ArrowVortex.
+	# If you do not copy/have these, ArrowVortex will not run (on wine).
+	file(
+		COPY
+		${CMAKE_FIND_ROOT_PATH}/bin/libgcc_s_seh-1.dll
+		${CMAKE_FIND_ROOT_PATH}/bin/libwinpthread-1.dll
+		DESTINATION .
+	)
+endif()
+
+target_link_libraries(ArrowVortex PRIVATE System ${MINGW_ESSENTIAL_LIBS})


### PR DESCRIPTION
Cleaned up `README.MD`, and adjusted `./CMakeLists.txt` and `src/System/CMakeLists.txt` to only do MinGW specific stuff on Linux. This fixes any build issue on our workflow related to copying specific DLLs required too.