### PR TITLE
Don't call glGetError() every frame in Release

### DIFF
--- a/src/System/System.cpp
+++ b/src/System/System.cpp
@@ -454,9 +454,9 @@ void CALLBACK messageLoop()
 
 #ifdef DEBUG
 		auto inputTime = Debug::getElapsedTime();
-#endif
 
 		VortexCheckGlError();
+#endif
 
 		gEditor->tick();
 


### PR DESCRIPTION
This is a debug function. If you check the current application in a profiler, this function comes up as being the hottest. Removing its use from a release build seems to lower cpu usage, so why not?

It is only disabled in the main loop here with a define, but is left intact at its root because its use in other less frequent locations can still be useful for user error logging.

Since it is behind a define, care will need to be taken relative to the cmake branch which is messing around with debug define names, etc