### PR TITLE
Remove msbuild action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,9 +46,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Setup msbuild (example)
-      uses: microsoft/setup-msbuild@v2
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Get AV
         uses: actions/checkout@v4
-      - name: Get MSBuild
-        uses: microsoft/setup-msbuild@v2
       - name: Obtain oggenc2.exe
         run: >
           curl https://www.rarewares.org/files/ogg/oggenc2.88-1.3.7-x64.zip --output oggenc.zip &&


### PR DESCRIPTION
msbuild usage was removed in https://github.com/uvcat7/ArrowVortex/commit/b349027242629ecf3504cbcf1ee27a3bbae122fe#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL26, removing setup action too