### PR TITLE
Sort charts on difficulty change + Open New Chart

### DIFF
--- a/src/Managers/ChartMan.cpp
+++ b/src/Managers/ChartMan.cpp
@@ -135,6 +135,7 @@ struct ChartManImpl : public ChartMan {
 
             gSimfile->openChart(bound.chart);
             bound.chart->difficulty = newDiff;
+            gSimfile->sortCharts();
             gEditor->reportChanges(VCM_CHART_PROPERTIES_CHANGED);
         }
         return msg;

--- a/src/Managers/SimfileMan.cpp
+++ b/src/Managers/SimfileMan.cpp
@@ -432,6 +432,7 @@ struct SimfileManImpl : public SimfileMan {
     // SimfileManImpl :: low level chart functions.
 
     std::string applyAdd(Chart* chart) {
+        myChartIndex = -1;
         mySimfile->charts.push_back(chart);
         sortCharts();
         openChart(chart);

--- a/src/Managers/SimfileMan.h
+++ b/src/Managers/SimfileMan.h
@@ -35,6 +35,9 @@ struct SimfileMan {
     /// Removes a chart from the chart list, and closes it if necessary.
     virtual void removeChart(const Chart* chart) = 0;
 
+    /// Sort chart order based on properties.
+    virtual void sortCharts() = 0;
+
     /// Opens one of the charts in the simfile for editing.
     virtual void openChart(int index) = 0;
 


### PR DESCRIPTION
- Trigger a chart re-sort on chart difficulty change.
- Reset Chart Index on New Chart to allow switching for new charts.

When a new chart is added, all the charts are sorted and indexes change, but `openChart` will only switch if the index has changed since the same one, which won't happen if the new chart is sorted before the current chart.

Fixes #169, #134.