### PR TITLE
Fix Segment Region Box on upscroll

### DIFF
--- a/src/Editor/Notefield.cpp
+++ b/src/Editor/Notefield.cpp
@@ -435,9 +435,9 @@ void drawBeatLines()
 // ================================================================================================
 // NotefieldImpl :: segments.
 
-bool validSegmentRegion(int& t, int& b, int& viewTop, int viewBtm)
+bool validSegmentRegion(int& t, int& b, int viewTop, int viewBtm)
 {
-	bool draw = (t > viewTop && t < viewBtm) || (b > viewTop && b < viewBtm) || (t > viewTop && b < viewBtm);
+	bool draw = (t > viewTop && t < viewBtm) || (b > viewTop && b < viewBtm) || (t > viewTop && b < viewBtm) || (b > viewTop && t < viewBtm);
 	if(draw)
 	{
 		t = clamp(t, viewTop, viewBtm);


### PR DESCRIPTION
Wouldn't be shown when both ends were off screen, unlike reverse scroll.