### PR TITLE
Correctly detect stream errors in XMR load and save

### DIFF
--- a/src/Core/Xmr.cpp
+++ b/src/Core/Xmr.cpp
@@ -920,7 +920,7 @@ XmrResult XmrDoc::loadFile(const char* path)
 
 	// Open the XMR file.
 	std::ifstream file(Widen(path).str());
-	if(file.bad())
+	if(file.fail())
 	{
 		xstring err(16);
 		err.append("could not open file");
@@ -962,7 +962,7 @@ XmrResult XmrDoc::saveFile(const char* path, XmrSaveSettings settings)
 
 	// Open the output file.
 	std::ofstream file(path);
-	if(file.bad())
+	if(file.fail())
 	{
 		xstring err(16);
 		err.append("could not open file");


### PR DESCRIPTION
`fail` checks failbit and badbit.
`bad` only checks badbit.

Path-constructed fstream sets the failbit when the file can't be loaded.

Closes #144