### PR TITLE
Patch clang-tidy setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.30)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-extra-arg=/EHsc;-p=build")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -8,7 +9,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 project(ArrowVortex)
 
 set(CMAKE_CONFIGURATION_TYPES Debug Release)
-set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 
 include_directories("${PROJECT_SOURCE_DIR}/src")
 

--- a/src/Core/Canvas.cpp
+++ b/src/Core/Canvas.cpp
@@ -140,7 +140,7 @@ struct GetPolyDist : public DistanceFunc {
 // Canvas parameters.
 
 struct Canvas::Data {
-    Canvas::Data();
+    Data();
     void draw(float* buf, int w, int h, const areaf& area, DistanceFunc* func);
 
     areai mask;

--- a/src/Dialogs/AdjustTempo.cpp
+++ b/src/Dialogs/AdjustTempo.cpp
@@ -5,7 +5,6 @@
 
 #include <Managers/TempoMan.h>
 #include <Managers/SimfileMan.h>
-#include <Simfile/SegmentGroup.h>
 
 #include <Editor/Selection.h>
 #include <Editor/View.h>

--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -334,7 +334,8 @@ struct EditingImpl : public Editing {
 
             if (note.quant > 0 && note.quant <= 192) {
                 note.quant =
-                    min(192u, static_cast<uint32_t>(note.quant * gView->getSnapQuant() /
+                    min(192u, static_cast<uint32_t>(
+                                  note.quant * gView->getSnapQuant() /
                                   gcd(note.quant, gView->getSnapQuant())));
             } else {
                 note.quant = 192;

--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -334,8 +334,8 @@ struct EditingImpl : public Editing {
 
             if (note.quant > 0 && note.quant <= 192) {
                 note.quant =
-                    min(192u, note.quant * gView->getSnapQuant() /
-                                  gcd(note.quant, gView->getSnapQuant()));
+                    min(192u, static_cast<uint32_t>(note.quant * gView->getSnapQuant() /
+                                  gcd(note.quant, gView->getSnapQuant())));
             } else {
                 note.quant = 192;
             }
@@ -937,7 +937,7 @@ struct EditingImpl : public Editing {
              it != end; ++it) {
             std::string beat = Str::val(it->row * BEATS_PER_ROW, 0, 3);
             const char* fmt = (it == last) ? "{%s,%i}};\n" : "{%s,%i},";
-            Debug::log(fmt, beat, it->col);
+            Debug::log(fmt, beat.c_str(), it->col);
         }
         Debug::logBlankLine();
         HudNote("Note table written to log.");
@@ -969,7 +969,7 @@ struct EditingImpl : public Editing {
             std::string text = gSystem->getClipboardText();
             double target = Str::readTime(text);
             if (target > 0) {
-                HudNote("Jump to %s.", Str::formatTime(target));
+                HudNote("Jump to %s.", Str::formatTime(target).c_str());
                 gView->setCursorTime(target);
             }
         }

--- a/src/Editor/Selection.cpp
+++ b/src/Editor/Selection.cpp
@@ -366,7 +366,7 @@ struct SelectionImpl : public Selection {
 
             Str::fmt fmt("Selected measure %1 to %2 (%3 measures)");
             fmt.arg(m1, 0, 2).arg(m2, 0, 2).arg(m2 - m1, 0, 2);
-            HudNote("%s", fmt);
+            HudNote("%s", static_cast<const char*>(fmt));
 
             setType(REGION);
         } else {

--- a/src/Editor/Shortcuts.cpp
+++ b/src/Editor/Shortcuts.cpp
@@ -431,8 +431,7 @@ struct ShortcutsImpl : public Shortcuts {
     // ================================================================================================
     // ShortcutsImpl :: API functions.
 
-    std::string getNotation(Action::Type action,
-                                       bool fullList = false) {
+    std::string getNotation(Action::Type action, bool fullList = false) {
         std::string out;
         for (auto& shortcut : shortcutMappings_) {
             if (shortcut.action->code == action) {

--- a/src/Editor/Shortcuts.cpp
+++ b/src/Editor/Shortcuts.cpp
@@ -431,7 +431,7 @@ struct ShortcutsImpl : public Shortcuts {
     // ================================================================================================
     // ShortcutsImpl :: API functions.
 
-    std::string Shortcuts::getNotation(Action::Type action,
+    std::string getNotation(Action::Type action,
                                        bool fullList = false) {
         std::string out;
         for (auto& shortcut : shortcutMappings_) {
@@ -466,7 +466,7 @@ struct ShortcutsImpl : public Shortcuts {
         return out;
     }
 
-    Action::Type Shortcuts::getAction(int keyflags, Code key) {
+    Action::Type getAction(int keyflags, Code key) {
         for (auto& shortcut : shortcutMappings_) {
             if (shortcut.key && shortcut.key->code == key) {
                 if (shortcut.keyflags == keyflags) {

--- a/src/Editor/View.cpp
+++ b/src/Editor/View.cpp
@@ -387,7 +387,7 @@ struct ViewImpl : public View, public InputHandler {
         if (myCustomSnap != size) {
             myCustomSnap = size;
             updateCustomSnapSteps();
-            HudNote("Custom Snap: %s", OrdinalSuffix(myCustomSnap));
+            HudNote("Custom Snap: %s", OrdinalSuffix(myCustomSnap).c_str());
             setSnapType(ST_CUSTOM);
         }
     }

--- a/src/Managers/TempoMan.h
+++ b/src/Managers/TempoMan.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Simfile/Tempo.h>
+#include <Simfile/SegmentGroup.h>
 
 namespace Vortex {
 

--- a/src/Simfile/LoadSm.cpp
+++ b/src/Simfile/LoadSm.cpp
@@ -318,8 +318,8 @@ static void ReadNoteRow(ReadNoteData& data, int row, char* p,
                 // Make sure we set the note to its largest quantization to
                 // avoid data loss
                 if (data.quants[col] > 0 && hold->quant > 0) {
-                    hold->quant = min(192u, quantization * hold->quant /
-                                                gcd(quantization, hold->quant));
+                    hold->quant = min(192u, static_cast<uint32_t>(quantization * hold->quant /
+                                                gcd(quantization, hold->quant)));
                 } else  // There was some error, so always play safe and use 192
                 {
                     HudError("Bug: couldn't get hold quantization in row %d",

--- a/src/Simfile/LoadSm.cpp
+++ b/src/Simfile/LoadSm.cpp
@@ -318,8 +318,10 @@ static void ReadNoteRow(ReadNoteData& data, int row, char* p,
                 // Make sure we set the note to its largest quantization to
                 // avoid data loss
                 if (data.quants[col] > 0 && hold->quant > 0) {
-                    hold->quant = min(192u, static_cast<uint32_t>(quantization * hold->quant /
-                                                gcd(quantization, hold->quant)));
+                    hold->quant = min(
+                        192u,
+                        static_cast<uint32_t>(quantization * hold->quant /
+                                              gcd(quantization, hold->quant)));
                 } else  // There was some error, so always play safe and use 192
                 {
                     HudError("Bug: couldn't get hold quantization in row %d",

--- a/src/Simfile/Parsing.cpp
+++ b/src/Simfile/Parsing.cpp
@@ -190,7 +190,7 @@ bool LoadSimfile(Simfile& sim, const std::string& path) {
         success = Osu::LoadOsu(filePath, &sim);
     } else {
         Debug::blockBegin(Debug::ERROR, "could not load sim");
-        Debug::log("file: %s\n", path);
+        Debug::log("file: %s\n", path.c_str());
         Debug::log("reason: unknown sim format\n");
         Debug::blockEnd();
     }

--- a/src/System/File.cpp
+++ b/src/System/File.cpp
@@ -321,8 +321,8 @@ bool moveFile(const std::string& path, const std::string& newPath,
         return true;
     } catch (const fs::filesystem_error& e) {
         Debug::blockBegin(Debug::ERROR, "could not move file");
-        Debug::log("path1: %s\n", e.path1());
-        Debug::log("path2: %s\n", e.path2());
+        Debug::log("path1: %s\n", e.path1().c_str());
+        Debug::log("path2: %s\n", e.path2().c_str());
         Debug::log("windows error code: %s\n", e.what());
         Debug::blockEnd();
         return false;


### PR DESCRIPTION
Without explicitly enabling exceptions, clang-tidy seems to throw a lot errors -- (reported by @Psycast , thanks!):
```
Severity  Code       Description                                                           File                  Line
--------  ---------  --------------------------------------------------------------------  --------------------  ----
Error     G310B715A  cannot use 'throw' with exceptions disabled [clang-diagnostic-error]  src\Core\Vector.h      430
Error     G310B715A  cannot use 'throw' with exceptions disabled [clang-diagnostic-error]  src\Core\Vector.h      430
Error     G310B715A  cannot use 'throw' with exceptions disabled [clang-diagnostic-error]  src\Core\Vector.h      430
Error     G310B715A  cannot use 'throw' with exceptions disabled [clang-diagnostic-error]  src\Core\Vector.h      430
Error     G310B715A  cannot use 'throw' with exceptions disabled [clang-diagnostic-error]  src\Core\Vector.h      430
Error     G310B715A  cannot use 'throw' with exceptions disabled [clang-diagnostic-error]  src\Core\Vector.h      430
Error     G310B715A  cannot use 'throw' with exceptions disabled [clang-diagnostic-error]  src\Core\Vector.h      430
Error     G310B715A  cannot use 'throw' with exceptions disabled [clang-diagnostic-error]  src\Core\Vector.h      430
Error     GAF447572  no matching function for call to 'min' [clang-diagnostic-error]       src\Simfile\LoadSm.cpp 321    
```

Also, some critical errors (such as passing strings to variadics and others) were reported by the linter, fixed those as well.