### PR TITLE
Clang errors

### DIFF
--- a/src/Core/ByteStream.cpp
+++ b/src/Core/ByteStream.cpp
@@ -11,7 +11,7 @@ namespace Vortex {
 // WriteStream.
 
 WriteStream::WriteStream() {
-    buffer_ = (uint8_t*)malloc(128);
+    buffer_ = static_cast<uint8_t*>(malloc(128));
     current_size_ = 0;
     capacity_ = 128;
     is_external_buffer_ = false;
@@ -19,7 +19,7 @@ WriteStream::WriteStream() {
 }
 
 WriteStream::WriteStream(void* out, int bytes) {
-    buffer_ = (uint8_t*)out;
+    buffer_ = static_cast<uint8_t*>(out);
     current_size_ = 0;
     capacity_ = bytes;
     is_external_buffer_ = true;
@@ -37,7 +37,7 @@ void WriteStream::write(const void* in, int bytes) {
         current_size_ = newSize;
     } else if (!is_external_buffer_) {
         capacity_ = max(capacity_ << 1, newSize);
-        buffer_ = (uint8_t*)realloc(buffer_, capacity_);
+        buffer_ = static_cast<uint8_t*>(realloc(buffer_, capacity_));
         memcpy(buffer_ + current_size_, in, bytes);
         current_size_ = newSize;
     } else {
@@ -47,12 +47,12 @@ void WriteStream::write(const void* in, int bytes) {
 
 void WriteStream::write8(const void* val) {
     if (current_size_ < capacity_) {
-        buffer_[current_size_] = *(const uint8_t*)val;
+        buffer_[current_size_] = *static_cast<const uint8_t*>(val);
         ++current_size_;
     } else if (!is_external_buffer_) {
         capacity_ <<= 1;
-        buffer_ = (uint8_t*)realloc(buffer_, capacity_);
-        buffer_[current_size_] = *(const uint8_t*)val;
+        buffer_ = static_cast<uint8_t*>(realloc(buffer_, capacity_));
+        buffer_[current_size_] = *static_cast<const uint8_t*>(val);
         ++current_size_;
     } else {
         is_write_successful_ = false;
@@ -62,12 +62,12 @@ void WriteStream::write8(const void* val) {
 void WriteStream::write16(const void* val) {
     int newSize = current_size_ + sizeof(uint16_t);
     if (newSize <= capacity_) {
-        *(uint16_t*)(buffer_ + current_size_) = *(const uint16_t*)val;
+        *reinterpret_cast<uint16_t*>(buffer_ + current_size_) = *static_cast<const uint16_t*>(val);
         current_size_ = newSize;
     } else if (!is_external_buffer_) {
         capacity_ <<= 1;
-        buffer_ = (uint8_t*)realloc(buffer_, capacity_);
-        *(uint16_t*)(buffer_ + current_size_) = *(const uint16_t*)val;
+        buffer_ = static_cast<uint8_t*>(realloc(buffer_, capacity_));
+        *reinterpret_cast<uint16_t*>(buffer_ + current_size_) = *static_cast<const uint16_t*>(val);
         current_size_ = newSize;
     } else {
         is_write_successful_ = false;
@@ -77,12 +77,12 @@ void WriteStream::write16(const void* val) {
 void WriteStream::write32(const void* val) {
     int newSize = current_size_ + sizeof(uint32_t);
     if (newSize <= capacity_) {
-        *(uint32_t*)(buffer_ + current_size_) = *(const uint32_t*)val;
+        *reinterpret_cast<uint32_t*>(buffer_ + current_size_) = *static_cast<const uint32_t*>(val);
         current_size_ = newSize;
     } else if (!is_external_buffer_) {
         capacity_ <<= 1;
-        buffer_ = (uint8_t*)realloc(buffer_, capacity_);
-        *(uint32_t*)(buffer_ + current_size_) = *(const uint32_t*)val;
+        buffer_ = static_cast<uint8_t*>(realloc(buffer_, capacity_));
+        *reinterpret_cast<uint32_t*>(buffer_ + current_size_) = *static_cast<const uint32_t*>(val);
         current_size_ = newSize;
     } else {
         is_write_successful_ = false;
@@ -92,12 +92,12 @@ void WriteStream::write32(const void* val) {
 void WriteStream::write64(const void* val) {
     int newSize = current_size_ + sizeof(uint64_t);
     if (newSize <= capacity_) {
-        *(uint64_t*)(buffer_ + current_size_) = *(const uint64_t*)val;
+        *reinterpret_cast<uint64_t*>(buffer_ + current_size_) = *static_cast<const uint64_t*>(val);
         current_size_ = newSize;
     } else if (!is_external_buffer_) {
         capacity_ <<= 1;
-        buffer_ = (uint8_t*)realloc(buffer_, capacity_);
-        *(uint64_t*)(buffer_ + current_size_) = *(const uint64_t*)val;
+        buffer_ = static_cast<uint8_t*>(realloc(buffer_, capacity_));
+        *reinterpret_cast<uint64_t*>(buffer_ + current_size_) = *static_cast<const uint64_t*>(val);
         current_size_ = newSize;
     } else {
         is_write_successful_ = false;
@@ -129,12 +129,12 @@ void WriteStream::writeStr(const std::string& str) {
 // ReadStream.
 
 ReadStream::ReadStream(const void* in, int bytes) {
-    read_position_ = (const uint8_t*)in;
+    read_position_ = static_cast<const uint8_t*>(in);
     end_position_ = read_position_ + bytes;
     is_read_successful_ = true;
 }
 
-ReadStream::~ReadStream() {}
+ReadStream::~ReadStream() = default;
 
 void ReadStream::skip(int bytes) {
     if (read_position_ + bytes <= end_position_) {
@@ -157,10 +157,10 @@ void ReadStream::read(void* out, int bytes) {
 
 void ReadStream::read8(void* out) {
     if (read_position_ != end_position_) {
-        *(uint8_t*)out = *read_position_;
+        *static_cast<uint8_t*>(out) = *read_position_;
         ++read_position_;
     } else {
-        *(uint8_t*)out = 0;
+        *static_cast<uint8_t*>(out) = 0;
         read_position_ = end_position_;
         is_read_successful_ = false;
     }
@@ -169,10 +169,10 @@ void ReadStream::read8(void* out) {
 void ReadStream::read16(void* out) {
     auto newPos = read_position_ + sizeof(uint16_t);
     if (newPos <= end_position_) {
-        *(uint16_t*)out = *(const uint16_t*)read_position_;
+        *static_cast<uint16_t*>(out) = *reinterpret_cast<const uint16_t*>(read_position_);
         read_position_ = newPos;
     } else {
-        *(uint16_t*)out = 0;
+        *static_cast<uint16_t*>(out) = 0;
         read_position_ = end_position_;
         is_read_successful_ = false;
     }
@@ -181,10 +181,10 @@ void ReadStream::read16(void* out) {
 void ReadStream::read32(void* out) {
     auto newPos = read_position_ + sizeof(uint32_t);
     if (newPos <= end_position_) {
-        *(uint32_t*)out = *(const uint32_t*)read_position_;
+        *static_cast<uint32_t*>(out) = *reinterpret_cast<const uint32_t*>(read_position_);
         read_position_ = newPos;
     } else {
-        *(uint32_t*)out = 0;
+        *static_cast<uint32_t*>(out) = 0;
         read_position_ = end_position_;
         is_read_successful_ = false;
     }
@@ -193,10 +193,10 @@ void ReadStream::read32(void* out) {
 void ReadStream::read64(void* out) {
     auto newPos = read_position_ + sizeof(uint64_t);
     if (newPos <= end_position_) {
-        *(uint64_t*)out = *(const uint64_t*)read_position_;
+        *static_cast<uint64_t*>(out) = *reinterpret_cast<const uint64_t*>(read_position_);
         read_position_ = newPos;
     } else {
-        *(uint64_t*)out = 0;
+        *static_cast<uint64_t*>(out) = 0;
         read_position_ = end_position_;
         is_read_successful_ = false;
     }
@@ -241,7 +241,7 @@ std::string ReadStream::readStr() {
     if (newPos <= end_position_) {
         auto str = read_position_;
         read_position_ = newPos;
-        return std::string((const char*)str, len);
+        return std::string(reinterpret_cast<const char*>(str), len);
     }
     read_position_ = end_position_;
     is_read_successful_ = false;

--- a/src/Core/ByteStream.cpp
+++ b/src/Core/ByteStream.cpp
@@ -62,12 +62,14 @@ void WriteStream::write8(const void* val) {
 void WriteStream::write16(const void* val) {
     int newSize = current_size_ + sizeof(uint16_t);
     if (newSize <= capacity_) {
-        *reinterpret_cast<uint16_t*>(buffer_ + current_size_) = *static_cast<const uint16_t*>(val);
+        *reinterpret_cast<uint16_t*>(buffer_ + current_size_) =
+            *static_cast<const uint16_t*>(val);
         current_size_ = newSize;
     } else if (!is_external_buffer_) {
         capacity_ <<= 1;
         buffer_ = static_cast<uint8_t*>(realloc(buffer_, capacity_));
-        *reinterpret_cast<uint16_t*>(buffer_ + current_size_) = *static_cast<const uint16_t*>(val);
+        *reinterpret_cast<uint16_t*>(buffer_ + current_size_) =
+            *static_cast<const uint16_t*>(val);
         current_size_ = newSize;
     } else {
         is_write_successful_ = false;
@@ -77,12 +79,14 @@ void WriteStream::write16(const void* val) {
 void WriteStream::write32(const void* val) {
     int newSize = current_size_ + sizeof(uint32_t);
     if (newSize <= capacity_) {
-        *reinterpret_cast<uint32_t*>(buffer_ + current_size_) = *static_cast<const uint32_t*>(val);
+        *reinterpret_cast<uint32_t*>(buffer_ + current_size_) =
+            *static_cast<const uint32_t*>(val);
         current_size_ = newSize;
     } else if (!is_external_buffer_) {
         capacity_ <<= 1;
         buffer_ = static_cast<uint8_t*>(realloc(buffer_, capacity_));
-        *reinterpret_cast<uint32_t*>(buffer_ + current_size_) = *static_cast<const uint32_t*>(val);
+        *reinterpret_cast<uint32_t*>(buffer_ + current_size_) =
+            *static_cast<const uint32_t*>(val);
         current_size_ = newSize;
     } else {
         is_write_successful_ = false;
@@ -92,12 +96,14 @@ void WriteStream::write32(const void* val) {
 void WriteStream::write64(const void* val) {
     int newSize = current_size_ + sizeof(uint64_t);
     if (newSize <= capacity_) {
-        *reinterpret_cast<uint64_t*>(buffer_ + current_size_) = *static_cast<const uint64_t*>(val);
+        *reinterpret_cast<uint64_t*>(buffer_ + current_size_) =
+            *static_cast<const uint64_t*>(val);
         current_size_ = newSize;
     } else if (!is_external_buffer_) {
         capacity_ <<= 1;
         buffer_ = static_cast<uint8_t*>(realloc(buffer_, capacity_));
-        *reinterpret_cast<uint64_t*>(buffer_ + current_size_) = *static_cast<const uint64_t*>(val);
+        *reinterpret_cast<uint64_t*>(buffer_ + current_size_) =
+            *static_cast<const uint64_t*>(val);
         current_size_ = newSize;
     } else {
         is_write_successful_ = false;
@@ -169,7 +175,8 @@ void ReadStream::read8(void* out) {
 void ReadStream::read16(void* out) {
     auto newPos = read_position_ + sizeof(uint16_t);
     if (newPos <= end_position_) {
-        *static_cast<uint16_t*>(out) = *reinterpret_cast<const uint16_t*>(read_position_);
+        *static_cast<uint16_t*>(out) =
+            *reinterpret_cast<const uint16_t*>(read_position_);
         read_position_ = newPos;
     } else {
         *static_cast<uint16_t*>(out) = 0;
@@ -181,7 +188,8 @@ void ReadStream::read16(void* out) {
 void ReadStream::read32(void* out) {
     auto newPos = read_position_ + sizeof(uint32_t);
     if (newPos <= end_position_) {
-        *static_cast<uint32_t*>(out) = *reinterpret_cast<const uint32_t*>(read_position_);
+        *static_cast<uint32_t*>(out) =
+            *reinterpret_cast<const uint32_t*>(read_position_);
         read_position_ = newPos;
     } else {
         *static_cast<uint32_t*>(out) = 0;
@@ -193,7 +201,8 @@ void ReadStream::read32(void* out) {
 void ReadStream::read64(void* out) {
     auto newPos = read_position_ + sizeof(uint64_t);
     if (newPos <= end_position_) {
-        *static_cast<uint64_t*>(out) = *reinterpret_cast<const uint64_t*>(read_position_);
+        *static_cast<uint64_t*>(out) =
+            *reinterpret_cast<const uint64_t*>(read_position_);
         read_position_ = newPos;
     } else {
         *static_cast<uint64_t*>(out) = 0;

--- a/src/Core/Canvas.cpp
+++ b/src/Core/Canvas.cpp
@@ -303,19 +303,22 @@ void Canvas::box(float x1, float y1, float x2, float y2, float radius) {
 }
 
 void Canvas::box(int x1, int y1, int x2, int y2, float radius) {
-    box(static_cast<float>(x1), static_cast<float>(y1), static_cast<float>(x2), static_cast<float>(y2), radius);
+    box(static_cast<float>(x1), static_cast<float>(y1), static_cast<float>(x2),
+        static_cast<float>(y2), radius);
 }
 
 void Canvas::polygon(const float* x, const float* y, int vertexCount) {
     if (vertexCount < 3) return;
     GetPolyDist func(x, y, vertexCount);
     data_->draw(canvas_data_, canvas_width_, canvas_height_,
-                {0, 0, static_cast<float>(canvas_width_), static_cast<float>(canvas_height_)}, &func);
+                {0, 0, static_cast<float>(canvas_width_),
+                 static_cast<float>(canvas_height_)},
+                &func);
 }
 
 Texture Canvas::createTexture(bool mipmap) const {
-    uint8_t* dst =
-        static_cast<uint8_t*>(malloc(canvas_width_ * canvas_height_ * 4 * sizeof(uint8_t)));
+    uint8_t* dst = static_cast<uint8_t*>(
+        malloc(canvas_width_ * canvas_height_ * 4 * sizeof(uint8_t)));
     for (int i = 0; i < canvas_width_ * canvas_height_ * 4; ++i) {
         int v = static_cast<int>(canvas_data_[i] * 255.f + 0.5f);
         dst[i] = min(max(v, 0), 255);
@@ -331,8 +334,8 @@ Canvas& Canvas::operator=(const Canvas& other) {
     canvas_width_ = other.canvas_width_, canvas_height_ = other.canvas_height_,
     canvas_data_ = nullptr;
     if (other.canvas_data_)
-        canvas_data_ =
-            static_cast<float*>(malloc(canvas_width_ * canvas_height_ * 4 * sizeof(float)));
+        canvas_data_ = static_cast<float*>(
+            malloc(canvas_width_ * canvas_height_ * 4 * sizeof(float)));
     memcpy(canvas_data_, other.canvas_data_,
            canvas_width_ * canvas_height_ * 4 * sizeof(float));
     return *this;

--- a/src/Core/Canvas.cpp
+++ b/src/Core/Canvas.cpp
@@ -61,16 +61,16 @@ struct GetLineDist : public DistanceFunc {
     GetLineDist(float ax, float ay, float bx, float by, float size)
         : ax(ax), ay(ay), bx(bx), by(by), size(size) {}
 
-    float Get(float px, float py) const {
+    float Get(float px, float py) const override {
         float num = (px - ax) * (bx - ax) + (py - ay) * (by - ay);
         float den = (bx - ax) * (bx - ax) + (by - ay) * (by - ay);
         float rdn = 1 / den, r = num * rdn;
         float s = ((ay - py) * (bx - ax) - (ax - px) * (by - ay)) * rdn;
-        if (r >= 0 && r <= 1) return (float)fabs(s * sqrt(den)) - size;
+        if (r >= 0 && r <= 1) return fabs(s * sqrt(den)) - size;
 
         float d1sq = (px - ax) * (px - ax) + (py - ay) * (py - ay);
         float d2sq = (px - bx) * (px - bx) + (py - by) * (py - by);
-        return (float)sqrt(d1sq < d2sq ? d1sq : d2sq) - size;
+        return sqrt(d1sq < d2sq ? d1sq : d2sq) - size;
     }
 };
 
@@ -80,9 +80,9 @@ struct GetCircleDist : public DistanceFunc {
 
     GetCircleDist(float x, float y, float r) : x(x), y(y), r(r) {}
 
-    float Get(float px, float py) const {
+    float Get(float px, float py) const override {
         float dx = px - x, dy = py - y;
-        return (float)sqrt(dx * dx + dy * dy) - r;
+        return sqrt(dx * dx + dy * dy) - r;
     }
 };
 
@@ -93,7 +93,7 @@ struct GetRoundRectDist : public DistanceFunc {
     GetRoundRectDist(float x1, float y1, float x2, float y2, float r)
         : x1(x1), y1(y1), x2(x2), y2(y2), r(r) {}
 
-    float Get(float px, float py) const {
+    float Get(float px, float py) const override {
         float x = min(max(px, x1 + r), x2 - r);
         float y = min(max(py, y1 + r), y2 - r);
         if (x == px && y == py) {
@@ -102,7 +102,7 @@ struct GetRoundRectDist : public DistanceFunc {
             return -min(dx, dy);
         } else {
             float dx = px - x, dy = py - y;
-            return (float)sqrt(dx * dx + dy * dy) - r;
+            return sqrt(dx * dx + dy * dy) - r;
         }
     }
 };
@@ -124,7 +124,7 @@ struct GetPolyDist : public DistanceFunc {
         return (numIntersects & 1);
     }
 
-    float Get(float px, float py) const {
+    float Get(float px, float py) const override {
         float d = 1e10;
         for (int i = 0, j = count - 1; i < count; j = i, ++i) {
             GetLineDist ld(x[i], y[i], x[j], y[j], 0);
@@ -163,28 +163,28 @@ void Canvas::Data::draw(float* buf, int w, int h, const areaf& area,
     if (blendMode == Canvas::BM_ALPHA) blendfunc = BlendAlpha;
     if (blendMode == Canvas::BM_ADD) blendfunc = BlendAdd;
 
-    int x1 = max(mask.l, (int)(area.l - outerGlow - 1 + 0.5f));
-    int y1 = max(mask.t, (int)(area.t - outerGlow - 1 + 0.5f));
-    int x2 = min(mask.r, (int)(area.r + outerGlow + 1 + 0.5f));
-    int y2 = min(mask.b, (int)(area.b + outerGlow + 1 + 0.5f));
+    int x1 = max(mask.l, static_cast<int>(area.l - outerGlow - 1 + 0.5f));
+    int y1 = max(mask.t, static_cast<int>(area.t - outerGlow - 1 + 0.5f));
+    int x2 = min(mask.r, static_cast<int>(area.r + outerGlow + 1 + 0.5f));
+    int y2 = min(mask.b, static_cast<int>(area.b + outerGlow + 1 + 0.5f));
 
     float rh = 1.f / max(1, y2 - y1);
     float rw = 1.f / max(1, x2 - x1);
     float ig = 1.f / (innerGlow + 1);
     float og = 1.f / (outerGlow + 1);
 
-    float yf = (float)y1 + 0.5f;
+    float yf = static_cast<float>(y1) + 0.5f;
     for (int y = y1; y < y2; ++y, yf += 1) {
         RGBA l = tl;
         BlendLinear(l, bl, yf * rh);
         RGBA r = tr;
         BlendLinear(r, br, yf * rh);
 
-        float xf = (float)x1 + 0.5f;
+        float xf = static_cast<float>(x1) + 0.5f;
         for (int x = x1; x < x2; ++x, xf += 1) {
             float dist = func->Get(xf, yf);
             if (dist >= outerGlow + 1) continue;
-            RGBA* dst = (RGBA*)(buf + ((y * w + x) * 4));
+            RGBA* dst = reinterpret_cast<RGBA*>(buf + ((y * w + x) * 4));
             RGBA src = l;
             BlendLinear(src, r, xf * rw);
             if (outline && dist < -0.5f) {
@@ -219,7 +219,7 @@ Canvas::Canvas(int w, int h, float lum)
       canvas_width_(w),
       canvas_height_(h),
       data_(new Canvas::Data) {
-    canvas_data_ = (float*)malloc(w * h * 4 * sizeof(float));
+    canvas_data_ = static_cast<float*>(malloc(w * h * 4 * sizeof(float)));
     data_->mask = {0, 0, canvas_width_, canvas_height_};
     clear(lum);
 }
@@ -303,21 +303,21 @@ void Canvas::box(float x1, float y1, float x2, float y2, float radius) {
 }
 
 void Canvas::box(int x1, int y1, int x2, int y2, float radius) {
-    box((float)x1, (float)y1, (float)x2, (float)y2, radius);
+    box(static_cast<float>(x1), static_cast<float>(y1), static_cast<float>(x2), static_cast<float>(y2), radius);
 }
 
 void Canvas::polygon(const float* x, const float* y, int vertexCount) {
     if (vertexCount < 3) return;
     GetPolyDist func(x, y, vertexCount);
     data_->draw(canvas_data_, canvas_width_, canvas_height_,
-                {0, 0, (float)canvas_width_, (float)canvas_height_}, &func);
+                {0, 0, static_cast<float>(canvas_width_), static_cast<float>(canvas_height_)}, &func);
 }
 
 Texture Canvas::createTexture(bool mipmap) const {
     uint8_t* dst =
-        (uint8_t*)malloc(canvas_width_ * canvas_height_ * 4 * sizeof(uint8_t));
+        static_cast<uint8_t*>(malloc(canvas_width_ * canvas_height_ * 4 * sizeof(uint8_t)));
     for (int i = 0; i < canvas_width_ * canvas_height_ * 4; ++i) {
-        int v = (int)(canvas_data_[i] * 255.f + 0.5f);
+        int v = static_cast<int>(canvas_data_[i] * 255.f + 0.5f);
         dst[i] = min(max(v, 0), 255);
     }
     Texture result(canvas_width_, canvas_height_, dst, mipmap);
@@ -332,7 +332,7 @@ Canvas& Canvas::operator=(const Canvas& other) {
     canvas_data_ = nullptr;
     if (other.canvas_data_)
         canvas_data_ =
-            (float*)malloc(canvas_width_ * canvas_height_ * 4 * sizeof(float));
+            static_cast<float*>(malloc(canvas_width_ * canvas_height_ * 4 * sizeof(float)));
     memcpy(canvas_data_, other.canvas_data_,
            canvas_width_ * canvas_height_ * 4 * sizeof(float));
     return *this;

--- a/src/Core/FontData.cpp
+++ b/src/Core/FontData.cpp
@@ -18,7 +18,7 @@ static const Texture::Format FORMAT = Texture::ALPHA;
 // Creates a padded grayscale copy of a glyph bitmap.
 static uint8_t* CopyGlyphBitmap(int boxW, int boxH, FT_Bitmap bitmap) {
     int srcW = bitmap.width, srcH = bitmap.rows, srcP = abs(bitmap.pitch);
-    uint8_t* out = (uint8_t*)calloc(boxW * boxH, 1);
+    uint8_t* out = static_cast<uint8_t*>(calloc(boxW * boxH, 1));
     for (int y = 0; y < srcH; ++y) {
         const uint8_t* src = bitmap.buffer + y * srcP;
         uint8_t* dst = out + ((y + PADDING) * boxW + PADDING) * CHANNELS;
@@ -102,7 +102,7 @@ static void IncreaseTextureHeight(GlyphCache* cache, int h) {
     while (newHeight < h) newHeight *= 2;
 
     cache->tex->increaseHeight(newHeight);
-    float ratio = (float)((double)oldHeight / (double)newHeight);
+    float ratio = static_cast<float>(static_cast<double>(oldHeight) / static_cast<double>(newHeight));
     for (auto& g : cache->glyphs) {
         g.second->uvs.t *= ratio;
         g.second->uvs.b *= ratio;
@@ -154,11 +154,11 @@ static Glyph* PutGlyphInCache(GlyphCache* cache, FT_GlyphSlot slot) {
     // If the glyph bitmap has pixels, we need to find a place for it on the
     // cache texture.
     const FT_Bitmap& bitmap = slot->bitmap;
-    int glyphW = (int)bitmap.width;
-    int glyphH = (int)bitmap.rows;
+    int glyphW = static_cast<int>(bitmap.width);
+    int glyphH = static_cast<int>(bitmap.rows);
     if (glyphW > 0 && glyphH > 0) {
-        int bitmapW = (int)bitmap.width + PADDING * 2;
-        int bitmapH = (int)bitmap.rows + PADDING * 2;
+        int bitmapW = static_cast<int>(bitmap.width) + PADDING * 2;
+        int bitmapH = static_cast<int>(bitmap.rows) + PADDING * 2;
 
         // First, check if we can reuse the spot of a previous glyph that is no
         // longer in use.
@@ -178,7 +178,7 @@ static Glyph* PutGlyphInCache(GlyphCache* cache, FT_GlyphSlot slot) {
                 // the shelf.
         {
             // Allocate a new glyph.
-            glyph = (Glyph*)calloc(1, sizeof(Glyph));
+            glyph = static_cast<Glyph*>(calloc(1, sizeof(Glyph)));
             glyph->hasAlphaTex = 1;
 
             // Reserve a spot on the glyph texture.
@@ -202,19 +202,19 @@ static Glyph* PutGlyphInCache(GlyphCache* cache, FT_GlyphSlot slot) {
         free(pixels);
 
         // Set the glyph uvs.
-        float rTexW = 1.f / (float)cache->tex->w;
-        float rTexH = 1.f / (float)cache->tex->h;
+        float rTexW = 1.f / static_cast<float>(cache->tex->w);
+        float rTexH = 1.f / static_cast<float>(cache->tex->h);
         glyph->uvs = {
-            (float)(glyph->box.x + PADDING) * rTexW,
-            (float)(glyph->box.y + PADDING) * rTexH,
-            (float)(glyph->box.x + PADDING + glyphW) * rTexW,
-            (float)(glyph->box.y + PADDING + glyphH) * rTexH,
+            static_cast<float>(glyph->box.x + PADDING) * rTexW,
+            static_cast<float>(glyph->box.y + PADDING) * rTexH,
+            static_cast<float>(glyph->box.x + PADDING + glyphW) * rTexW,
+            static_cast<float>(glyph->box.y + PADDING + glyphH) * rTexH,
         };
         glyph->hasPixels = 1;
     } else  // The bitmap does not have pixels, so we can just allocate a glyph
             // and return it.
     {
-        glyph = (Glyph*)calloc(1, sizeof(Glyph));
+        glyph = static_cast<Glyph*>(calloc(1, sizeof(Glyph)));
     }
 
     glyph->ofs.l = slot->bitmap_left;
@@ -227,7 +227,7 @@ static Glyph* PutGlyphInCache(GlyphCache* cache, FT_GlyphSlot slot) {
 
 Glyph* RenderGlyph(FontData* font, GlyphCache* cache, int size, int charcode) {
     Glyph* glyph = nullptr;
-    FT_Face face = (FT_Face)font->ftface;
+    FT_Face face = static_cast<FT_Face>(font->ftface);
 
     // Sanity check for invalid codepoint values.
     if (charcode < 0) return nullptr;
@@ -246,7 +246,7 @@ Glyph* RenderGlyph(FontData* font, GlyphCache* cache, int size, int charcode) {
     // Some fonts do not have whitespace glyphs, but we can approximate them if
     // necessary.
     else if (charcode < 33 && (glyphTraits[charcode] & GTB_WHITESPACE)) {
-        glyph = (Glyph*)calloc(1, sizeof(Glyph));
+        glyph = static_cast<Glyph*>(calloc(1, sizeof(Glyph)));
         glyph->advance = size / 2;
     } else  // If its a non-whitespace glyph that is not supported, we are out
             // of luck.
@@ -275,7 +275,7 @@ Glyph* RenderGlyph(FontData* font, GlyphCache* cache, int size, int charcode) {
 
 FontData::FontData(void* inFtface, const char* inPath,
                    Text::Hinting inHinting) {
-    FT_Select_Charmap((FT_Face)inFtface, FT_ENCODING_UNICODE);
+    FT_Select_Charmap(static_cast<FT_Face>(inFtface), FT_ENCODING_UNICODE);
 
     currentCache = nullptr;
     currentSize = 0;
@@ -309,7 +309,7 @@ FontData::~FontData() { clear(); }
 
 void FontData::clear() {
     if (ftface) {
-        FT_Done_Face((FT_Face)ftface);
+        FT_Done_Face(static_cast<FT_Face>(ftface));
     }
 
     for (auto& cache : caches) {
@@ -348,10 +348,10 @@ void FontData::setSize(FontSize size) {
         if (it != caches.end()) {
             currentCache = it->second;
         } else {
-            GlyphCache* cache = CreateCache((FT_Face)ftface, size);
+            GlyphCache* cache = CreateCache(static_cast<FT_Face>(ftface), size);
             caches[size] = currentCache = cache;
         }
-        FT_Set_Pixel_Sizes((FT_Face)ftface, 0, size);
+        FT_Set_Pixel_Sizes(static_cast<FT_Face>(ftface), 0, size);
         currentSize = size;
     }
 }
@@ -376,7 +376,7 @@ bool FontData::hasKerning() const {
 }
 
 int FontData::getKerning(const Glyph* left, const Glyph* right) const {
-    auto face = (FT_Face)ftface;
+    auto face = static_cast<FT_Face>(ftface);
     FT_Vector delta;
     FT_Get_Kerning(face, left->index, right->index, FT_KERNING_DEFAULT, &delta);
     return delta.x >> 6;

--- a/src/Core/FontData.cpp
+++ b/src/Core/FontData.cpp
@@ -102,7 +102,8 @@ static void IncreaseTextureHeight(GlyphCache* cache, int h) {
     while (newHeight < h) newHeight *= 2;
 
     cache->tex->increaseHeight(newHeight);
-    float ratio = static_cast<float>(static_cast<double>(oldHeight) / static_cast<double>(newHeight));
+    float ratio = static_cast<float>(static_cast<double>(oldHeight) /
+                                     static_cast<double>(newHeight));
     for (auto& g : cache->glyphs) {
         g.second->uvs.t *= ratio;
         g.second->uvs.b *= ratio;

--- a/src/Core/FontManager.cpp
+++ b/src/Core/FontManager.cpp
@@ -140,7 +140,8 @@ FontData* FontManager::load(const std::string& path, Text::Hinting hinting) {
 
     // If not, try to load the font.
     FT_Face face;
-    int result = FT_New_Face(static_cast<FT_Library>(FM->ftLib), path.c_str(), 0, &face);
+    int result =
+        FT_New_Face(static_cast<FT_Library>(FM->ftLib), path.c_str(), 0, &face);
     if (result == FT_Err_Ok) {
         FontData* font = new FontData(face, path.c_str(), hinting);
         FM->fonts[path] = font;

--- a/src/Core/FontManager.cpp
+++ b/src/Core/FontManager.cpp
@@ -60,8 +60,8 @@ static void CreatePlaceholderGlyphs(Glyph* out) {
         Glyph& glyph = out[i];
         memset(&glyph, 0, sizeof(Glyph));
 
-        float rw = 1.0f / (float)boxW;
-        float rh = 1.0f / (float)boxH;
+        float rw = 1.0f / static_cast<float>(boxW);
+        float rh = 1.0f / static_cast<float>(boxH);
 
         glyph.hasPixels = 1;
         glyph.hasAlphaTex = 1;
@@ -104,7 +104,7 @@ void FontManager::destroy() {
         }
     }
 
-    FT_Done_FreeType((FT_Library)FM->ftLib);
+    FT_Done_FreeType(static_cast<FT_Library>(FM->ftLib));
 
     delete FM;
     FM = nullptr;
@@ -140,7 +140,7 @@ FontData* FontManager::load(const std::string& path, Text::Hinting hinting) {
 
     // If not, try to load the font.
     FT_Face face;
-    int result = FT_New_Face((FT_Library)(FM->ftLib), path.c_str(), 0, &face);
+    int result = FT_New_Face(static_cast<FT_Library>(FM->ftLib), path.c_str(), 0, &face);
     if (result == FT_Err_Ok) {
         FontData* font = new FontData(face, path.c_str(), hinting);
         FM->fonts[path] = font;
@@ -178,7 +178,7 @@ void FontManager::cache(FontData* font) {
 
 bool FontManager::loadGlyph(const std::string& name, const Texture& texture,
                             int dx, int dy, int advance) {
-    auto tex = (Texture::Data*)texture.data();
+    auto tex = static_cast<Texture::Data*>(texture.data());
     if (tex) {
         texture.cache();
 
@@ -233,7 +233,7 @@ FontData* FontManager::fallback() { return FM->fallback; }
 // ================================================================================================
 // API functions from "draw.h"
 
-void Font::cache() const { FontManager::cache((FontData*)data_); }
+void Font::cache() const { FontManager::cache(static_cast<FontData*>(data_)); }
 
 void Font::LogInfo() { FontManager::log(); }
 

--- a/src/Core/Gui.cpp
+++ b/src/Core/Gui.cpp
@@ -26,8 +26,8 @@ struct GuiMainData {
     vec2i viewSize;
     vec2i mousePos;
 
-    GuiMain::ClipboardSetFunction clipboardSet;
-    GuiMain::ClipboardGetFunction clipboardGet;
+    GuiMain::ClipboardSetFunction clipboardSet = nullptr;
+    GuiMain::ClipboardGetFunction clipboardGet = nullptr;
     std::string clipboardText;
 
     std::string tooltipPreviousText;
@@ -85,7 +85,8 @@ static void handleTooltip() {
         if (GUI->tooltipText.length() && GUI->tooltipTimer > 1.0f) {
             TextStyle style;
 
-            int alpha = clamp(static_cast<int>(GUI->tooltipTimer * 1000 - 1000), 0, 255);
+            int alpha = clamp(static_cast<int>(GUI->tooltipTimer * 1000 - 1000),
+                              0, 255);
 
             style.textColor = Color32(0, alpha);
             style.shadowColor = Colors::blank;

--- a/src/Core/Gui.cpp
+++ b/src/Core/Gui.cpp
@@ -85,7 +85,7 @@ static void handleTooltip() {
         if (GUI->tooltipText.length() && GUI->tooltipTimer > 1.0f) {
             TextStyle style;
 
-            int alpha = clamp((int)(GUI->tooltipTimer * 1000 - 1000), 0, 255);
+            int alpha = clamp(static_cast<int>(GUI->tooltipTimer * 1000 - 1000), 0, 255);
 
             style.textColor = Color32(0, alpha);
             style.shadowColor = Colors::blank;

--- a/src/Core/GuiContext.cpp
+++ b/src/Core/GuiContext.cpp
@@ -11,6 +11,8 @@ GuiContext::~GuiContext() = default;
 GuiContextImpl::~GuiContextImpl() { Vec::release(dialogs_); }
 
 GuiContextImpl::GuiContextImpl() {
+    delta_time_ = 0;
+    mouse_position_ = {0, 0};
     view_rect_ = {0, 0, INT_MAX, INT_MAX};
     input_events_ = nullptr;
 }
@@ -46,7 +48,7 @@ void GuiContextImpl::tick(recti view, float deltaTime, InputEvents& events) {
         } else if (dialog->request_move_to_top_) {
             dialogs_.erase(i);
             dialogs_.push_back(dialog);
-            dialog->request_move_to_top_ = 0;
+            dialog->request_move_to_top_ = false;
         }
     }
 
@@ -68,10 +70,10 @@ void GuiContextImpl::tick(recti view, float deltaTime, InputEvents& events) {
 
 void GuiContextImpl::draw() {
     // Draw the dialogs.
-    FOR_VECTOR_FORWARD(dialogs_, i) { dialogs_[i]->draw(); }
+    for (DialogData* dialog : dialogs_) { dialog->draw(); }
 
     // Draw widgets with focus at the top.
-    FOR_VECTOR_FORWARD(focus_widgets_, i) { focus_widgets_[i]->onDraw(); }
+    for (GuiWidget* focus_widget : focus_widgets_) { focus_widget->onDraw(); }
 }
 
 void GuiContextImpl::removeWidget(GuiWidget* w) {
@@ -83,8 +85,8 @@ void GuiContextImpl::addDialog(DialogData* f) { dialogs_.push_back(f); }
 void GuiContextImpl::removeDialog(DialogData* f) { dialogs_.erase_values(f); }
 
 void GuiContextImpl::grabFocus(GuiWidget* w) {
-    FOR_VECTOR_FORWARD(focus_widgets_, i) {
-        if (focus_widgets_[i] == w) return;
+    for (GuiWidget* focus_widget : focus_widgets_) {
+        if (focus_widget == w) return;
     }
     focus_widgets_.push_back(w);
 }

--- a/src/Core/GuiContext.cpp
+++ b/src/Core/GuiContext.cpp
@@ -6,7 +6,7 @@
 
 namespace Vortex {
 
-GuiContext::~GuiContext() {}
+GuiContext::~GuiContext() = default;
 
 GuiContextImpl::~GuiContextImpl() { Vec::release(dialogs_); }
 

--- a/src/Core/GuiContext.cpp
+++ b/src/Core/GuiContext.cpp
@@ -70,10 +70,14 @@ void GuiContextImpl::tick(recti view, float deltaTime, InputEvents& events) {
 
 void GuiContextImpl::draw() {
     // Draw the dialogs.
-    for (DialogData* dialog : dialogs_) { dialog->draw(); }
+    for (DialogData* dialog : dialogs_) {
+        dialog->draw();
+    }
 
     // Draw widgets with focus at the top.
-    for (GuiWidget* focus_widget : focus_widgets_) { focus_widget->onDraw(); }
+    for (GuiWidget* focus_widget : focus_widgets_) {
+        focus_widget->onDraw();
+    }
 }
 
 void GuiContextImpl::removeWidget(GuiWidget* w) {

--- a/src/Core/GuiDialog.cpp
+++ b/src/Core/GuiDialog.cpp
@@ -26,17 +26,17 @@ DialogData::DialogData(GuiContext* gui, GuiDialog* dialog)
     : GuiWidget(gui),
       dialog_ptr_(dialog),
       gui_(gui),
-      is_pinnable_(1),
-      is_closeable_(1),
-      is_minimizable_(1),
-      is_horizontally_resizable_(0),
-      is_vertically_resizable_(0),
-      request_close_(0),
-      request_pin_(0),
-      request_minimize_(0),
-      request_move_to_top_(0),
-      pinned_state_(0),
-      minimized_state_(0),
+      is_pinnable_(true),
+      is_closeable_(true),
+      is_minimizable_(true),
+      is_horizontally_resizable_(false),
+      is_vertically_resizable_(false),
+      request_close_(false),
+      request_pin_(false),
+      request_minimize_(false),
+      request_move_to_top_(false),
+      pinned_state_(false),
+      minimized_state_(false),
       min_size_({0, 0}),
       max_size_({INT_MAX, INT_MAX}),
       pinned_position_({0, 0}),
@@ -60,7 +60,7 @@ static DialogData::DragAction* StartDrag(recti r, int mx, int my) {
 
 void DialogData::HandleDrag() {
     if (current_action_ && current_action_->type == ACT_DRAG) {
-        auto action = (DragAction*)current_action_;
+        auto action = static_cast<DragAction*>(current_action_);
         vec2i mpos = gui_->getMousePos();
 
         rect_.x = mpos.x + action->offset.x;
@@ -103,7 +103,7 @@ static DialogData::ResizeAction* StartResize(DialogData::ActionType type,
 
 void DialogData::HandleResize() {
     if (current_action_ && current_action_->type >= ACT_RESIZE) {
-        auto action = (ResizeAction*)current_action_;
+        auto action = static_cast<ResizeAction*>(current_action_);
         vec2i mpos = gui_->getMousePos();
         vec2i anchor = action->anchor;
 
@@ -138,7 +138,7 @@ void DialogData::onMousePress(MousePress& evt) {
             auto actionType = GetAction(evt.x, evt.y);
 
             if (actionType != ACT_NONE || IsInside(rect_, evt.x, evt.y)) {
-                request_move_to_top_ = 1;
+                request_move_to_top_ = true;
             }
             if (actionType == ACT_DRAG) {
                 startCapturingMouse();
@@ -147,11 +147,11 @@ void DialogData::onMousePress(MousePress& evt) {
                 startCapturingMouse();
                 current_action_ = StartResize(actionType, rect_, evt.x, evt.y);
             } else if (actionType == ACT_CLOSE) {
-                request_close_ = 1;
+                request_close_ = true;
             } else if (actionType == ACT_MINIMIZE) {
-                request_minimize_ = 1;
+                request_minimize_ = true;
             } else if (actionType == ACT_PIN) {
-                request_pin_ = 1;
+                request_pin_ = true;
             }
         }
         evt.setHandled();
@@ -177,7 +177,7 @@ void DialogData::ClampRect() {
     }
 
     if (current_action_ && current_action_->type >= ACT_RESIZE) {
-        auto a = (ResizeAction*)current_action_;
+        auto a = static_cast<ResizeAction*>(current_action_);
         if (a->dirH < 0) rect_.w = min(rect_.w, a->anchor.x - bounds.x);
         if (a->dirH > 0)
             rect_.w = min(rect_.w, bounds.x + bounds.w - a->anchor.x);
@@ -190,7 +190,7 @@ void DialogData::ClampRect() {
     rect_.h = max(min_size_.y, min(max_size_.y, min(bounds.h, rect_.h)));
 
     if (current_action_ && current_action_->type >= ACT_RESIZE) {
-        auto a = (ResizeAction*)current_action_;
+        auto a = static_cast<ResizeAction*>(current_action_);
         if (a->dirH < 0) rect_.x = a->anchor.x - rect_.w;
         if (a->dirV < 0) rect_.y = a->anchor.y - rect_.h;
     }
@@ -202,15 +202,15 @@ void DialogData::ClampRect() {
 
 void DialogData::arrange() {
     if (request_minimize_) {
-        request_minimize_ = 0;
+        request_minimize_ = false;
         minimized_state_ = !minimized_state_;
-        if (minimized_state_) pinned_state_ = 0;
+        if (minimized_state_) pinned_state_ = false;
     }
     if (request_pin_) {
-        request_pin_ = 0;
+        request_pin_ = false;
         pinned_state_ = !pinned_state_;
         if (pinned_state_) {
-            minimized_state_ = 0;
+            minimized_state_ = false;
             pinned_position_ = Pos(rect_);
         }
     }
@@ -419,9 +419,9 @@ void GuiDialog::onTick() {}
 
 void GuiDialog::onDraw() {}
 
-void GuiDialog::requestClose() { DATA->request_close_ = 1; }
+void GuiDialog::requestClose() { DATA->request_close_ = true; }
 
-void GuiDialog::requestPin() { DATA->request_pin_ = 1; }
+void GuiDialog::requestPin() { DATA->request_pin_ = true; }
 
 void GuiDialog::setPosition(int x, int y) {
     DATA->rect_.x = x;
@@ -442,9 +442,9 @@ void GuiDialog::setMaximumWidth(int w) { DATA->max_size_.x = max(0, w); }
 
 void GuiDialog::setMaximumHeight(int h) { DATA->max_size_.y = max(0, h); }
 
-void GuiDialog::setCloseable(bool enable) { DATA->is_closeable_ = 1; }
+void GuiDialog::setCloseable(bool enable) { DATA->is_closeable_ = true; }
 
-void GuiDialog::setMinimizable(bool enable) { DATA->is_minimizable_ = 1; }
+void GuiDialog::setMinimizable(bool enable) { DATA->is_minimizable_ = true; }
 
 void GuiDialog::setResizeable(bool horizontal, bool vertical) {
     DATA->is_horizontally_resizable_ = horizontal;

--- a/src/Core/GuiDialog.cpp
+++ b/src/Core/GuiDialog.cpp
@@ -409,7 +409,7 @@ void DialogData::FinishActions() {
 
 GuiDialog::GuiDialog(GuiContext* gui) : data_(new DialogData(gui, this)) {}
 
-GuiDialog::~GuiDialog() {}
+GuiDialog::~GuiDialog() = default;
 
 void GuiDialog::onUpdateSize() {}
 

--- a/src/Core/GuiDialog.h
+++ b/src/Core/GuiDialog.h
@@ -46,19 +46,19 @@ class DialogData : public GuiWidget {
     GuiDialog* dialog_ptr_;
     GuiContext* gui_;
 
-    uint32_t is_pinnable_ : 1;
-    uint32_t is_closeable_ : 1;
-    uint32_t is_minimizable_ : 1;
-    uint32_t is_horizontally_resizable_ : 1;
-    uint32_t is_vertically_resizable_ : 1;
+    bool is_pinnable_ : 1;
+    bool is_closeable_ : 1;
+    bool is_minimizable_ : 1;
+    bool is_horizontally_resizable_ : 1;
+    bool is_vertically_resizable_ : 1;
 
-    uint32_t request_close_ : 1;
-    uint32_t request_pin_ : 1;
-    uint32_t request_minimize_ : 1;
-    uint32_t request_move_to_top_ : 1;
+    bool request_close_ : 1;
+    bool request_pin_ : 1;
+    bool request_minimize_ : 1;
+    bool request_move_to_top_ : 1;
 
-    uint32_t pinned_state_ : 1;
-    uint32_t minimized_state_ : 1;
+    bool pinned_state_ : 1;
+    bool minimized_state_ : 1;
 
    private:
     friend class GuiDialog;

--- a/src/Core/GuiDraw.cpp
+++ b/src/Core/GuiDraw.cpp
@@ -23,7 +23,7 @@ GuiDrawGraphics* GD = nullptr;
 
 struct CanvasHelper {
     CanvasHelper(int w, int h, float r, float l)
-        : canvas(w * 2, h, l), myX(0), myY(0), myW(w), myH(h), myR(r) {
+        : canvas(w * 2, h, l),  myW(w), myH(h), myR(r) {
         canvas.setBlendMode(Canvas::BM_NONE);
     }
     void clear(int x, int y, float r, float l) {
@@ -42,7 +42,7 @@ struct CanvasHelper {
         tile.border = border;
     }
     Canvas canvas;
-    int myX, myY, myW, myH;
+    int myX = 0, myY = 0, myW, myH;
     float myR;
 };
 
@@ -62,7 +62,7 @@ static void CreateDialogTextures() {
     Canvas c2(16, 16, 0.05f);
     float lum[] = {0.05f, 0.35f, 0.2f};
     for (int i = 0; i < 3; ++i) {
-        float s = (float)i + 0.25f;
+        float s = static_cast<float>(i) + 0.25f;
         float x[] = {8 + s, 18, 18, 8 + s, 8 + s, s, 8 + s};
         float y[] = {-2, -2, 18, 18, 16, 8, 0};
         c2.setColor(lum[i]);
@@ -315,8 +315,8 @@ void GuiDraw::checkerboard(recti r, uint32_t color) {
     // Texture coordinates.
     float uv[8];
     uv[0] = uv[1] = uv[3] = uv[4] = 0;
-    uv[2] = uv[6] = (float)r.w / 16.0f;
-    uv[5] = uv[7] = (float)r.h / 16.0f;
+    uv[2] = uv[6] = static_cast<float>(r.w) / 16.0f;
+    uv[5] = uv[7] = static_cast<float>(r.h) / 16.0f;
 
     // Render quad.
     Renderer::setColor(color);

--- a/src/Core/GuiDraw.cpp
+++ b/src/Core/GuiDraw.cpp
@@ -23,7 +23,7 @@ GuiDrawGraphics* GD = nullptr;
 
 struct CanvasHelper {
     CanvasHelper(int w, int h, float r, float l)
-        : canvas(w * 2, h, l),  myW(w), myH(h), myR(r) {
+        : canvas(w * 2, h, l), myW(w), myH(h), myR(r) {
         canvas.setBlendMode(Canvas::BM_NONE);
     }
     void clear(int x, int y, float r, float l) {

--- a/src/Core/GuiManager.cpp
+++ b/src/Core/GuiManager.cpp
@@ -21,8 +21,9 @@ GuiManagerData* GM = nullptr;
 
 template <typename T>
 void Register(const char* id) {
-    GuiManager::registerWidgetClass(
-        id, [](GuiContext* gui) { return static_cast<GuiWidget*>(new T(gui)); });
+    GuiManager::registerWidgetClass(id, [](GuiContext* gui) {
+        return static_cast<GuiWidget*>(new T(gui));
+    });
 }
 
 static void RegisterCommonWidgetClasses() {

--- a/src/Core/GuiManager.cpp
+++ b/src/Core/GuiManager.cpp
@@ -22,7 +22,7 @@ GuiManagerData* GM = nullptr;
 template <typename T>
 void Register(const char* id) {
     GuiManager::registerWidgetClass(
-        id, [](GuiContext* gui) { return (GuiWidget*)(new T(gui)); });
+        id, [](GuiContext* gui) { return static_cast<GuiWidget*>(new T(gui)); });
 }
 
 static void RegisterCommonWidgetClasses() {

--- a/src/Core/ImageLoader.cpp
+++ b/src/Core/ImageLoader.cpp
@@ -1237,8 +1237,7 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y,
                     for (i = 0; i < z->s->img_x; ++i) out[i] = y[i];
                 else
                     for (i = 0; i < z->s->img_x; ++i)
-                        if (*out && *(out + 1))
-                            *out++ = y[i], *out++ = 255;
+                        if (*out && *(out + 1)) *out++ = y[i], *out++ = 255;
             }
         }
         stbi__cleanup_jpeg(z);

--- a/src/Core/ImageLoader.cpp
+++ b/src/Core/ImageLoader.cpp
@@ -214,7 +214,8 @@ static int stbi__getn(stbi__context *s, stbi_uc *buffer, int n) {
 
             memcpy(buffer, s->img_buffer, blen);
 
-            count = s->io->read(reinterpret_cast<char *>(buffer) + blen, n - blen);
+            count =
+                s->io->read(reinterpret_cast<char *>(buffer) + blen, n - blen);
             res = (count == (n - blen));
             s->img_buffer = s->img_buffer_end;
             return res;
@@ -317,7 +318,8 @@ static int stbi__build_huffman(stbi__huffman *h, int *count) {
     int i, j, k = 0, code;
     // build size list for each symbol (from JPEG spec)
     for (i = 0; i < 16; ++i)
-        for (j = 0; j < count[i]; ++j) h->size[k++] = static_cast<stbi_uc>(i + 1);
+        for (j = 0; j < count[i]; ++j)
+            h->size[k++] = static_cast<stbi_uc>(i + 1);
     h->size[k] = 0;
 
     // compute actual symbols (from jpeg spec)
@@ -327,7 +329,8 @@ static int stbi__build_huffman(stbi__huffman *h, int *count) {
         // compute delta to add to code to compute symbol id
         h->delta[j] = k - code;
         if (h->size[k] == j) {
-            while (h->size[k] == j) h->code[k++] = static_cast<stbi__uint16>(code++);
+            while (h->size[k] == j)
+                h->code[k++] = static_cast<stbi__uint16>(code++);
             if (code - 1 >= (1 << j))
                 return stbi__err("bad code lengths", "Corrupt JPEG");
         }
@@ -486,7 +489,8 @@ static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64],
         } else {
             k += r;
             // decode into unzigzag'd location
-            data[stbi__jpeg_dezigzag[k++]] = static_cast<short>(stbi__extend_receive(j, s));
+            data[stbi__jpeg_dezigzag[k++]] =
+                static_cast<short>(stbi__extend_receive(j, s));
         }
     } while (k < 64);
     return 1;
@@ -905,8 +909,8 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan) {
             return stbi__err("outofmem", "Out of memory");
         }
         // align blocks for installable-idct using mmx/sse
-        z->img_comp[i].data =
-            (stbi_uc *)(((size_t)z->img_comp[i].raw_data + 15) & ~15);
+        z->img_comp[i].data = reinterpret_cast<stbi_uc *>(
+            (reinterpret_cast<size_t>(z->img_comp[i].raw_data) + 15) & ~15);
         z->img_comp[i].linebuf = nullptr;
     }
 
@@ -1157,7 +1161,7 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y,
         int k;
         stbi__uint32 i, j;
         stbi_uc *output;
-        stbi_uc *coutput[4];
+        stbi_uc *coutput[4] = {nullptr, nullptr, nullptr, nullptr};
 
         stbi__resample res_comp[4];
 
@@ -1166,7 +1170,8 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y,
 
             // allocate line buffer big enough for upsampling off the edges
             // with upsample factor of 4
-            z->img_comp[k].linebuf = static_cast<stbi_uc *>(stbi__malloc(z->s->img_x + 3));
+            z->img_comp[k].linebuf =
+                static_cast<stbi_uc *>(stbi__malloc(z->s->img_x + 3));
             if (!z->img_comp[k].linebuf) {
                 stbi__cleanup_jpeg(z);
                 return stbi__errpuc("outofmem", "Out of memory");
@@ -1192,7 +1197,8 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y,
         }
 
         // can't error after this so, this is safe
-        output = static_cast<stbi_uc *>(stbi__malloc(n * z->s->img_x * z->s->img_y + 1));
+        output = static_cast<stbi_uc *>(
+            stbi__malloc(n * z->s->img_x * z->s->img_y + 1));
         if (!output) {
             stbi__cleanup_jpeg(z);
             return stbi__errpuc("outofmem", "Out of memory");
@@ -1231,7 +1237,8 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y,
                     for (i = 0; i < z->s->img_x; ++i) out[i] = y[i];
                 else
                     for (i = 0; i < z->s->img_x; ++i)
-                        *out++ = y[i], *out++ = 255;
+                        if (*out && *(out + 1))
+                            *out++ = y[i], *out++ = 255;
             }
         }
         stbi__cleanup_jpeg(z);
@@ -1383,7 +1390,7 @@ stbi_inline static int stbi__zhuffman_decode(stbi__zbuf *a, stbi__zhuffman *z) {
     int b, s, k;
     if (a->num_bits < 16) stbi__fill_bits(a);
     b = z->fast[a->code_buffer & STBI__ZFAST_MASK];
-    if (b < 0xffff) {
+    if (b < 288 && b >= 0) {
         s = z->size[b];
         a->code_buffer >>= s;
         a->num_bits -= s;
@@ -1484,6 +1491,7 @@ static int stbi__compute_huffman_codes(stbi__zbuf *a) {
     int hclen = stbi__zreceive(a, 4) + 4;
 
     memset(codelength_sizes, 0, sizeof(codelength_sizes));
+    memset(lencodes, 0, sizeof(lencodes));
     for (i = 0; i < hclen; ++i) {
         int s = stbi__zreceive(a, 3);
         codelength_sizes[length_dezigzag[i]] = static_cast<stbi_uc>(s);
@@ -1498,7 +1506,7 @@ static int stbi__compute_huffman_codes(stbi__zbuf *a) {
             lencodes[n++] = static_cast<stbi_uc>(c);
         else if (c == 16) {
             c = stbi__zreceive(a, 2) + 3;
-            memset(lencodes + n, lencodes[n - 1], c);
+            memset(lencodes + n, lencodes[std::max(0, n - 1)], c);
             n += c;
         } else if (c == 17) {
             c = stbi__zreceive(a, 3) + 3;
@@ -1524,8 +1532,8 @@ static int stbi__parse_uncomperssed_block(stbi__zbuf *a) {
     // drain the bit-packed data into header
     k = 0;
     while (a->num_bits > 0) {
-        header[k++] =
-            static_cast<stbi_uc>(a->code_buffer & 255);  // suppress MSVC run-time check
+        header[k++] = static_cast<stbi_uc>(
+            a->code_buffer & 255);  // suppress MSVC run-time check
         a->code_buffer >>= 8;
         a->num_bits -= 8;
     }
@@ -1622,8 +1630,9 @@ STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len,
     stbi__zbuf a;
     char *p = static_cast<char *>(stbi__malloc(initial_size));
     if (p == nullptr) return nullptr;
-    a.zbuffer = (stbi_uc *)buffer;
-    a.zbuffer_end = (stbi_uc *)buffer + len;
+    a.zbuffer = reinterpret_cast<stbi_uc *>(const_cast<char *>(buffer));
+    a.zbuffer_end =
+        reinterpret_cast<stbi_uc *>(const_cast<char *>(buffer)) + len;
     if (stbi__do_zlib(&a, p, initial_size, 1, 1)) {
         if (outlen) *outlen = static_cast<int>(a.zout - a.zout_start);
         return a.zout_start;
@@ -1646,8 +1655,9 @@ STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer,
     stbi__zbuf a;
     char *p = static_cast<char *>(stbi__malloc(initial_size));
     if (p == nullptr) return nullptr;
-    a.zbuffer = (stbi_uc *)buffer;
-    a.zbuffer_end = (stbi_uc *)buffer + len;
+    a.zbuffer = reinterpret_cast<stbi_uc *>(const_cast<char *>(buffer));
+    a.zbuffer_end =
+        reinterpret_cast<stbi_uc *>(const_cast<char *>(buffer)) + len;
     if (stbi__do_zlib(&a, p, initial_size, 1, parse_header)) {
         if (outlen) *outlen = static_cast<int>(a.zout - a.zout_start);
         return a.zout_start;
@@ -1859,7 +1869,8 @@ static int stbi__create_png_image(stbi__png *a, stbi_uc *raw,
                                           a->s->img_y);
 
     // de-interlacing
-    final = static_cast<stbi_uc *>(stbi__malloc(a->s->img_x * a->s->img_y * out_n));
+    final =
+        static_cast<stbi_uc *>(stbi__malloc(a->s->img_x * a->s->img_y * out_n));
     for (p = 0; p < 7; ++p) {
         int xorig[] = {0, 4, 0, 2, 0, 1, 0};
         int yorig[] = {0, 0, 4, 0, 2, 0, 1};
@@ -1954,7 +1965,8 @@ static int stbi__parse_png_file(stbi__png *z, int scan) {
     stbi_uc palette[1024], pal_img_n = 0;
     stbi_uc has_trans = 0, tc[3];
     stbi__uint32 ioff = 0, idata_limit = 0, i, pal_len = 0;
-    int first = 1, k, interlace = 0, is_iphone = 0;
+    int first = 1, k, interlace = 0;
+    bool is_iphone = false;
     stbi__context *s = z->s;
 
     z->expanded = nullptr;
@@ -1969,7 +1981,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan) {
         stbi__pngchunk c = stbi__get_chunk_header(s);
         switch (c.type) {
             case PNG_TYPE('C', 'g', 'B', 'I'):
-                is_iphone = 1;
+                is_iphone = false;
                 stbi__skip(s, c.length);
                 break;
             case PNG_TYPE('I', 'H', 'D', 'R'): {
@@ -2062,9 +2074,9 @@ static int stbi__parse_png_file(stbi__png *z, int scan) {
                         return stbi__err("bad tRNS len", "Corrupt PNG");
                     has_trans = 1;
                     for (k = 0; k < s->img_n; ++k)
-                        tc[k] =
-                            static_cast<stbi_uc>(stbi__get16be(s) &
-                                      255);  // non 8-bit images will be larger
+                        tc[k] = static_cast<stbi_uc>(
+                            stbi__get16be(s) &
+                            255);  // non 8-bit images will be larger
                 }
                 break;
             }
@@ -2099,10 +2111,10 @@ static int stbi__parse_png_file(stbi__png *z, int scan) {
                 if (scan != SCAN_load) return 1;
                 if (z->idata == nullptr)
                     return stbi__err("no IDAT", "Corrupt PNG");
-                z->expanded =
-                    reinterpret_cast<stbi_uc *>(stbi_zlib_decode_malloc_guesssize_headerflag(
-                        reinterpret_cast<char *>(z->idata), ioff, 16384, reinterpret_cast<int *>(&raw_len),
-                        !is_iphone));
+                z->expanded = reinterpret_cast<stbi_uc *>(
+                    stbi_zlib_decode_malloc_guesssize_headerflag(
+                        reinterpret_cast<char *>(z->idata), ioff, 16384,
+                        reinterpret_cast<int *>(&raw_len), !is_iphone));
                 if (z->expanded == nullptr) return 0;  // zlib should set error
                 free(z->idata);
                 z->idata = nullptr;
@@ -2302,8 +2314,8 @@ void ImageLoader::release(ImageLoader::Data &data) {
 Zlib::Data Zlib::deflate(const stbi_uc *data, int inSize) {
     int numBytes = 0;
     Zlib::Data out = {nullptr, 0};
-    out.data = reinterpret_cast<stbi_uc *>(stbi_zlib_decode_malloc(reinterpret_cast<const char *>(data), inSize,
-                                                  &numBytes));
+    out.data = reinterpret_cast<stbi_uc *>(stbi_zlib_decode_malloc(
+        reinterpret_cast<const char *>(data), inSize, &numBytes));
     if (out.data) out.numBytes = numBytes;
     return out;
 }

--- a/src/Core/ImageLoader.cpp
+++ b/src/Core/ImageLoader.cpp
@@ -148,7 +148,7 @@ static stbi_uc *stbi_load_main(stbi__context *s, int *x, int *y, int *comp) {
 stbi_uc *stbi_load_from_callbacks(const stbi_io_callbacks &clbk, int *x, int *y,
                                   int *comp) {
     stbi__context s;
-    stbi__start_callbacks(&s, (stbi_io_callbacks *)(&clbk));
+    stbi__start_callbacks(&s, const_cast<stbi_io_callbacks *>(&clbk));
     return stbi_load_main(&s, x, y, comp);
 }
 
@@ -160,7 +160,7 @@ stbi_uc *stbi_load_from_callbacks(const stbi_io_callbacks &clbk, int *x, int *y,
 enum { SCAN_load = 0, SCAN_type, SCAN_header };
 
 static void stbi__refill_buffer(stbi__context *s) {
-    int n = s->io->read((char *)s->buffer_start, s->buflen);
+    int n = s->io->read(reinterpret_cast<char *>(s->buffer_start), s->buflen);
     if (n == 0) {
         // at end of file, treat same as if from memory, but need to Handle case
         // where s->img_buffer isn't pointing to safe memory, e.g. 0-byte file
@@ -196,7 +196,7 @@ stbi_inline static int stbi__at_eof(stbi__context *s) {
 
 static void stbi__skip(stbi__context *s, int n) {
     if (s->io) {
-        int blen = (int)(s->img_buffer_end - s->img_buffer);
+        int blen = static_cast<int>(s->img_buffer_end - s->img_buffer);
         if (blen < n) {
             s->img_buffer = s->img_buffer_end;
             s->io->skip(n - blen);
@@ -208,13 +208,13 @@ static void stbi__skip(stbi__context *s, int n) {
 
 static int stbi__getn(stbi__context *s, stbi_uc *buffer, int n) {
     if (s->io) {
-        int blen = (int)(s->img_buffer_end - s->img_buffer);
+        int blen = static_cast<int>(s->img_buffer_end - s->img_buffer);
         if (blen < n) {
             int res, count;
 
             memcpy(buffer, s->img_buffer, blen);
 
-            count = s->io->read((char *)buffer + blen, n - blen);
+            count = s->io->read(reinterpret_cast<char *>(buffer) + blen, n - blen);
             res = (count == (n - blen));
             s->img_buffer = s->img_buffer_end;
             return res;
@@ -317,7 +317,7 @@ static int stbi__build_huffman(stbi__huffman *h, int *count) {
     int i, j, k = 0, code;
     // build size list for each symbol (from JPEG spec)
     for (i = 0; i < 16; ++i)
-        for (j = 0; j < count[i]; ++j) h->size[k++] = (stbi_uc)(i + 1);
+        for (j = 0; j < count[i]; ++j) h->size[k++] = static_cast<stbi_uc>(i + 1);
     h->size[k] = 0;
 
     // compute actual symbols (from jpeg spec)
@@ -327,7 +327,7 @@ static int stbi__build_huffman(stbi__huffman *h, int *count) {
         // compute delta to add to code to compute symbol id
         h->delta[j] = k - code;
         if (h->size[k] == j) {
-            while (h->size[k] == j) h->code[k++] = (stbi__uint16)(code++);
+            while (h->size[k] == j) h->code[k++] = static_cast<stbi__uint16>(code++);
             if (code - 1 >= (1 << j))
                 return stbi__err("bad code lengths", "Corrupt JPEG");
         }
@@ -345,7 +345,7 @@ static int stbi__build_huffman(stbi__huffman *h, int *count) {
             int c = h->code[i] << (FAST_BITS - s);
             int m = 1 << (FAST_BITS - s);
             for (j = 0; j < m; ++j) {
-                h->fast[c + j] = (stbi_uc)i;
+                h->fast[c + j] = static_cast<stbi_uc>(i);
             }
         }
     }
@@ -358,7 +358,7 @@ static void stbi__grow_buffer_unsafe(stbi__jpeg *j) {
         if (b == 0xff) {
             int c = stbi__get8(j->s);
             if (c != 0) {
-                j->marker = (stbi_uc)c;
+                j->marker = static_cast<stbi_uc>(c);
                 j->nomore = 1;
                 return;
             }
@@ -470,7 +470,7 @@ static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64],
     diff = t ? stbi__extend_receive(j, t) : 0;
     dc = j->img_comp[b].dc_pred + diff;
     j->img_comp[b].dc_pred = dc;
-    data[0] = (short)dc;
+    data[0] = static_cast<short>(dc);
 
     // decode AC components, see JPEG spec
     k = 1;
@@ -486,7 +486,7 @@ static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64],
         } else {
             k += r;
             // decode into unzigzag'd location
-            data[stbi__jpeg_dezigzag[k++]] = (short)stbi__extend_receive(j, s);
+            data[stbi__jpeg_dezigzag[k++]] = static_cast<short>(stbi__extend_receive(j, s));
         }
     } while (k < 64);
     return 1;
@@ -495,11 +495,11 @@ static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64],
 // take a -128..127 value and stbi__clamp it and convert to 0..255
 stbi_inline static stbi_uc stbi__clamp(int x) {
     // trick to use a single test to catch both cases
-    if ((stbi__uint32)x > 255) {
+    if (static_cast<stbi__uint32>(x) > 255) {
         if (x < 0) return 0;
         if (x > 255) return 255;
     }
-    return (stbi_uc)x;
+    return static_cast<stbi_uc>(x);
 }
 
 #define stbi__f2f(x) (int)(((x) * 4096 + 0.5))
@@ -789,7 +789,7 @@ static int stbi__process_scan_header(stbi__jpeg *z) {
     int i;
     int Ls = stbi__get16be(z->s);
     z->scan_n = stbi__get8(z->s);
-    if (z->scan_n < 1 || z->scan_n > 4 || z->scan_n > (int)z->s->img_n)
+    if (z->scan_n < 1 || z->scan_n > 4 || z->scan_n > z->s->img_n)
         return stbi__err("bad stbi__SOS component count", "Corrupt JPEG");
     if (Ls != 6 + 2 * z->scan_n)
         return stbi__err("bad stbi__SOS len", "Corrupt JPEG");
@@ -1082,27 +1082,27 @@ static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y,
         r >>= 16;
         g >>= 16;
         b >>= 16;
-        if ((unsigned)r > 255) {
+        if (static_cast<unsigned>(r) > 255) {
             if (r < 0)
                 r = 0;
             else
                 r = 255;
         }
-        if ((unsigned)g > 255) {
+        if (static_cast<unsigned>(g) > 255) {
             if (g < 0)
                 g = 0;
             else
                 g = 255;
         }
-        if ((unsigned)b > 255) {
+        if (static_cast<unsigned>(b) > 255) {
             if (b < 0)
                 b = 0;
             else
                 b = 255;
         }
-        out[0] = (stbi_uc)r;
-        out[1] = (stbi_uc)g;
-        out[2] = (stbi_uc)b;
+        out[0] = static_cast<stbi_uc>(r);
+        out[1] = static_cast<stbi_uc>(g);
+        out[2] = static_cast<stbi_uc>(b);
         out[3] = 255;
         out += step;
     }
@@ -1166,7 +1166,7 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y,
 
             // allocate line buffer big enough for upsampling off the edges
             // with upsample factor of 4
-            z->img_comp[k].linebuf = (stbi_uc *)stbi__malloc(z->s->img_x + 3);
+            z->img_comp[k].linebuf = static_cast<stbi_uc *>(stbi__malloc(z->s->img_x + 3));
             if (!z->img_comp[k].linebuf) {
                 stbi__cleanup_jpeg(z);
                 return stbi__errpuc("outofmem", "Out of memory");
@@ -1192,7 +1192,7 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y,
         }
 
         // can't error after this so, this is safe
-        output = (stbi_uc *)stbi__malloc(n * z->s->img_x * z->s->img_y + 1);
+        output = static_cast<stbi_uc *>(stbi__malloc(n * z->s->img_x * z->s->img_y + 1));
         if (!output) {
             stbi__cleanup_jpeg(z);
             return stbi__errpuc("outofmem", "Out of memory");
@@ -1308,8 +1308,8 @@ static int stbi__zbuild_huffman(stbi__zhuffman *z, stbi_uc *sizelist, int num) {
     code = 0;
     for (i = 1; i < 16; ++i) {
         next_code[i] = code;
-        z->firstcode[i] = (stbi__uint16)code;
-        z->firstsymbol[i] = (stbi__uint16)k;
+        z->firstcode[i] = static_cast<stbi__uint16>(code);
+        z->firstsymbol[i] = static_cast<stbi__uint16>(k);
         code = (code + sizes[i]);
         if (sizes[i])
             if (code - 1 >= (1 << i))
@@ -1323,12 +1323,12 @@ static int stbi__zbuild_huffman(stbi__zhuffman *z, stbi_uc *sizelist, int num) {
         int s = sizelist[i];
         if (s) {
             int c = next_code[s] - z->firstcode[s] + z->firstsymbol[s];
-            z->size[c] = (stbi_uc)s;
-            z->value[c] = (stbi__uint16)i;
+            z->size[c] = static_cast<stbi_uc>(s);
+            z->value[c] = static_cast<stbi__uint16>(i);
             if (s <= STBI__ZFAST_BITS) {
                 int k = stbi__bit_reverse(next_code[s], s);
                 while (k < (1 << STBI__ZFAST_BITS)) {
-                    z->fast[k] = (stbi__uint16)c;
+                    z->fast[k] = static_cast<stbi__uint16>(c);
                     k += (1 << s);
                 }
             }
@@ -1410,10 +1410,10 @@ static int stbi__zexpand(stbi__zbuf *z, int n)  // need to make room for n bytes
     int cur, limit;
     if (!z->z_expandable)
         return stbi__err("output buffer limit", "Corrupt PNG");
-    cur = (int)(z->zout - z->zout_start);
-    limit = (int)(z->zout_end - z->zout_start);
+    cur = static_cast<int>(z->zout - z->zout_start);
+    limit = static_cast<int>(z->zout_end - z->zout_start);
     while (cur + n > limit) limit *= 2;
-    q = (char *)realloc(z->zout_start, limit);
+    q = static_cast<char *>(realloc(z->zout_start, limit));
     if (q == nullptr) return stbi__err("outofmem", "Out of memory");
     z->zout_start = q;
     z->zout = q + cur;
@@ -1447,7 +1447,7 @@ static int stbi__parse_huffman_block(stbi__zbuf *a) {
                                  "Corrupt PNG");  // error in huffman codes
             if (a->zout >= a->zout_end)
                 if (!stbi__zexpand(a, 1)) return 0;
-            *a->zout++ = (char)z;
+            *a->zout++ = static_cast<char>(z);
         } else {
             stbi_uc *p;
             int len, dist;
@@ -1465,7 +1465,7 @@ static int stbi__parse_huffman_block(stbi__zbuf *a) {
                 return stbi__err("bad dist", "Corrupt PNG");
             if (a->zout + len > a->zout_end)
                 if (!stbi__zexpand(a, len)) return 0;
-            p = (stbi_uc *)(a->zout - dist);
+            p = reinterpret_cast<stbi_uc *>(a->zout - dist);
             while (len--) *a->zout++ = *p++;
         }
     }
@@ -1486,7 +1486,7 @@ static int stbi__compute_huffman_codes(stbi__zbuf *a) {
     memset(codelength_sizes, 0, sizeof(codelength_sizes));
     for (i = 0; i < hclen; ++i) {
         int s = stbi__zreceive(a, 3);
-        codelength_sizes[length_dezigzag[i]] = (stbi_uc)s;
+        codelength_sizes[length_dezigzag[i]] = static_cast<stbi_uc>(s);
     }
     if (!stbi__zbuild_huffman(&z_codelength, codelength_sizes, 19)) return 0;
 
@@ -1495,7 +1495,7 @@ static int stbi__compute_huffman_codes(stbi__zbuf *a) {
         int c = stbi__zhuffman_decode(a, &z_codelength);
         STBI_ASSERT(c >= 0 && c < 19);
         if (c < 16)
-            lencodes[n++] = (stbi_uc)c;
+            lencodes[n++] = static_cast<stbi_uc>(c);
         else if (c == 16) {
             c = stbi__zreceive(a, 2) + 3;
             memset(lencodes + n, lencodes[n - 1], c);
@@ -1525,7 +1525,7 @@ static int stbi__parse_uncomperssed_block(stbi__zbuf *a) {
     k = 0;
     while (a->num_bits > 0) {
         header[k++] =
-            (stbi_uc)(a->code_buffer & 255);  // suppress MSVC run-time check
+            static_cast<stbi_uc>(a->code_buffer & 255);  // suppress MSVC run-time check
         a->code_buffer >>= 8;
         a->num_bits -= 8;
     }
@@ -1565,7 +1565,7 @@ static int stbi__parse_zlib_header(stbi__zbuf *a) {
 
 // should statically initialize these for optimal thread safety
 static stbi_uc stbi__zdefault_length[288], stbi__zdefault_distance[32];
-static void stbi__init_zdefaults(void) {
+static void stbi__init_zdefaults() {
     int i;  // use <= to match clearly with spec
     for (i = 0; i <= 143; ++i) stbi__zdefault_length[i] = 8;
     for (; i <= 255; ++i) stbi__zdefault_length[i] = 9;
@@ -1620,12 +1620,12 @@ static int stbi__do_zlib(stbi__zbuf *a, char *obuf, int olen, int exp,
 STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len,
                                                 int initial_size, int *outlen) {
     stbi__zbuf a;
-    char *p = (char *)stbi__malloc(initial_size);
+    char *p = static_cast<char *>(stbi__malloc(initial_size));
     if (p == nullptr) return nullptr;
     a.zbuffer = (stbi_uc *)buffer;
     a.zbuffer_end = (stbi_uc *)buffer + len;
     if (stbi__do_zlib(&a, p, initial_size, 1, 1)) {
-        if (outlen) *outlen = (int)(a.zout - a.zout_start);
+        if (outlen) *outlen = static_cast<int>(a.zout - a.zout_start);
         return a.zout_start;
     } else {
         free(a.zout_start);
@@ -1644,12 +1644,12 @@ STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer,
                                                            int *outlen,
                                                            int parse_header) {
     stbi__zbuf a;
-    char *p = (char *)stbi__malloc(initial_size);
+    char *p = static_cast<char *>(stbi__malloc(initial_size));
     if (p == nullptr) return nullptr;
     a.zbuffer = (stbi_uc *)buffer;
     a.zbuffer_end = (stbi_uc *)buffer + len;
     if (stbi__do_zlib(&a, p, initial_size, 1, parse_header)) {
-        if (outlen) *outlen = (int)(a.zout - a.zout_start);
+        if (outlen) *outlen = static_cast<int>(a.zout - a.zout_start);
         return a.zout_start;
     } else {
         free(a.zout_start);
@@ -1730,7 +1730,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw,
     int k;
     int img_n = s->img_n;  // copy it into a local for later
     STBI_ASSERT(out_n == s->img_n || out_n == s->img_n + 1);
-    a->out = (stbi_uc *)stbi__malloc(x * y * out_n);
+    a->out = static_cast<stbi_uc *>(stbi__malloc(x * y * out_n));
     if (!a->out) return stbi__err("outofmem", "Out of memory");
     if (s->img_x == x && s->img_y == y) {
         if (raw_len != (img_n * x + 1) * y)
@@ -1859,7 +1859,7 @@ static int stbi__create_png_image(stbi__png *a, stbi_uc *raw,
                                           a->s->img_y);
 
     // de-interlacing
-    final = (stbi_uc *)stbi__malloc(a->s->img_x * a->s->img_y * out_n);
+    final = static_cast<stbi_uc *>(stbi__malloc(a->s->img_x * a->s->img_y * out_n));
     for (p = 0; p < 7; ++p) {
         int xorig[] = {0, 4, 0, 2, 0, 1, 0};
         int yorig[] = {0, 0, 4, 0, 2, 0, 1};
@@ -1918,7 +1918,7 @@ static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len,
     stbi__uint32 i, pixel_count = a->s->img_x * a->s->img_y;
     stbi_uc *p, *temp_out, *orig = a->out;
 
-    p = (stbi_uc *)stbi__malloc(pixel_count * pal_img_n);
+    p = static_cast<stbi_uc *>(stbi__malloc(pixel_count * pal_img_n));
     if (p == nullptr) return stbi__err("outofmem", "Out of memory");
 
     // between here and free(out) below, exitting would leak
@@ -2058,12 +2058,12 @@ static int stbi__parse_png_file(stbi__png *z, int scan) {
                 } else {
                     if (!(s->img_n & 1))
                         return stbi__err("tRNS with alpha", "Corrupt PNG");
-                    if (c.length != (stbi__uint32)s->img_n * 2)
+                    if (c.length != static_cast<stbi__uint32>(s->img_n) * 2)
                         return stbi__err("bad tRNS len", "Corrupt PNG");
                     has_trans = 1;
                     for (k = 0; k < s->img_n; ++k)
                         tc[k] =
-                            (stbi_uc)(stbi__get16be(s) &
+                            static_cast<stbi_uc>(stbi__get16be(s) &
                                       255);  // non 8-bit images will be larger
                 }
                 break;
@@ -2082,7 +2082,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan) {
                     if (idata_limit == 0)
                         idata_limit = c.length > 4096 ? c.length : 4096;
                     while (ioff + c.length > idata_limit) idata_limit *= 2;
-                    p = (stbi_uc *)realloc(z->idata, idata_limit);
+                    p = static_cast<stbi_uc *>(realloc(z->idata, idata_limit));
                     if (p == nullptr)
                         return stbi__err("outofmem", "Out of memory");
                     z->idata = p;
@@ -2100,9 +2100,9 @@ static int stbi__parse_png_file(stbi__png *z, int scan) {
                 if (z->idata == nullptr)
                     return stbi__err("no IDAT", "Corrupt PNG");
                 z->expanded =
-                    (stbi_uc *)stbi_zlib_decode_malloc_guesssize_headerflag(
-                        (char *)z->idata, ioff, 16384, (int *)&raw_len,
-                        !is_iphone);
+                    reinterpret_cast<stbi_uc *>(stbi_zlib_decode_malloc_guesssize_headerflag(
+                        reinterpret_cast<char *>(z->idata), ioff, 16384, reinterpret_cast<int *>(&raw_len),
+                        !is_iphone));
                 if (z->expanded == nullptr) return 0;  // zlib should set error
                 free(z->idata);
                 z->idata = nullptr;
@@ -2195,7 +2195,7 @@ static int stbi__png_test(stbi__context *s) {
         for (int x = w - 1; x >= 0; --x, s += inChannels, d += outChannels)
 
 static stbi_uc ComputeY(int r, int g, int b) {
-    return (stbi_uc)(((r * 77) + (g * 150) + (29 * b)) >> 8);
+    return static_cast<stbi_uc>(((r * 77) + (g * 150) + (29 * b)) >> 8);
 }
 
 static stbi_uc *ConvertImage(stbi_uc *data, int inChannels,
@@ -2204,7 +2204,7 @@ static stbi_uc *ConvertImage(stbi_uc *data, int inChannels,
     int outChannels = sFmtChannels[fmt];
     if (outChannels == inChannels) return data;
 
-    stbi_uc *out = (stbi_uc *)stbi__malloc(outChannels * w * h);
+    stbi_uc *out = static_cast<stbi_uc *>(stbi__malloc(outChannels * w * h));
     if (!out) {
         free(data);
         return stbi__errpuc("outofmem", "Out of memory");
@@ -2302,8 +2302,8 @@ void ImageLoader::release(ImageLoader::Data &data) {
 Zlib::Data Zlib::deflate(const stbi_uc *data, int inSize) {
     int numBytes = 0;
     Zlib::Data out = {nullptr, 0};
-    out.data = (stbi_uc *)stbi_zlib_decode_malloc((const char *)data, inSize,
-                                                  &numBytes);
+    out.data = reinterpret_cast<stbi_uc *>(stbi_zlib_decode_malloc(reinterpret_cast<const char *>(data), inSize,
+                                                  &numBytes));
     if (out.data) out.numBytes = numBytes;
     return out;
 }

--- a/src/Core/Input.cpp
+++ b/src/Core/Input.cpp
@@ -32,12 +32,12 @@ struct EventHeader {
 };
 
 static void SetTextInputPointers(TextInput& event) {
-    event.text = (char*)(&event + 1);
+    event.text = reinterpret_cast<char*>(&event + 1);
 }
 
 static void SetFileDropPointers(FileDrop& event) {
-    char** files = (char**)(&event + 1);
-    char* str = (char*)(files + event.count);
+    char** files = reinterpret_cast<char**>(&event + 1);
+    char* str = reinterpret_cast<char*>(files + event.count);
     for (int i = 0; i < event.count; ++i) {
         files[i] = str;
         str += strlen(str) + 1;
@@ -46,21 +46,21 @@ static void SetFileDropPointers(FileDrop& event) {
 }
 
 static EventHeader* CopyEvent(EventHeader* event) {
-    EventHeader* out = (EventHeader*)malloc(event->size);
+    EventHeader* out = static_cast<EventHeader*>(malloc(event->size));
     memcpy(out, event, event->size);
     if (out->type == ET_TEXT_INPUT) {
-        SetTextInputPointers(*(TextInput*)(out + 1));
+        SetTextInputPointers(*reinterpret_cast<TextInput*>(out + 1));
     } else if (out->type == ET_FILE_DROP) {
-        SetFileDropPointers(*(FileDrop*)(out + 1));
+        SetFileDropPointers(*reinterpret_cast<FileDrop*>(out + 1));
     }
     return out;
 }
 
 static char* AddEvent(void*& data, int type, int eventSize) {
     int numBytes = sizeof(EventHeader) + eventSize;
-    EventHeader* header = (EventHeader*)malloc(numBytes);
+    EventHeader* header = static_cast<EventHeader*>(malloc(numBytes));
     if (data) {
-        EventHeader* last = (EventHeader*)data;
+        EventHeader* last = static_cast<EventHeader*>(data);
         while (last->next) last = last->next;
         last->next = header;
     } else {
@@ -69,7 +69,7 @@ static char* AddEvent(void*& data, int type, int eventSize) {
     header->type = type;
     header->next = nullptr;
     header->size = numBytes;
-    return (char*)(header + 1);
+    return reinterpret_cast<char*>(header + 1);
 }
 
 template <typename T>
@@ -81,7 +81,7 @@ static void AddEventT(void*& data, int type, const T& eventData) {
 static char* WriteString(void* buffer, const char* str) {
     size_t size = strlen(str) + 1;
     memcpy(buffer, str, size);
-    return (char*)buffer + size;
+    return static_cast<char*>(buffer) + size;
 }
 
 template <typename T>
@@ -104,15 +104,15 @@ static void ValidateEvents(const void* data, const void* it = nullptr) {
 static char* ReadNextEvent(void* data, int type, char* it) {
     EventHeader* cur;
     if (it) {
-        cur = (EventHeader*)it;
+        cur = reinterpret_cast<EventHeader*>(it);
         cur = (cur - 1)->next;
     } else {
-        cur = (EventHeader*)data;
+        cur = static_cast<EventHeader*>(data);
     }
     while (cur && cur->type != type) {
         cur = cur->next;
     }
-    return cur ? (char*)(cur + 1) : nullptr;
+    return cur ? reinterpret_cast<char*>(cur + 1) : nullptr;
 }
 
 template <typename T>
@@ -135,7 +135,7 @@ InputEvents::InputEvents(const InputEvents& other) : data_(nullptr) {
 }
 
 void InputEvents::clear() {
-    EventHeader* header = (EventHeader*)data_;
+    EventHeader* header = static_cast<EventHeader*>(data_);
     while (header) {
         EventHeader* next = header->next;
         free(header);
@@ -148,7 +148,7 @@ void InputEvents::operator=(const InputEvents& other) {
     if (data_ != other.data_) {
         clear();
         EventHeader* last = nullptr;
-        for (EventHeader* it = (EventHeader*)other.data_; it; it = it->next) {
+        for (EventHeader* it = static_cast<EventHeader*>(other.data_); it; it = it->next) {
             EventHeader* event = CopyEvent(it);
             if (last) {
                 last->next = event;
@@ -208,7 +208,7 @@ void InputEvents::addTextInput(const char* text) {
 
     int numBytes = sizeof(TextInput) + strlen(text) + 1;
 
-    TextInput* event = (TextInput*)AddEvent(data_, ET_TEXT_INPUT, numBytes);
+    TextInput* event = reinterpret_cast<TextInput*>(AddEvent(data_, ET_TEXT_INPUT, numBytes));
     event->handled = false;
     event->text = nullptr;
     WriteString(event + 1, text);
@@ -225,13 +225,13 @@ void InputEvents::addFileDrop(const char* const* files, int count, int x,
     for (int i = 0; i < count; ++i) {
         numBytes += strlen(files[i]) + 1;
     }
-    FileDrop* event = (FileDrop*)AddEvent(data_, ET_FILE_DROP, numBytes);
+    FileDrop* event = reinterpret_cast<FileDrop*>(AddEvent(data_, ET_FILE_DROP, numBytes));
     event->handled = false;
     event->count = count;
     event->x = x;
     event->y = y;
 
-    char* p = (char*)(event + 1);
+    char* p = reinterpret_cast<char*>(event + 1);
     p += count * sizeof(char*);
     for (int i = 0; i < count; ++i) {
         p = WriteString(p, files[i]);
@@ -298,35 +298,35 @@ typedef void (*HandleEventFunction)(void*, InputHandler*);
 static void HandleDummyFunction(void* p, InputHandler* h) {}
 
 static void HandleMouseMove(void* p, InputHandler* h) {
-    h->onMouseMove(*(MouseMove*)p);
+    h->onMouseMove(*static_cast<MouseMove*>(p));
 }
 
 static void HandleMousePress(void* p, InputHandler* h) {
-    h->onMousePress(*(MousePress*)p);
+    h->onMousePress(*static_cast<MousePress*>(p));
 }
 
 static void HandleMouseRelease(void* p, InputHandler* h) {
-    h->onMouseRelease(*(MouseRelease*)p);
+    h->onMouseRelease(*static_cast<MouseRelease*>(p));
 }
 
 static void HandleMouseScroll(void* p, InputHandler* h) {
-    h->onMouseScroll(*(MouseScroll*)p);
+    h->onMouseScroll(*static_cast<MouseScroll*>(p));
 }
 
 static void HandleKeyPress(void* p, InputHandler* h) {
-    h->onKeyPress(*(KeyPress*)p);
+    h->onKeyPress(*static_cast<KeyPress*>(p));
 }
 
 static void HandleKeyRelease(void* p, InputHandler* h) {
-    h->onKeyRelease(*(KeyRelease*)p);
+    h->onKeyRelease(*static_cast<KeyRelease*>(p));
 }
 
 static void HandleTextInput(void* p, InputHandler* h) {
-    h->onTextInput(*(TextInput*)p);
+    h->onTextInput(*static_cast<TextInput*>(p));
 }
 
 static void HandleFileDrop(void* p, InputHandler* h) {
-    h->onFileDrop(*(FileDrop*)p);
+    h->onFileDrop(*static_cast<FileDrop*>(p));
 }
 
 static void HandleWindowInactive(void* p, InputHandler* h) {
@@ -341,7 +341,7 @@ static HandleEventFunction handleFunctions[NUM_EVENT_TYPES] = {
 };
 
 void InputHandler::handleInputs(InputEvents& events) {
-    for (EventHeader* it = (EventHeader*)events.data_; it; it = it->next) {
+    for (EventHeader* it = static_cast<EventHeader*>(events.data_); it; it = it->next) {
         handleFunctions[it->type](it + 1, this);
     }
 }

--- a/src/Core/Input.cpp
+++ b/src/Core/Input.cpp
@@ -92,7 +92,9 @@ static char* WriteData(char* buffer, T& data) {
 
 static void ValidateEvents(const void* data, const void* it = nullptr) {
     bool itFound = false;
-    for (EventHeader* event = (EventHeader*)data; event; event = event->next) {
+    for (EventHeader* event =
+             static_cast<EventHeader*>(const_cast<void*>(data));
+         event; event = event->next) {
         VortexAssert(event->type >= 1 && event->type < NUM_EVENT_TYPES);
         if (it && (event + 1) == it) itFound = true;
     }
@@ -117,7 +119,8 @@ static char* ReadNextEvent(void* data, int type, char* it) {
 
 template <typename T>
 bool ReadNext(void* data, int type, T*& it) {
-    it = (T*)ReadNextEvent(data, type, (char*)it);
+    it = reinterpret_cast<T*>(
+        ReadNextEvent(data, type, reinterpret_cast<char*>(it)));
     return it != nullptr;
 }
 
@@ -148,7 +151,8 @@ void InputEvents::operator=(const InputEvents& other) {
     if (data_ != other.data_) {
         clear();
         EventHeader* last = nullptr;
-        for (EventHeader* it = static_cast<EventHeader*>(other.data_); it; it = it->next) {
+        for (EventHeader* it = static_cast<EventHeader*>(other.data_); it;
+             it = it->next) {
             EventHeader* event = CopyEvent(it);
             if (last) {
                 last->next = event;
@@ -208,7 +212,8 @@ void InputEvents::addTextInput(const char* text) {
 
     int numBytes = sizeof(TextInput) + strlen(text) + 1;
 
-    TextInput* event = reinterpret_cast<TextInput*>(AddEvent(data_, ET_TEXT_INPUT, numBytes));
+    TextInput* event =
+        reinterpret_cast<TextInput*>(AddEvent(data_, ET_TEXT_INPUT, numBytes));
     event->handled = false;
     event->text = nullptr;
     WriteString(event + 1, text);
@@ -225,7 +230,8 @@ void InputEvents::addFileDrop(const char* const* files, int count, int x,
     for (int i = 0; i < count; ++i) {
         numBytes += strlen(files[i]) + 1;
     }
-    FileDrop* event = reinterpret_cast<FileDrop*>(AddEvent(data_, ET_FILE_DROP, numBytes));
+    FileDrop* event =
+        reinterpret_cast<FileDrop*>(AddEvent(data_, ET_FILE_DROP, numBytes));
     event->handled = false;
     event->count = count;
     event->x = x;
@@ -341,7 +347,8 @@ static HandleEventFunction handleFunctions[NUM_EVENT_TYPES] = {
 };
 
 void InputHandler::handleInputs(InputEvents& events) {
-    for (EventHeader* it = static_cast<EventHeader*>(events.data_); it; it = it->next) {
+    for (EventHeader* it = static_cast<EventHeader*>(events.data_); it;
+         it = it->next) {
         handleFunctions[it->type](it + 1, this);
     }
 }

--- a/src/Core/QuadBatch.cpp
+++ b/src/Core/QuadBatch.cpp
@@ -19,9 +19,11 @@ BatchSprite::BatchSprite(int w, int h) : width(w), height(h) {
 
 void BatchSprite::init(BatchSprite* spr, int count, int cols, int rows,
                        int sprW, int sprH) {
-    float du = 1.f / static_cast<float>(cols), dv = 1.f / static_cast<float>(rows);
+    float du = 1.f / static_cast<float>(cols),
+          dv = 1.f / static_cast<float>(rows);
     for (int i = 0; i != count; ++i) {
-        float u = static_cast<float>(i % cols) * du, v = static_cast<float>(i / cols) * dv;
+        float u = static_cast<float>(i % cols) * du,
+              v = static_cast<float>(i / cols) * dv;
         float uvs[8] = {u, v, u + du, v, u, v + dv, u + du, v + dv};
         memcpy(spr[i].uvs, uvs, sizeof(float) * 8);
         spr[i].width = sprW, spr[i].height = sprH;

--- a/src/Core/QuadBatch.cpp
+++ b/src/Core/QuadBatch.cpp
@@ -19,9 +19,9 @@ BatchSprite::BatchSprite(int w, int h) : width(w), height(h) {
 
 void BatchSprite::init(BatchSprite* spr, int count, int cols, int rows,
                        int sprW, int sprH) {
-    float du = 1.f / (float)cols, dv = 1.f / (float)rows;
+    float du = 1.f / static_cast<float>(cols), dv = 1.f / static_cast<float>(rows);
     for (int i = 0; i != count; ++i) {
-        float u = (float)(i % cols) * du, v = (float)(i / cols) * dv;
+        float u = static_cast<float>(i % cols) * du, v = static_cast<float>(i / cols) * dv;
         float uvs[8] = {u, v, u + du, v, u, v + dv, u + du, v + dv};
         memcpy(spr[i].uvs, uvs, sizeof(float) * 8);
         spr[i].width = sprW, spr[i].height = sprH;
@@ -74,11 +74,11 @@ void BatchSprite::draw(QuadBatchT* out, int x, int y, int y2) {
 }
 
 void BatchSprite::draw(QuadBatchTC* out, int x, int y) {
-    draw(out, x, y, (uint32_t)RGBAtoColor32(255, 255, 255, 255));
+    draw(out, x, y, RGBAtoColor32(255, 255, 255, 255));
 }
 
 void BatchSprite::draw(QuadBatchTC* out, int x, int y, uint8_t alpha) {
-    draw(out, x, y, (uint32_t)RGBAtoColor32(255, 255, 255, alpha));
+    draw(out, x, y, RGBAtoColor32(255, 255, 255, alpha));
 }
 
 void BatchSprite::draw(QuadBatchTC* out, int x, int y, uint32_t col) {
@@ -95,11 +95,11 @@ void BatchSprite::draw(QuadBatchTC* out, int x, int y, uint32_t col) {
 }
 
 void BatchSprite::draw(QuadBatchTC* out, int x, int y, int y2) {
-    draw(out, x, y, y2, (uint32_t)RGBAtoColor32(255, 255, 255, 255));
+    draw(out, x, y, y2, RGBAtoColor32(255, 255, 255, 255));
 }
 
 void BatchSprite::draw(QuadBatchTC* out, int x, int y, int y2, uint8_t alpha) {
-    draw(out, x, y, y2, (uint32_t)RGBAtoColor32(255, 255, 255, alpha));
+    draw(out, x, y, y2, RGBAtoColor32(255, 255, 255, alpha));
 }
 
 void BatchSprite::draw(QuadBatchTC* out, int x, int y, int y2, uint32_t col) {
@@ -115,18 +115,18 @@ void BatchSprite::draw(QuadBatchTC* out, int x, int y, int y2, uint32_t col) {
 
 void BatchSprite::draw(QuadBatchTC* out, float x, float y, float rotation,
                        float scale, uint32_t color) {
-    float rsin = (float)sin(rotation);
-    float rcos = (float)cos(rotation);
+    float rsin = sin(rotation);
+    float rcos = cos(rotation);
 
-    float w = (float)(width * DrawScale / 512) * scale;
-    float h = (float)(height * DrawScale / 512) * scale;
+    float w = static_cast<float>(width * DrawScale / 512) * scale;
+    float h = static_cast<float>(height * DrawScale / 512) * scale;
     const float xy[8] = {-w, -h, +w, -h, -w, +h, +w, +h};
 
     out->push();
     int* vp = out->pos;
     for (int i = 0, j = 1; i < 8; i += 2, j += 2) {
-        vp[i] = (int)(x + xy[i] * rcos - xy[j] * rsin);
-        vp[j] = (int)(y + xy[i] * rsin + xy[j] * rcos);
+        vp[i] = static_cast<int>(x + xy[i] * rcos - xy[j] * rsin);
+        vp[j] = static_cast<int>(y + xy[i] * rsin + xy[j] * rcos);
     }
 
     uint32_t vc[4] = {color, color, color, color};

--- a/src/Core/Renderer.cpp
+++ b/src/Core/Renderer.cpp
@@ -47,7 +47,7 @@ static RendererInstance* RI;
 // Creation/destruction.
 
 static void createBatchData() {
-    RI->batchPos = (uint8_t*)malloc(VB_POS_SIZE + VB_UVS_SIZE + VB_COL_SIZE);
+    RI->batchPos = static_cast<uint8_t*>(malloc(VB_POS_SIZE + VB_UVS_SIZE + VB_COL_SIZE));
     RI->batchUvs = RI->batchPos + VB_POS_SIZE;
     RI->batchCol = RI->batchUvs + VB_UVS_SIZE;
     RI->quadsLeft = BATCH_QUAD_LIMIT;
@@ -55,7 +55,7 @@ static void createBatchData() {
 
 static void createQuadIndices() {
     RI->quadIndices =
-        (uint32_t*)malloc(sizeof(uint32_t) * BATCH_QUAD_LIMIT * 6);
+        static_cast<uint32_t*>(malloc(sizeof(uint32_t) * BATCH_QUAD_LIMIT * 6));
     for (uint32_t *p = RI->quadIndices, i = 0; i < BATCH_QUAD_LIMIT * 4;
          i += 4) {
         *p = i + 0;
@@ -187,7 +187,7 @@ void Renderer::setColor(colorf color) {
 }
 
 void Renderer::setColor(uint32_t color) {
-    uint8_t* c = (uint8_t*)&color;
+    uint8_t* c = reinterpret_cast<uint8_t*>(&color);
     glColor4ub(c[0], c[1], c[2], c[3]);
 }
 
@@ -344,20 +344,20 @@ void Renderer::drawTris(int numTris, const uint32_t* indices, const int* pos,
 // Batch rendering.
 
 static void FlushIC() {
-    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft, (int*)RI->batchPos,
-                        (uint32_t*)RI->batchCol);
+    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft, reinterpret_cast<int*>(RI->batchPos),
+                        reinterpret_cast<uint32_t*>(RI->batchCol));
     RI->quadsLeft = BATCH_QUAD_LIMIT;
 }
 
 static void FlushIT() {
-    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft, (int*)RI->batchPos,
-                        (float*)RI->batchUvs);
+    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft, reinterpret_cast<int*>(RI->batchPos),
+                        reinterpret_cast<float*>(RI->batchUvs));
     RI->quadsLeft = BATCH_QUAD_LIMIT;
 }
 
 static void FlushITC() {
-    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft, (int*)RI->batchPos,
-                        (float*)RI->batchUvs, (uint32_t*)RI->batchCol);
+    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft, reinterpret_cast<int*>(RI->batchPos),
+                        reinterpret_cast<float*>(RI->batchUvs), reinterpret_cast<uint32_t*>(RI->batchCol));
     RI->quadsLeft = BATCH_QUAD_LIMIT;
 }
 
@@ -366,8 +366,8 @@ void QuadBatchC::push(int numQuads) {
     int offset = BATCH_QUAD_LIMIT - RI->quadsLeft;
     RI->quadsLeft -= numQuads;
 
-    pos = (int*)(RI->batchPos + offset * VB_POS_STRIDE);
-    col = (uint32_t*)(RI->batchCol + offset * VB_COL_STRIDE);
+    pos = reinterpret_cast<int*>(RI->batchPos + offset * VB_POS_STRIDE);
+    col = reinterpret_cast<uint32_t*>(RI->batchCol + offset * VB_COL_STRIDE);
 }
 
 void QuadBatchT::push(int numQuads) {
@@ -375,8 +375,8 @@ void QuadBatchT::push(int numQuads) {
     int offset = BATCH_QUAD_LIMIT - RI->quadsLeft;
     RI->quadsLeft -= numQuads;
 
-    pos = (int*)(RI->batchPos + offset * VB_POS_STRIDE);
-    uvs = (float*)(RI->batchUvs + offset * VB_UVS_STRIDE);
+    pos = reinterpret_cast<int*>(RI->batchPos + offset * VB_POS_STRIDE);
+    uvs = reinterpret_cast<float*>(RI->batchUvs + offset * VB_UVS_STRIDE);
 }
 
 void QuadBatchTC::push(int numQuads) {
@@ -384,9 +384,9 @@ void QuadBatchTC::push(int numQuads) {
     int offset = BATCH_QUAD_LIMIT - RI->quadsLeft;
     RI->quadsLeft -= numQuads;
 
-    pos = (int*)(RI->batchPos + offset * VB_POS_STRIDE);
-    uvs = (float*)(RI->batchUvs + offset * VB_UVS_STRIDE);
-    col = (uint32_t*)(RI->batchCol + offset * VB_COL_STRIDE);
+    pos = reinterpret_cast<int*>(RI->batchPos + offset * VB_POS_STRIDE);
+    uvs = reinterpret_cast<float*>(RI->batchUvs + offset * VB_UVS_STRIDE);
+    col = reinterpret_cast<uint32_t*>(RI->batchCol + offset * VB_COL_STRIDE);
 }
 
 void QuadBatchC::flush() { FlushIC(); }
@@ -396,15 +396,15 @@ void QuadBatchT::flush() { FlushIT(); }
 void QuadBatchTC::flush() { FlushITC(); }
 
 QuadBatchC Renderer::batchC() {
-    return {(int*)RI->batchPos, (uint32_t*)RI->batchCol};
+    return {reinterpret_cast<int*>(RI->batchPos), reinterpret_cast<uint32_t*>(RI->batchCol)};
 }
 
 QuadBatchT Renderer::batchT() {
-    return {(int*)RI->batchPos, (float*)RI->batchUvs};
+    return {reinterpret_cast<int*>(RI->batchPos), reinterpret_cast<float*>(RI->batchUvs)};
 }
 
 QuadBatchTC Renderer::batchTC() {
-    return {(int*)RI->batchPos, (float*)RI->batchUvs, (uint32_t*)RI->batchCol};
+    return {reinterpret_cast<int*>(RI->batchPos), reinterpret_cast<float*>(RI->batchUvs), reinterpret_cast<uint32_t*>(RI->batchCol)};
 }
 
 const TileRect& Renderer::getRoundedBox() { return RI->roundedBox; }

--- a/src/Core/Renderer.cpp
+++ b/src/Core/Renderer.cpp
@@ -47,7 +47,8 @@ static RendererInstance* RI;
 // Creation/destruction.
 
 static void createBatchData() {
-    RI->batchPos = static_cast<uint8_t*>(malloc(VB_POS_SIZE + VB_UVS_SIZE + VB_COL_SIZE));
+    RI->batchPos =
+        static_cast<uint8_t*>(malloc(VB_POS_SIZE + VB_UVS_SIZE + VB_COL_SIZE));
     RI->batchUvs = RI->batchPos + VB_POS_SIZE;
     RI->batchCol = RI->batchUvs + VB_UVS_SIZE;
     RI->quadsLeft = BATCH_QUAD_LIMIT;
@@ -240,7 +241,7 @@ static int FlushQuads(GLint vertexType, const void* pos,
                       const uint32_t* col = nullptr) {
     glDrawElements(GL_TRIANGLES, BATCH_QUAD_LIMIT * 6, GL_UNSIGNED_INT,
                    RI->quadIndices);
-    pos = (int*)pos + BATCH_QUAD_LIMIT * 8;
+    pos = reinterpret_cast<const int*>(pos) + BATCH_QUAD_LIMIT * 8;
     glVertexPointer(2, vertexType, 0, pos);
     if (uvs) {
         uvs += BATCH_QUAD_LIMIT * 8;
@@ -344,20 +345,24 @@ void Renderer::drawTris(int numTris, const uint32_t* indices, const int* pos,
 // Batch rendering.
 
 static void FlushIC() {
-    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft, reinterpret_cast<int*>(RI->batchPos),
+    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft,
+                        reinterpret_cast<int*>(RI->batchPos),
                         reinterpret_cast<uint32_t*>(RI->batchCol));
     RI->quadsLeft = BATCH_QUAD_LIMIT;
 }
 
 static void FlushIT() {
-    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft, reinterpret_cast<int*>(RI->batchPos),
+    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft,
+                        reinterpret_cast<int*>(RI->batchPos),
                         reinterpret_cast<float*>(RI->batchUvs));
     RI->quadsLeft = BATCH_QUAD_LIMIT;
 }
 
 static void FlushITC() {
-    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft, reinterpret_cast<int*>(RI->batchPos),
-                        reinterpret_cast<float*>(RI->batchUvs), reinterpret_cast<uint32_t*>(RI->batchCol));
+    Renderer::drawQuads(BATCH_QUAD_LIMIT - RI->quadsLeft,
+                        reinterpret_cast<int*>(RI->batchPos),
+                        reinterpret_cast<float*>(RI->batchUvs),
+                        reinterpret_cast<uint32_t*>(RI->batchCol));
     RI->quadsLeft = BATCH_QUAD_LIMIT;
 }
 
@@ -396,15 +401,19 @@ void QuadBatchT::flush() { FlushIT(); }
 void QuadBatchTC::flush() { FlushITC(); }
 
 QuadBatchC Renderer::batchC() {
-    return {reinterpret_cast<int*>(RI->batchPos), reinterpret_cast<uint32_t*>(RI->batchCol)};
+    return {reinterpret_cast<int*>(RI->batchPos),
+            reinterpret_cast<uint32_t*>(RI->batchCol)};
 }
 
 QuadBatchT Renderer::batchT() {
-    return {reinterpret_cast<int*>(RI->batchPos), reinterpret_cast<float*>(RI->batchUvs)};
+    return {reinterpret_cast<int*>(RI->batchPos),
+            reinterpret_cast<float*>(RI->batchUvs)};
 }
 
 QuadBatchTC Renderer::batchTC() {
-    return {reinterpret_cast<int*>(RI->batchPos), reinterpret_cast<float*>(RI->batchUvs), reinterpret_cast<uint32_t*>(RI->batchCol)};
+    return {reinterpret_cast<int*>(RI->batchPos),
+            reinterpret_cast<float*>(RI->batchUvs),
+            reinterpret_cast<uint32_t*>(RI->batchCol)};
 }
 
 const TileRect& Renderer::getRoundedBox() { return RI->roundedBox; }

--- a/src/Core/Shader.cpp
+++ b/src/Core/Shader.cpp
@@ -171,7 +171,7 @@ static GLuint Link(GLuint vert, GLuint frag, std::string& log) {
             glGetProgramiv(program, GL_INFO_LOG_LENGTH, &size);
             log.clear();
             log.resize(size);
-            glGetProgramInfoLog(program, size, 0, &log[0]);
+            glGetProgramInfoLog(program, size, nullptr, &log[0]);
         }
         glDeleteProgram(program);
         program = 0;

--- a/src/Core/Slot.cpp
+++ b/src/Core/Slot.cpp
@@ -10,8 +10,8 @@ namespace Vortex {
 namespace {
 
 struct BaseValue {
-    BaseValue() : refs(1) {}
-    virtual ~BaseValue() {}
+    BaseValue()  = default;
+    virtual ~BaseValue() = default;
 
     virtual void set(int v) {}
     virtual void set(double v) {}
@@ -21,138 +21,138 @@ struct BaseValue {
     virtual double getf() const = 0;
     virtual bool getb() const = 0;
 
-    int refs;
+    int refs = 1;
 };
 
 // Self-contained values.
 
 struct IntValue : public BaseValue {
-    IntValue() : val(0) {}
+    IntValue()  = default;
 
-    void set(int v) { val = v; }
-    void set(double v) { val = (int)lround(v); }
-    void set(bool v) { val = v; }
+    void set(int v) override { val = v; }
+    void set(double v) override { val = static_cast<int>(lround(v)); }
+    void set(bool v) override { val = v; }
 
-    int geti() const { return val; }
-    double getf() const { return val; }
-    bool getb() const { return val != 0; }
+    int geti() const override { return val; }
+    double getf() const override { return val; }
+    bool getb() const override { return val != 0; }
 
-    int val;
+    int val = 0;
 };
 
 struct DoubleValue : public BaseValue {
-    DoubleValue() : val(0) {}
+    DoubleValue()  = default;
 
-    void set(int v) { val = v; }
-    void set(double v) { val = v; }
-    void set(bool v) { val = v; }
+    void set(int v) override { val = v; }
+    void set(double v) override { val = v; }
+    void set(bool v) override { val = v; }
 
-    int geti() const { return (int)val; }
-    double getf() const { return val; }
-    bool getb() const { return val != 0; }
+    int geti() const override { return static_cast<int>(val); }
+    double getf() const override { return val; }
+    bool getb() const override { return val != 0; }
 
-    double val;
+    double val = 0;
 };
 
 struct BoolValue : public BaseValue {
-    BoolValue() : val(false) {}
+    BoolValue()  = default;
 
-    void set(int v) { val = (v != 0); }
-    void set(double v) { val = (v != 0); }
-    void set(bool v) { val = v; }
+    void set(int v) override { val = (v != 0); }
+    void set(double v) override { val = (v != 0); }
+    void set(bool v) override { val = v; }
 
-    int geti() const { return val; }
-    double getf() const { return val; }
-    bool getb() const { return val; }
+    int geti() const override { return val; }
+    double getf() const override { return val; }
+    bool getb() const override { return val; }
 
-    bool val;
+    bool val = false;
 };
 
 // Values by reference.
 
 template <typename T>
 struct IntPtr : public BaseValue {
-    IntPtr(T* v) : val(v) {}
+    explicit IntPtr(T* v) : val(v) {}
 
-    void set(int v) { *val = (T)v; }
-    void set(double v) { *val = (T)lround(v); }
-    void set(bool v) { *val = v; }
+    void set(int v) override { *val = (T)v; }
+    void set(double v) override { *val = (T)lround(v); }
+    void set(bool v) override { *val = v; }
 
-    int geti() const { return (int)*val; }
-    double getf() const { return (double)*val; }
-    bool getb() const { return *val != 0; }
+    int geti() const override { return (int)*val; }
+    double getf() const override { return (double)*val; }
+    bool getb() const override { return *val != 0; }
 
     T* val;
 };
 
 template <typename T>
 struct ConstIntPtr : public BaseValue {
-    ConstIntPtr(const T* v) : val(v) {}
+    explicit ConstIntPtr(const T* v) : val(v) {}
 
-    int geti() const { return (int)*val; }
-    double getf() const { return (double)*val; }
-    bool getb() const { return *val != 0; }
+    int geti() const override { return (int)*val; }
+    double getf() const override { return (double)*val; }
+    bool getb() const override { return *val != 0; }
 
     const T* val;
 };
 
 template <typename T>
 struct FloatPtr : public BaseValue {
-    FloatPtr(T* v) : val(v) {}
+    explicit FloatPtr(T* v) : val(v) {}
 
-    void set(int v) { *val = (T)v; }
-    void set(double v) { *val = (T)v; }
-    void set(bool v) { *val = v; }
+    void set(int v) override { *val = (T)v; }
+    void set(double v) override { *val = (T)v; }
+    void set(bool v) override { *val = v; }
 
-    int geti() const { return (int)lround(*val); }
-    double getf() const { return (double)*val; }
-    bool getb() const { return *val != 0; }
+    int geti() const override { return (int)lround(*val); }
+    double getf() const override { return (double)*val; }
+    bool getb() const override { return *val != 0; }
 
     T* val;
 };
 
 template <typename T>
 struct ConstFloatPtr : public BaseValue {
-    ConstFloatPtr(const T* v) : val(v) {}
+    explicit ConstFloatPtr(const T* v) : val(v) {}
 
-    int geti() const { return (int)lround(*val); }
-    double getf() const { return (double)*val; }
-    bool getb() const { return *val != 0; }
+    int geti() const override { return (int)lround(*val); }
+    double getf() const override { return (double)*val; }
+    bool getb() const override { return *val != 0; }
 
     const T* val;
 };
 
 struct BoolPtr : public BaseValue {
-    BoolPtr(bool* v) : val(v) {}
+    explicit BoolPtr(bool* v) : val(v) {}
 
-    void set(int v) { *val = v != 0; }
-    void set(double v) { *val = v != 0; }
-    void set(bool v) { *val = v; }
+    void set(int v) override { *val = v != 0; }
+    void set(double v) override { *val = v != 0; }
+    void set(bool v) override { *val = v; }
 
-    int geti() const { return (int)*val; }
-    double getf() const { return (double)*val; }
-    bool getb() const { return *val; }
+    int geti() const override { return static_cast<int>(*val); }
+    double getf() const override { return static_cast<double>(*val); }
+    bool getb() const override { return *val; }
 
     bool* val;
 };
 
 struct ConstBoolPtr : public BaseValue {
-    ConstBoolPtr(const bool* v) : val(v) {}
+    explicit ConstBoolPtr(const bool* v) : val(v) {}
 
-    int geti() const { return (int)*val; }
-    double getf() const { return (double)*val; }
-    bool getb() const { return *val; }
+    int geti() const override { return static_cast<int>(*val); }
+    double getf() const override { return static_cast<double>(*val); }
+    bool getb() const override { return *val; }
 
     const bool* val;
 };
 
 static void ReferenceVal(void* data) {
-    BaseValue* v = (BaseValue*)data;
+    BaseValue* v = static_cast<BaseValue*>(data);
     ++v->refs;
 }
 
 static void ReleaseVal(void* data) {
-    BaseValue* v = (BaseValue*)data;
+    BaseValue* v = static_cast<BaseValue*>(data);
     if (!--v->refs) delete v;
 }
 
@@ -246,48 +246,48 @@ void ValueSlot::bind(bool* v) {
 
 IntSlot::IntSlot() { data_ = new IntValue; }
 
-IntSlot::~IntSlot() {}
+IntSlot::~IntSlot() = default;
 
 void IntSlot::unbind() {
     ReleaseVal(data_);
     data_ = new IntValue;
 }
 
-void IntSlot::set(int v) { ((BaseValue*)data_)->set(v); }
+void IntSlot::set(int v) { (static_cast<BaseValue*>(data_))->set(v); }
 
-int IntSlot::get() const { return ((BaseValue*)data_)->geti(); }
+int IntSlot::get() const { return (static_cast<BaseValue*>(data_))->geti(); }
 
 // ================================================================================================
 // FloatSlot :: implementation.
 
 FloatSlot::FloatSlot() { data_ = new DoubleValue; }
 
-FloatSlot::~FloatSlot() {}
+FloatSlot::~FloatSlot() = default;
 
 void FloatSlot::unbind() {
     ReleaseVal(data_);
     data_ = new DoubleValue;
 }
 
-void FloatSlot::set(double v) { ((BaseValue*)data_)->set(v); }
+void FloatSlot::set(double v) { (static_cast<BaseValue*>(data_))->set(v); }
 
-double FloatSlot::get() const { return ((BaseValue*)data_)->getf(); }
+double FloatSlot::get() const { return (static_cast<BaseValue*>(data_))->getf(); }
 
 // ================================================================================================
 // BoolSlot :: implementation.
 
 BoolSlot::BoolSlot() { data_ = new BoolValue; }
 
-BoolSlot::~BoolSlot() {}
+BoolSlot::~BoolSlot() = default;
 
 void BoolSlot::unbind() {
     ReleaseVal(data_);
     data_ = new BoolValue;
 }
 
-void BoolSlot::set(bool v) { ((BaseValue*)data_)->set(v); }
+void BoolSlot::set(bool v) { (static_cast<BaseValue*>(data_))->set(v); }
 
-bool BoolSlot::get() const { return ((BaseValue*)data_)->getb(); }
+bool BoolSlot::get() const { return (static_cast<BaseValue*>(data_))->getb(); }
 
 // ================================================================================================
 // TextSlot :: helper classes.
@@ -295,47 +295,47 @@ bool BoolSlot::get() const { return ((BaseValue*)data_)->getb(); }
 namespace {
 
 struct BaseStr {
-    BaseStr() : refs(1) {}
-    virtual ~BaseStr() {}
+    BaseStr()  = default;
+    virtual ~BaseStr() = default;
 
     virtual void set(const char* s) {}
     virtual const char* get() const = 0;
 
-    int refs;
+    int refs = 1;
 };
 
 struct StringVal : public BaseStr {
-    void set(const char* s) { str = s; }
-    const char* get() const { return str.c_str(); }
+    void set(const char* s) override { str = s; }
+    const char* get() const override { return str.c_str(); }
     std::string str;
 };
 
 struct ConstCharPtr : public BaseStr {
-    ConstCharPtr(const char* s) : str(s) {}
-    const char* get() const { return str; }
+    explicit ConstCharPtr(const char* s) : str(s) {}
+    const char* get() const override { return str; }
     const char* str;
 };
 
 struct StringPtr : public BaseStr {
-    StringPtr(std::string* s) : str(s) {}
-    void set(const char* s) { *str = s; }
-    const char* get() const { return str->c_str(); }
+    explicit StringPtr(std::string* s) : str(s) {}
+    void set(const char* s) override { *str = s; }
+    const char* get() const override { return str->c_str(); }
     std::string* str;
 };
 
 struct ConstStringPtr : public BaseStr {
-    ConstStringPtr(const std::string* s) : str(s) {}
-    const char* get() const { return str->c_str(); }
+    explicit ConstStringPtr(const std::string* s) : str(s) {}
+    const char* get() const override { return str->c_str(); }
     const std::string* str;
 };
 
 static void ReferenceStr(void* data) {
-    BaseStr* str = (BaseStr*)data;
+    BaseStr* str = static_cast<BaseStr*>(data);
     ++str->refs;
 }
 
 static void ReleaseStr(void* data) {
-    BaseStr* str = (BaseStr*)data;
+    BaseStr* str = static_cast<BaseStr*>(data);
     if (--str->refs == 0) delete str;
 }
 
@@ -374,33 +374,33 @@ void TextSlot::bind(std::string* str) {
     data_ = new StringPtr(str);
 }
 
-void TextSlot::set(const char* str) { ((BaseStr*)data_)->set(str); }
+void TextSlot::set(const char* str) { (static_cast<BaseStr*>(data_))->set(str); }
 
 void TextSlot::set(const std::string& str) {
-    ((BaseStr*)data_)->set(str.c_str());
+    (static_cast<BaseStr*>(data_))->set(str.c_str());
 }
 
-const char* TextSlot::get() const { return ((BaseStr*)data_)->get(); }
+const char* TextSlot::get() const { return (static_cast<BaseStr*>(data_))->get(); }
 
 // ================================================================================================
 // CallSlot :: implementation.
 
 CallSlot::CallSlot() : data_(nullptr) {}
 
-CallSlot::~CallSlot() { delete (Functor::Generic*)data_; }
+CallSlot::~CallSlot() { delete static_cast<Functor::Generic*>(data_); }
 
 void CallSlot::unbind() {
-    delete (Functor::Generic*)data_;
+    delete static_cast<Functor::Generic*>(data_);
     data_ = nullptr;
 }
 
 void CallSlot::bind(Functor::Generic* fun) {
-    delete (Functor::Generic*)data_;
+    delete static_cast<Functor::Generic*>(data_);
     data_ = fun;
 }
 
 void CallSlot::call() {
-    if (data_) ((Functor::Generic*)data_)->exec();
+    if (data_) (static_cast<Functor::Generic*>(data_))->exec();
 }
 
 };  // namespace Vortex

--- a/src/Core/Slot.cpp
+++ b/src/Core/Slot.cpp
@@ -10,7 +10,7 @@ namespace Vortex {
 namespace {
 
 struct BaseValue {
-    BaseValue()  = default;
+    BaseValue() = default;
     virtual ~BaseValue() = default;
 
     virtual void set(int v) {}
@@ -27,7 +27,7 @@ struct BaseValue {
 // Self-contained values.
 
 struct IntValue : public BaseValue {
-    IntValue()  = default;
+    IntValue() = default;
 
     void set(int v) override { val = v; }
     void set(double v) override { val = static_cast<int>(lround(v)); }
@@ -41,7 +41,7 @@ struct IntValue : public BaseValue {
 };
 
 struct DoubleValue : public BaseValue {
-    DoubleValue()  = default;
+    DoubleValue() = default;
 
     void set(int v) override { val = v; }
     void set(double v) override { val = v; }
@@ -55,7 +55,7 @@ struct DoubleValue : public BaseValue {
 };
 
 struct BoolValue : public BaseValue {
-    BoolValue()  = default;
+    BoolValue() = default;
 
     void set(int v) override { val = (v != 0); }
     void set(double v) override { val = (v != 0); }
@@ -74,12 +74,12 @@ template <typename T>
 struct IntPtr : public BaseValue {
     explicit IntPtr(T* v) : val(v) {}
 
-    void set(int v) override { *val = (T)v; }
-    void set(double v) override { *val = (T)lround(v); }
+    void set(int v) override { *val = static_cast<T>(v); }
+    void set(double v) override { *val = static_cast<T>(lround(v)); }
     void set(bool v) override { *val = v; }
 
-    int geti() const override { return (int)*val; }
-    double getf() const override { return (double)*val; }
+    int geti() const override { return static_cast<int>(*val); }
+    double getf() const override { return static_cast<double>(*val); }
     bool getb() const override { return *val != 0; }
 
     T* val;
@@ -89,8 +89,8 @@ template <typename T>
 struct ConstIntPtr : public BaseValue {
     explicit ConstIntPtr(const T* v) : val(v) {}
 
-    int geti() const override { return (int)*val; }
-    double getf() const override { return (double)*val; }
+    int geti() const override { return static_cast<int>(*val); }
+    double getf() const override { return static_cast<double>(*val); }
     bool getb() const override { return *val != 0; }
 
     const T* val;
@@ -100,12 +100,12 @@ template <typename T>
 struct FloatPtr : public BaseValue {
     explicit FloatPtr(T* v) : val(v) {}
 
-    void set(int v) override { *val = (T)v; }
-    void set(double v) override { *val = (T)v; }
+    void set(int v) override { *val = static_cast<T>(v); }
+    void set(double v) override { *val = static_cast<T>(v); }
     void set(bool v) override { *val = v; }
 
-    int geti() const override { return (int)lround(*val); }
-    double getf() const override { return (double)*val; }
+    int geti() const override { return static_cast<int>(lround(*val)); }
+    double getf() const override { return static_cast<double>(*val); }
     bool getb() const override { return *val != 0; }
 
     T* val;
@@ -115,8 +115,8 @@ template <typename T>
 struct ConstFloatPtr : public BaseValue {
     explicit ConstFloatPtr(const T* v) : val(v) {}
 
-    int geti() const override { return (int)lround(*val); }
-    double getf() const override { return (double)*val; }
+    int geti() const override { return static_cast<int>(lround(*val)); }
+    double getf() const override { return static_cast<double>(*val); }
     bool getb() const override { return *val != 0; }
 
     const T* val;
@@ -271,7 +271,9 @@ void FloatSlot::unbind() {
 
 void FloatSlot::set(double v) { (static_cast<BaseValue*>(data_))->set(v); }
 
-double FloatSlot::get() const { return (static_cast<BaseValue*>(data_))->getf(); }
+double FloatSlot::get() const {
+    return (static_cast<BaseValue*>(data_))->getf();
+}
 
 // ================================================================================================
 // BoolSlot :: implementation.
@@ -295,7 +297,7 @@ bool BoolSlot::get() const { return (static_cast<BaseValue*>(data_))->getb(); }
 namespace {
 
 struct BaseStr {
-    BaseStr()  = default;
+    BaseStr() = default;
     virtual ~BaseStr() = default;
 
     virtual void set(const char* s) {}
@@ -374,13 +376,17 @@ void TextSlot::bind(std::string* str) {
     data_ = new StringPtr(str);
 }
 
-void TextSlot::set(const char* str) { (static_cast<BaseStr*>(data_))->set(str); }
+void TextSlot::set(const char* str) {
+    (static_cast<BaseStr*>(data_))->set(str);
+}
 
 void TextSlot::set(const std::string& str) {
     (static_cast<BaseStr*>(data_))->set(str.c_str());
 }
 
-const char* TextSlot::get() const { return (static_cast<BaseStr*>(data_))->get(); }
+const char* TextSlot::get() const {
+    return (static_cast<BaseStr*>(data_))->get();
+}
 
 // ================================================================================================
 // CallSlot :: implementation.

--- a/src/Core/StringUtils.cpp
+++ b/src/Core/StringUtils.cpp
@@ -805,7 +805,9 @@ std::string Str::formatTime(double seconds, bool precise) {
     t -= min * (60 * 1000);
     int64_t sec = t / 1000;
 
-    auto fmt = Str::fmt("%1:%2.").arg(static_cast<int>(min), 2).arg(static_cast<int>(sec), 2);
+    auto fmt = Str::fmt("%1:%2.")
+                   .arg(static_cast<int>(min), 2)
+                   .arg(static_cast<int>(sec), 2);
 
     if (precise) {
         t -= sec * 1000;

--- a/src/Core/StringUtils.cpp
+++ b/src/Core/StringUtils.cpp
@@ -629,7 +629,7 @@ static const uint8_t* ParseNumber(const uint8_t* p, double& out) {
     for (; *p >= '0' && *p <= '9'; ++p) {
         sum = sum * 10 + (*p - '0');
     }
-    out = (double)sum;
+    out = static_cast<double>(sum);
 
     // Digits after the decimal-point.
     if (*p == '.' || *p == ',') {
@@ -638,7 +638,7 @@ static const uint8_t* ParseNumber(const uint8_t* p, double& out) {
         for (++p; *p >= '0' && *p <= '9'; ++p, ++digits) {
             dec = dec * 10 + (*p - '0');
         }
-        out += (double)dec / pow(10.0, digits);
+        out += static_cast<double>(dec) / pow(10.0, digits);
     }
 
     // Optional exponent.
@@ -720,7 +720,7 @@ static const uint8_t* ParseNestedExpression(const uint8_t* p, double& out) {
 
 bool Str::parse(const char* expr, double& out) {
     double tmp = 0.0;
-    const uint8_t* begin = SkipWs((const uint8_t*)expr);
+    const uint8_t* begin = SkipWs(reinterpret_cast<const uint8_t*>(expr));
     const uint8_t* p = ParseNestedExpression(begin, tmp);
     if (p > begin) out = tmp;
     return (p > begin);
@@ -800,20 +800,20 @@ std::string Str::formatTime(double seconds, bool precise) {
         seconds = -seconds;
     }
 
-    int64_t t = (int64_t)(seconds * 1000.0);
+    int64_t t = static_cast<int64_t>(seconds * 1000.0);
     int64_t min = t / (60 * 1000);
     t -= min * (60 * 1000);
     int64_t sec = t / 1000;
 
-    auto fmt = Str::fmt("%1:%2.").arg((int)min, 2).arg((int)sec, 2);
+    auto fmt = Str::fmt("%1:%2.").arg(static_cast<int>(min), 2).arg(static_cast<int>(sec), 2);
 
     if (precise) {
         t -= sec * 1000;
-        Str::appendVal(fmt, (int)t, 3);
+        Str::appendVal(fmt, static_cast<int>(t), 3);
     } else {
         t -= sec * 1000;
         t /= 100;
-        Str::appendVal(fmt, (int)t);
+        Str::appendVal(fmt, static_cast<int>(t));
     }
 
     if (negative) {

--- a/src/Core/TextDraw.cpp
+++ b/src/Core/TextDraw.cpp
@@ -117,8 +117,8 @@ void TextDraw::create() {
     RD->glyphCap = 16;
 
     int vcap = RD->glyphCap * 4;
-    RD->vpos = (int*)malloc(sizeof(int) * 2 * vcap);
-    RD->vtex = (float*)malloc(sizeof(float) * 2 * vcap);
+    RD->vpos = static_cast<int*>(malloc(sizeof(int) * 2 * vcap));
+    RD->vtex = static_cast<float*>(malloc(sizeof(float) * 2 * vcap));
 
     CreateShaders();
 }
@@ -139,8 +139,8 @@ void TextDraw::destroy() {
 static void AllocateMoreGlyphs() {
     RD->glyphCap *= 2;
     int vcap = RD->glyphCap * 4;
-    RD->vpos = (int*)realloc(RD->vpos, sizeof(int) * 2 * vcap);
-    RD->vtex = (float*)realloc(RD->vtex, sizeof(float) * 2 * vcap);
+    RD->vpos = static_cast<int*>(realloc(RD->vpos, sizeof(int) * 2 * vcap));
+    RD->vtex = static_cast<float*>(realloc(RD->vtex, sizeof(float) * 2 * vcap));
 }
 
 static void DrawCurrentGlyphs() {

--- a/src/Core/TextDraw.cpp
+++ b/src/Core/TextDraw.cpp
@@ -139,8 +139,14 @@ void TextDraw::destroy() {
 static void AllocateMoreGlyphs() {
     RD->glyphCap *= 2;
     int vcap = RD->glyphCap * 4;
-    RD->vpos = static_cast<int*>(realloc(RD->vpos, sizeof(int) * 2 * vcap));
-    RD->vtex = static_cast<float*>(realloc(RD->vtex, sizeof(float) * 2 * vcap));
+    auto tmp = realloc(RD->vpos, sizeof(int) * 2 * vcap);
+    if (tmp) {
+        RD->vpos = static_cast<int*>(tmp);
+    }
+    tmp = realloc(RD->vtex, sizeof(float) * 2 * vcap);
+    if (tmp) {
+        RD->vtex = static_cast<float*>(tmp);
+    }
 }
 
 static void DrawCurrentGlyphs() {

--- a/src/Core/TextLayout.cpp
+++ b/src/Core/TextLayout.cpp
@@ -69,14 +69,14 @@ static double ReadNumber(const uint8_t* p, int len) {
     // Integer part.
     for (; i < len && p[i] >= '0' && p[i] <= '9'; ++i) {
         out *= 10.0;
-        out += (double)(p[i] - '0');
+        out += static_cast<double>(p[i] - '0');
     }
 
     // Fractional part.
     if (p[i] == '.') {
         double mul = 0.1;
         for (++i; i < len && p[i] >= '0' && p[i] <= '9'; ++i) {
-            out += (double)(p[i] - '0') * mul;
+            out += static_cast<double>(p[i] - '0') * mul;
             mul *= 0.1;
         }
     }
@@ -154,16 +154,16 @@ static void ReadShadowColor(const uint8_t* param, int len) {
 }
 
 static void ReadFontSize(const uint8_t* param, int len) {
-    int fontSize = (int)(ReadNumber(param, len) + 0.5);
+    int fontSize = static_cast<int>(ReadNumber(param, len) + 0.5);
 
     if (len == 0) {
         fontSize = LD->baseFontSize;
     } else if (param[len - 1] == '%') {
         fontSize =
-            (int)(ReadNumber(param, len) * (double)LD->baseFontSize / 100.0 +
+            static_cast<int>(ReadNumber(param, len) * static_cast<double>(LD->baseFontSize) / 100.0 +
                   0.5);
     } else {
-        fontSize = (int)(ReadNumber(param, len) + 0.5);
+        fontSize = static_cast<int>(ReadNumber(param, len) + 0.5);
     }
     LD->fontSize = min(max(1, fontSize), 256);
     SetLineMetrics();
@@ -171,7 +171,7 @@ static void ReadFontSize(const uint8_t* param, int len) {
 
 static void ReadFontChange(const uint8_t* param, int len) {
     // Resolve the path of the font file (could be an asset name).
-    std::string path((const char*)param, len);
+    std::string path(reinterpret_cast<const char*>(param), len);
 
     // Look for the font in the font manager.
     FontData* font = FontManager::find(path);
@@ -262,7 +262,7 @@ static const Glyph* ReadMarkup(const uint8_t* str) {
                 break;
             case ID1('G'):
                 return FontManager::getGlyph(
-                    std::string((const char*)param, paramLen));
+                    std::string(reinterpret_cast<const char*>(param), paramLen));
             case ID2('L', 'B'):
                 return GetGlyph('{');
             case ID2('R', 'B'):
@@ -500,7 +500,7 @@ static void CreateLayout(const char* str) {
     // Make a list of every line of glyphs.
     bool isMultiline = !(LD->flags & Text::SINGLE_LINE);
     while (true) {
-        auto glyph = ReadGlyph((const uint8_t*)str);
+        auto glyph = ReadGlyph(reinterpret_cast<const uint8_t*>(str));
         if (!glyph) break;
 
         // Apply glyph advance.
@@ -562,7 +562,7 @@ static vec2i ArrangeText(const TextStyle& style, int maxLineWidth,
     LD->flags = style.textFlags;
     LD->align = align;
 
-    LD->font = LD->baseFont = (FontData*)style.font.data();
+    LD->font = LD->baseFont = static_cast<FontData*>(style.font.data());
     LD->fontSize = LD->baseFontSize = style.fontSize;
 
     LD->baseTextColor = LD->textColor = style.textColor;

--- a/src/Core/TextLayout.cpp
+++ b/src/Core/TextLayout.cpp
@@ -160,8 +160,9 @@ static void ReadFontSize(const uint8_t* param, int len) {
         fontSize = LD->baseFontSize;
     } else if (param[len - 1] == '%') {
         fontSize =
-            static_cast<int>(ReadNumber(param, len) * static_cast<double>(LD->baseFontSize) / 100.0 +
-                  0.5);
+            static_cast<int>(ReadNumber(param, len) *
+                                 static_cast<double>(LD->baseFontSize) / 100.0 +
+                             0.5);
     } else {
         fontSize = static_cast<int>(ReadNumber(param, len) + 0.5);
     }
@@ -261,8 +262,8 @@ static const Glyph* ReadMarkup(const uint8_t* str) {
                 ReadFontChange(param, paramLen);
                 break;
             case ID1('G'):
-                return FontManager::getGlyph(
-                    std::string(reinterpret_cast<const char*>(param), paramLen));
+                return FontManager::getGlyph(std::string(
+                    reinterpret_cast<const char*>(param), paramLen));
             case ID2('L', 'B'):
                 return GetGlyph('{');
             case ID2('R', 'B'):

--- a/src/Core/TextureImpl.cpp
+++ b/src/Core/TextureImpl.cpp
@@ -190,8 +190,8 @@ static void GenerateMipmapLevel(const uint8_t* src, uint8_t* dst, int w, int h,
 static void GenerateMipmaps(int w, int h, const uint8_t* pixeldata,
                             Texture::Format fmt) {
     int ch = sNumChannels[fmt];
-    uint8_t* tmpA = (uint8_t*)malloc((w / 2) * (h / 2) * ch);
-    uint8_t* tmpB = (uint8_t*)malloc((w / 4) * (h / 4) * ch);
+    uint8_t* tmpA = static_cast<uint8_t*>(malloc((w / 2) * (h / 2) * ch));
+    uint8_t* tmpB = static_cast<uint8_t*>(malloc((w / 4) * (h / 4) * ch));
 
     // The first mipmap level is generated from the source buffer.
     GenerateMipmapLevel(pixeldata, tmpA, w, h, fmt);
@@ -219,16 +219,16 @@ static bool PowerOfTwoTexImage2D(Texture::Format fmt, int w, int h,
     int nh = NextPowerOfTwo(h);
     if (nw == w && nh == h) return false;
 
-    uint8_t *buffer = (uint8_t*)malloc(nw * nh * channels), *dst = buffer;
+    uint8_t *buffer = static_cast<uint8_t*>(malloc(nw * nh * channels)), *dst = buffer;
     int maxIndex = w * h - w - 1;
     int x, y;
     float sx, sy;
-    float dx = w / (float)nw;
-    float dy = h / (float)nh;
+    float dx = w / static_cast<float>(nw);
+    float dy = h / static_cast<float>(nh);
     for (y = 0, sy = 0; y < nh; ++y, sy += dy) {
-        int py = (int)sy;
+        int py = static_cast<int>(sy);
         for (x = 0, sx = 0; x < nw; ++x, sx += dx, dst += channels) {
-            int px = (int)sx;
+            int px = static_cast<int>(sx);
 
             const uint8_t* p1 =
                 pixels + clamp(py * w + px, 0, maxIndex) * channels;
@@ -245,7 +245,7 @@ static bool PowerOfTwoTexImage2D(Texture::Format fmt, int w, int h,
                 float w3 = fx0 * fy1;
                 float w4 = fx1 * fy1;
 
-                dst[ch] = (uint8_t)(p1[ch] * w1 + p2[ch] * w2 + p3[ch] * w3 +
+                dst[ch] = static_cast<uint8_t>(p1[ch] * w1 + p2[ch] * w2 + p3[ch] * w3 +
                                     p4[ch] * w4);
             }
         }
@@ -311,8 +311,8 @@ Texture::Data::Data(int inW, int inH, Texture::Format inFmt,
         if (unaligned) glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
     }
 
-    rw = (float)(1.0 / w);
-    rh = (float)(1.0 / h);
+    rw = static_cast<float>(1.0 / w);
+    rh = static_cast<float>(1.0 / h);
     refs = 1;
     mipmapped = mipmap;
     cached = false;
@@ -355,7 +355,7 @@ void Texture::Data::increaseHeight(int newHeight) {
         }
 
         int channels = sNumChannels[usedFmt];
-        uint8_t* pixels = (uint8_t*)malloc(w * newHeight * channels);
+        uint8_t* pixels = static_cast<uint8_t*>(malloc(w * newHeight * channels));
         memset(pixels + w * h * channels, 0, w * (newHeight - h) * channels);
 
         glBindTexture(GL_TEXTURE_2D, handle);
@@ -368,7 +368,7 @@ void Texture::Data::increaseHeight(int newHeight) {
         glBindTexture(GL_TEXTURE_2D, 0);
 
         h = newHeight;
-        rh = 1.0f / (float)max(h, 1);
+        rh = 1.0f / static_cast<float>max(h, 1);
         free(pixels);
     }
 }

--- a/src/Core/TextureImpl.cpp
+++ b/src/Core/TextureImpl.cpp
@@ -219,7 +219,8 @@ static bool PowerOfTwoTexImage2D(Texture::Format fmt, int w, int h,
     int nh = NextPowerOfTwo(h);
     if (nw == w && nh == h) return false;
 
-    uint8_t *buffer = static_cast<uint8_t*>(malloc(nw * nh * channels)), *dst = buffer;
+    uint8_t *buffer = static_cast<uint8_t*>(malloc(nw * nh * channels)),
+            *dst = buffer;
     int maxIndex = w * h - w - 1;
     int x, y;
     float sx, sy;
@@ -245,8 +246,8 @@ static bool PowerOfTwoTexImage2D(Texture::Format fmt, int w, int h,
                 float w3 = fx0 * fy1;
                 float w4 = fx1 * fy1;
 
-                dst[ch] = static_cast<uint8_t>(p1[ch] * w1 + p2[ch] * w2 + p3[ch] * w3 +
-                                    p4[ch] * w4);
+                dst[ch] = static_cast<uint8_t>(p1[ch] * w1 + p2[ch] * w2 +
+                                               p3[ch] * w3 + p4[ch] * w4);
             }
         }
     }
@@ -355,7 +356,8 @@ void Texture::Data::increaseHeight(int newHeight) {
         }
 
         int channels = sNumChannels[usedFmt];
-        uint8_t* pixels = static_cast<uint8_t*>(malloc(w * newHeight * channels));
+        uint8_t* pixels =
+            static_cast<uint8_t*>(malloc(w * newHeight * channels));
         memset(pixels + w * h * channels, 0, w * (newHeight - h) * channels);
 
         glBindTexture(GL_TEXTURE_2D, handle);
@@ -368,7 +370,7 @@ void Texture::Data::increaseHeight(int newHeight) {
         glBindTexture(GL_TEXTURE_2D, 0);
 
         h = newHeight;
-        rh = 1.0f / static_cast<float>max(h, 1);
+        rh = 1.0f / static_cast<float> max(h, 1);
         free(pixels);
     }
 }

--- a/src/Core/Vector.h
+++ b/src/Core/Vector.h
@@ -256,8 +256,10 @@ void Vector<T>::squeeze() {
         if (capacity_ > size_) {
             T* src = data_;
             capacity_ = size_;
-            data_ = (T*)malloc(sizeof(T) * capacity_);
-            memcpy(data_, src, size_ * sizeof(T));
+            data_ = static_cast<T*>(malloc(sizeof(T) * capacity_));
+            if (data_) {
+                memcpy(data_, src, size_ * sizeof(T));
+            }
             free(src);
         }
     } else
@@ -267,7 +269,7 @@ void Vector<T>::squeeze() {
 template <typename T>
 void Vector<T>::reserve(int n) {
     if (n > capacity_) {
-        data_ = (T*)realloc(data_, sizeof(T) * n);
+        data_ = static_cast<T*>(realloc(data_, sizeof(T) * n));
         capacity_ = n;
     }
 }

--- a/src/Core/WideString.cpp
+++ b/src/Core/WideString.cpp
@@ -19,8 +19,10 @@ static wchar_t* nullstr = reinterpret_cast<wchar_t*>(metaData + metaSize);
 
 static void StrAlloc(wchar_t*& s, int n) {
     int* cap = static_cast<int*>(malloc(metaSize + sizeof(wchar_t) * (n + 1)));
-    cap[0] = cap[1] = n;
-    s = reinterpret_cast<wchar_t*>(cap + 2);
+    if (cap) {
+        cap[0] = cap[1] = n;
+        s = reinterpret_cast<wchar_t*>(cap + 2);
+    }
 }
 
 static void StrRealloc(wchar_t*& s, int n) {
@@ -29,7 +31,10 @@ static void StrRealloc(wchar_t*& s, int n) {
         if (*cap < n) {
             *cap = *cap << 1;
             if (*cap < n) *cap = n;
-            cap = static_cast<int*>(realloc(cap, metaSize + sizeof(wchar_t) * (*cap + 1)));
+            auto tmp = realloc(cap, metaSize + sizeof(wchar_t) * (*cap + 1));
+            if (tmp) {
+                cap = static_cast<int*>(tmp);
+            }
             s = reinterpret_cast<wchar_t*>(cap + 2);
         }
         cap[1] = n;
@@ -61,7 +66,7 @@ WideString::~WideString() { StrFree(widestring_); }
 
 WideString::WideString() : widestring_(nullstr) {}
 
-WideString::WideString(WideString&& s) : widestring_(s.widestring_) {
+WideString::WideString(WideString&& s) noexcept : widestring_(s.widestring_) {
     s.widestring_ = nullstr;
 }
 
@@ -89,7 +94,7 @@ WideString::WideString(const wchar_t* s, int n) {
     widestring_[n] = 0;
 }
 
-WideString& WideString::operator=(WideString&& s) {
+WideString& WideString::operator=(WideString&& s) noexcept {
     swap(s);
     return *this;
 }
@@ -190,22 +195,27 @@ static uint32_t ReadU8(const uint8_t*& p, const uint8_t* end) {
                     c <<= 6;
                     c += *p;
                     ++p;
+                    break;
                 case 4:
                     c <<= 6;
                     c += *p;
                     ++p;
+                    break;
                 case 3:
                     c <<= 6;
                     c += *p;
                     ++p;
+                    break;
                 case 2:
                     c <<= 6;
                     c += *p;
                     ++p;
+                    break;
                 case 1:
                     c <<= 6;
                     c += *p;
                     ++p;
+                    break;
             };
             c -= utf8Offsets[numBytes];
         } else
@@ -236,12 +246,15 @@ static void WriteU8(std::string& str, uint32_t c) {
             case 4:
                 buffer[3] = (c | 0x80) & 0xBF;
                 c >>= 6;
+                break;
             case 3:
                 buffer[2] = (c | 0x80) & 0xBF;
                 c >>= 6;
+                break;
             case 2:
                 buffer[1] = (c | 0x80) & 0xBF;
                 c >>= 6;
+                break;
         };
         buffer[0] = c | utf8LeadingByte[numBytes];
         Str::append(str, reinterpret_cast<const char*>(buffer), numBytes);
@@ -265,10 +278,12 @@ static void WriteU16(WideString& str, uint32_t c) {
 std::string Narrow(const wchar_t* s, int len) {
     std::string out;
     if (sizeof(wchar_t) == sizeof(uint16_t)) {
-        for (auto p = reinterpret_cast<const uint16_t*>(s), end = p + len; p != end;)
+        for (auto p = reinterpret_cast<const uint16_t*>(s), end = p + len;
+             p != end;)
             WriteU8(out, ReadU16(p, end));
     } else if (sizeof(wchar_t) == sizeof(uint32_t)) {
-        for (auto p = reinterpret_cast<const uint32_t*>(s), end = p + len; p != end;)
+        for (auto p = reinterpret_cast<const uint32_t*>(s), end = p + len;
+             p != end;)
             WriteU8(out, *p);
     }
     return out;
@@ -277,10 +292,12 @@ std::string Narrow(const wchar_t* s, int len) {
 WideString Widen(const char* s, int len) {
     WideString out;
     if (sizeof(wchar_t) == sizeof(uint16_t)) {
-        for (auto p = reinterpret_cast<const uint8_t*>(s), end = p + len; p != end;)
+        for (auto p = reinterpret_cast<const uint8_t*>(s), end = p + len;
+             p != end;)
             WriteU16(out, ReadU8(p, end));
     } else if (sizeof(wchar_t) == sizeof(uint32_t)) {
-        for (auto p = reinterpret_cast<const uint8_t*>(s), end = p + len; p != end;)
+        for (auto p = reinterpret_cast<const uint8_t*>(s), end = p + len;
+             p != end;)
             out.push_back(ReadU8(p, end));
     }
     return out;

--- a/src/Core/WideString.cpp
+++ b/src/Core/WideString.cpp
@@ -15,22 +15,22 @@ namespace {
 
 static const int metaSize = sizeof(int) * 2;
 static char metaData[metaSize + sizeof(wchar_t)] = {};
-static wchar_t* nullstr = (wchar_t*)(metaData + metaSize);
+static wchar_t* nullstr = reinterpret_cast<wchar_t*>(metaData + metaSize);
 
 static void StrAlloc(wchar_t*& s, int n) {
-    int* cap = (int*)malloc(metaSize + sizeof(wchar_t) * (n + 1));
+    int* cap = static_cast<int*>(malloc(metaSize + sizeof(wchar_t) * (n + 1)));
     cap[0] = cap[1] = n;
-    s = (wchar_t*)(cap + 2);
+    s = reinterpret_cast<wchar_t*>(cap + 2);
 }
 
 static void StrRealloc(wchar_t*& s, int n) {
     if (s != nullstr) {
-        int* cap = (int*)s - 2;
+        int* cap = reinterpret_cast<int*>(s) - 2;
         if (*cap < n) {
             *cap = *cap << 1;
             if (*cap < n) *cap = n;
-            cap = (int*)realloc(cap, metaSize + sizeof(wchar_t) * (*cap + 1));
-            s = (wchar_t*)(cap + 2);
+            cap = static_cast<int*>(realloc(cap, metaSize + sizeof(wchar_t) * (*cap + 1)));
+            s = reinterpret_cast<wchar_t*>(cap + 2);
         }
         cap[1] = n;
     } else {
@@ -40,7 +40,7 @@ static void StrRealloc(wchar_t*& s, int n) {
 
 inline void StrFree(wchar_t* s) {
     if (s != nullstr) {
-        free((int*)s - 2);
+        free(reinterpret_cast<int*>(s) - 2);
     }
 }
 
@@ -226,9 +226,9 @@ static uint32_t ReadU16(const uint16_t*& p, const uint16_t* end) {
 
 static void WriteU8(std::string& str, uint32_t c) {
     if (c < 0x80) {
-        Str::append(str, (char)c);
+        Str::append(str, static_cast<char>(c));
     } else if (c > 0x10FFFF) {
-        Str::append(str, (char)c);
+        Str::append(str, static_cast<char>(c));
     } else {
         int numBytes = (c < 0x800) ? 2 : ((c < 0x10000) ? 3 : 4);
         uint8_t buffer[4];
@@ -244,19 +244,19 @@ static void WriteU8(std::string& str, uint32_t c) {
                 c >>= 6;
         };
         buffer[0] = c | utf8LeadingByte[numBytes];
-        Str::append(str, (const char*)buffer, numBytes);
+        Str::append(str, reinterpret_cast<const char*>(buffer), numBytes);
     }
 }
 
 static void WriteU16(WideString& str, uint32_t c) {
     if (c < 0xFFFF)
-        str.push_back((uint16_t)c);
+        str.push_back(static_cast<uint16_t>(c));
     else if (c > 0x10FFFF)
         str.push_back(L'~');
     else {
         c -= 0x10000;
-        str.push_back((uint16_t)(c >> 10) + 0xD800);
-        str.push_back((uint16_t)(c & 0x3FFUL) + 0xDC00);
+        str.push_back(static_cast<uint16_t>(c >> 10) + 0xD800);
+        str.push_back(static_cast<uint16_t>(c & 0x3FFUL) + 0xDC00);
     }
 }
 
@@ -265,10 +265,10 @@ static void WriteU16(WideString& str, uint32_t c) {
 std::string Narrow(const wchar_t* s, int len) {
     std::string out;
     if (sizeof(wchar_t) == sizeof(uint16_t)) {
-        for (auto p = (const uint16_t*)s, end = p + len; p != end;)
+        for (auto p = reinterpret_cast<const uint16_t*>(s), end = p + len; p != end;)
             WriteU8(out, ReadU16(p, end));
     } else if (sizeof(wchar_t) == sizeof(uint32_t)) {
-        for (auto p = (const uint32_t*)s, end = p + len; p != end;)
+        for (auto p = reinterpret_cast<const uint32_t*>(s), end = p + len; p != end;)
             WriteU8(out, *p);
     }
     return out;
@@ -277,10 +277,10 @@ std::string Narrow(const wchar_t* s, int len) {
 WideString Widen(const char* s, int len) {
     WideString out;
     if (sizeof(wchar_t) == sizeof(uint16_t)) {
-        for (auto p = (const uint8_t*)s, end = p + len; p != end;)
+        for (auto p = reinterpret_cast<const uint8_t*>(s), end = p + len; p != end;)
             WriteU16(out, ReadU8(p, end));
     } else if (sizeof(wchar_t) == sizeof(uint32_t)) {
-        for (auto p = (const uint8_t*)s, end = p + len; p != end;)
+        for (auto p = reinterpret_cast<const uint8_t*>(s), end = p + len; p != end;)
             out.push_back(ReadU8(p, end));
     }
     return out;

--- a/src/Core/WideString.h
+++ b/src/Core/WideString.h
@@ -9,9 +9,9 @@ class WideString {
    public:
     ~WideString();
     WideString();
-    WideString(WideString&& s);
+    WideString(WideString&& s) noexcept;
     WideString(const WideString& s);
-    WideString& operator=(WideString&& s);
+    WideString& operator=(WideString&& s) noexcept;
     WideString& operator=(const WideString& s);
 
     /// Constructs a string with character c repeated n times.

--- a/src/Core/WidgetsColor.cpp
+++ b/src/Core/WidgetsColor.cpp
@@ -144,14 +144,22 @@ void WgColorPicker::Expanded::tick(recti r, GuiContext* gui) {
 
     if (myDrag == 1) {
         recti r = getSr();
-        myCol.s = clamp(static_cast<float>(mpos.x - r.x) / static_cast<float>(r.w), 0.0f, 1.0f);
-        myCol.v = clamp(1.0f - static_cast<float>(mpos.y - r.y) / static_cast<float>(r.h), 0.0f, 1.0f);
+        myCol.s =
+            clamp(static_cast<float>(mpos.x - r.x) / static_cast<float>(r.w),
+                  0.0f, 1.0f);
+        myCol.v = clamp(
+            1.0f - static_cast<float>(mpos.y - r.y) / static_cast<float>(r.h),
+            0.0f, 1.0f);
     } else if (myDrag == 2) {
         recti r = getHr();
-        myCol.h = clamp(static_cast<float>(mpos.y - r.y) / static_cast<float>(r.h), 0.0f, 1.0f);
+        myCol.h =
+            clamp(static_cast<float>(mpos.y - r.y) / static_cast<float>(r.h),
+                  0.0f, 1.0f);
     } else if (myDrag == 3) {
         recti r = getAr();
-        myCol.a = clamp(1.0f - static_cast<float>(mpos.y - r.y) / static_cast<float>(r.h), 0.0f, 1.0f);
+        myCol.a = clamp(
+            1.0f - static_cast<float>(mpos.y - r.y) / static_cast<float>(r.h),
+            0.0f, 1.0f);
     }
 }
 
@@ -246,8 +254,9 @@ void WgColorPicker::onTick() {
             captureMouseOver();
         }
 
-        colorf rgb = {static_cast<float>(red.get()), static_cast<float>(green.get()), static_cast<float>(blue.get()),
-                      static_cast<float>(alpha.get())};
+        colorf rgb = {
+            static_cast<float>(red.get()), static_cast<float>(green.get()),
+            static_cast<float>(blue.get()), static_cast<float>(alpha.get())};
         colorpicker_expanded_->myCol = RGBtoHSV(rgb, rgb.a);
 
         if (colorpicker_expanded_->myDrag) {
@@ -266,8 +275,9 @@ void WgColorPicker::onTick() {
 }
 
 void WgColorPicker::onDraw() {
-    colorf rgb = {static_cast<float>(red.get()), static_cast<float>(green.get()), static_cast<float>(blue.get()),
-                  static_cast<float>(alpha.get())};
+    colorf rgb = {
+        static_cast<float>(red.get()), static_cast<float>(green.get()),
+        static_cast<float>(blue.get()), static_cast<float>(alpha.get())};
 
     Draw::fill(rect_, Colors::black);
     recti r = Shrink(rect_, 1);
@@ -279,8 +289,10 @@ void WgColorPicker::onDraw() {
     Draw::fill(r, ToColor32(HSVtoRGB(hsv, rgb.a)));
 
     r = Shrink(r, 1);
-    Draw::fill(r, ToColor32(static_cast<float>(red.get()), static_cast<float>(green.get()),
-                            static_cast<float>(blue.get()), static_cast<float>(alpha.get())));
+    Draw::fill(r, ToColor32(static_cast<float>(red.get()),
+                            static_cast<float>(green.get()),
+                            static_cast<float>(blue.get()),
+                            static_cast<float>(alpha.get())));
 
     if (colorpicker_expanded_) colorpicker_expanded_->draw();
 }

--- a/src/Core/WidgetsColor.cpp
+++ b/src/Core/WidgetsColor.cpp
@@ -144,14 +144,14 @@ void WgColorPicker::Expanded::tick(recti r, GuiContext* gui) {
 
     if (myDrag == 1) {
         recti r = getSr();
-        myCol.s = clamp((float)(mpos.x - r.x) / (float)r.w, 0.0f, 1.0f);
-        myCol.v = clamp(1.0f - (float)(mpos.y - r.y) / (float)r.h, 0.0f, 1.0f);
+        myCol.s = clamp(static_cast<float>(mpos.x - r.x) / static_cast<float>(r.w), 0.0f, 1.0f);
+        myCol.v = clamp(1.0f - static_cast<float>(mpos.y - r.y) / static_cast<float>(r.h), 0.0f, 1.0f);
     } else if (myDrag == 2) {
         recti r = getHr();
-        myCol.h = clamp((float)(mpos.y - r.y) / (float)r.h, 0.0f, 1.0f);
+        myCol.h = clamp(static_cast<float>(mpos.y - r.y) / static_cast<float>(r.h), 0.0f, 1.0f);
     } else if (myDrag == 3) {
         recti r = getAr();
-        myCol.a = clamp(1.0f - (float)(mpos.y - r.y) / (float)r.h, 0.0f, 1.0f);
+        myCol.a = clamp(1.0f - static_cast<float>(mpos.y - r.y) / static_cast<float>(r.h), 0.0f, 1.0f);
     }
 }
 
@@ -171,8 +171,8 @@ void WgColorPicker::Expanded::draw() {
     recti hr = getHr();
     for (int i = 0, y = 0; i < 6; ++i) {
         int by = hr.h * (i + 1) / 6;
-        t = ToColor32({(float)(i + 0) / 6.0f, 1.0f, 1.0f, 1.0f});
-        b = ToColor32({(float)(i + 1) / 6.0f, 1.0f, 1.0f, 1.0f});
+        t = ToColor32({static_cast<float>(i + 0) / 6.0f, 1.0f, 1.0f, 1.0f});
+        b = ToColor32({static_cast<float>(i + 1) / 6.0f, 1.0f, 1.0f, 1.0f});
         Draw::fill({hr.x, hr.y + y, hr.w, by - y}, t, t, b, b, true);
         y = by;
     }
@@ -184,10 +184,10 @@ void WgColorPicker::Expanded::draw() {
              br = ToColor32({myCol.h, 1, 0, 1});
     Draw::fill(sr, tl, tr, bl, br, true);
 
-    int sx = sr.x + (int)(sr.w * myCol.s);
-    int sy = sr.y + (int)(sr.h * (1.0f - myCol.v));
-    int hy = hr.y + (int)(hr.h * myCol.h);
-    int ay = ar.y + (int)(ar.h * (1.0f - myCol.a));
+    int sx = sr.x + static_cast<int>(sr.w * myCol.s);
+    int sy = sr.y + static_cast<int>(sr.h * (1.0f - myCol.v));
+    int hy = hr.y + static_cast<int>(hr.h * myCol.h);
+    int ay = ar.y + static_cast<int>(ar.h * (1.0f - myCol.a));
 
     Draw::outline({sx - 2, sy - 2, 5, 5}, Colors::black);
     Draw::outline({sx - 1, sy - 1, 3, 3}, Colors::white);
@@ -246,8 +246,8 @@ void WgColorPicker::onTick() {
             captureMouseOver();
         }
 
-        colorf rgb = {(float)red.get(), (float)green.get(), (float)blue.get(),
-                      (float)alpha.get()};
+        colorf rgb = {static_cast<float>(red.get()), static_cast<float>(green.get()), static_cast<float>(blue.get()),
+                      static_cast<float>(alpha.get())};
         colorpicker_expanded_->myCol = RGBtoHSV(rgb, rgb.a);
 
         if (colorpicker_expanded_->myDrag) {
@@ -266,8 +266,8 @@ void WgColorPicker::onTick() {
 }
 
 void WgColorPicker::onDraw() {
-    colorf rgb = {(float)red.get(), (float)green.get(), (float)blue.get(),
-                  (float)alpha.get()};
+    colorf rgb = {static_cast<float>(red.get()), static_cast<float>(green.get()), static_cast<float>(blue.get()),
+                  static_cast<float>(alpha.get())};
 
     Draw::fill(rect_, Colors::black);
     recti r = Shrink(rect_, 1);
@@ -279,8 +279,8 @@ void WgColorPicker::onDraw() {
     Draw::fill(r, ToColor32(HSVtoRGB(hsv, rgb.a)));
 
     r = Shrink(r, 1);
-    Draw::fill(r, ToColor32((float)red.get(), (float)green.get(),
-                            (float)blue.get(), (float)alpha.get()));
+    Draw::fill(r, ToColor32(static_cast<float>(red.get()), static_cast<float>(green.get()),
+                            static_cast<float>(blue.get()), static_cast<float>(alpha.get())));
 
     if (colorpicker_expanded_) colorpicker_expanded_->draw();
 }

--- a/src/Core/WidgetsLayout.cpp
+++ b/src/Core/WidgetsLayout.cpp
@@ -130,7 +130,9 @@ void RowLayout::onTick() {
 }
 
 void RowLayout::onDraw() {
-    for (GuiWidget* widget : widget_list_) { widget->draw(); }
+    for (GuiWidget* widget : widget_list_) {
+        widget->draw();
+    }
 }
 
 void RowLayout::add(GuiWidget* widget) {

--- a/src/Core/WidgetsLayout.cpp
+++ b/src/Core/WidgetsLayout.cpp
@@ -16,9 +16,9 @@ struct RowLayout::Col {
 };
 
 struct RowLayout::Row {
-    Row() : expand(0) {}
+    Row()  = default;
 
-    uint32_t expand : 1;
+    uint32_t expand : 1 = 0;
 
     Vector<RowLayout::Col> cols;
     Vector<GuiWidget*> widgets;
@@ -69,7 +69,7 @@ void RowLayout::onUpdateSize() {
                 vec2i size = (*widget)->getSize();
                 h = max(h, size.y);
                 if (cols[c].adjust) {
-                    cols[c].width = max(cols[c].width, (uint32_t)size.x);
+                    cols[c].width = max(cols[c].width, static_cast<uint32_t>(size.x));
                 }
             }
 

--- a/src/Core/WidgetsLayout.cpp
+++ b/src/Core/WidgetsLayout.cpp
@@ -16,7 +16,7 @@ struct RowLayout::Col {
 };
 
 struct RowLayout::Row {
-    Row()  = default;
+    Row() = default;
 
     uint32_t expand : 1 = 0;
 
@@ -69,7 +69,8 @@ void RowLayout::onUpdateSize() {
                 vec2i size = (*widget)->getSize();
                 h = max(h, size.y);
                 if (cols[c].adjust) {
-                    cols[c].width = max(cols[c].width, static_cast<uint32_t>(size.x));
+                    cols[c].width =
+                        max(cols[c].width, static_cast<uint32_t>(size.x));
                 }
             }
 
@@ -129,7 +130,7 @@ void RowLayout::onTick() {
 }
 
 void RowLayout::onDraw() {
-    FOR_VECTOR_FORWARD(widget_list_, i) { widget_list_[i]->draw(); }
+    for (GuiWidget* widget : widget_list_) { widget->draw(); }
 }
 
 void RowLayout::add(GuiWidget* widget) {

--- a/src/Core/WidgetsScroll.cpp
+++ b/src/Core/WidgetsScroll.cpp
@@ -34,11 +34,13 @@ struct ScrollButtonData {
 static ScrollButtonData GetButton(int size, int end, int page, int scroll) {
     ScrollButtonData out = {0, size};
     if (end > page) {
-        out.size = static_cast<int>(0.5 + size * static_cast<double>(page) / static_cast<double>(end));
+        out.size = static_cast<int>(0.5 + size * static_cast<double>(page) /
+                                              static_cast<double>(end));
         out.size = max(16, out.size);
 
-        out.pos = static_cast<int>(0.5 + scroll * static_cast<double>(size - out.size) /
-                                  static_cast<double>(end - page));
+        out.pos = static_cast<int>(
+            0.5 + scroll * static_cast<double>(size - out.size) /
+                      static_cast<double>(end - page));
         out.pos = max(0, min(out.pos, size - out.size));
     }
     return out;
@@ -48,8 +50,9 @@ static int GetScroll(int size, int end, int page, int pos) {
     int out = 0;
     if (end > page) {
         ScrollButtonData button = GetButton(size, end, page, 0);
-        out = static_cast<int>(0.5 +
-                    pos * static_cast<double>(end - page) / static_cast<double>(size - button.size));
+        out =
+            static_cast<int>(0.5 + pos * static_cast<double>(end - page) /
+                                       static_cast<double>(size - button.size));
         out = max(0, min(out, end - page));
     }
     return out;

--- a/src/Core/WidgetsScroll.cpp
+++ b/src/Core/WidgetsScroll.cpp
@@ -34,11 +34,11 @@ struct ScrollButtonData {
 static ScrollButtonData GetButton(int size, int end, int page, int scroll) {
     ScrollButtonData out = {0, size};
     if (end > page) {
-        out.size = (int)(0.5 + size * (double)page / (double)end);
+        out.size = static_cast<int>(0.5 + size * static_cast<double>(page) / static_cast<double>(end));
         out.size = max(16, out.size);
 
-        out.pos = (int)(0.5 + scroll * (double)(size - out.size) /
-                                  (double)(end - page));
+        out.pos = static_cast<int>(0.5 + scroll * static_cast<double>(size - out.size) /
+                                  static_cast<double>(end - page));
         out.pos = max(0, min(out.pos, size - out.size));
     }
     return out;
@@ -48,8 +48,8 @@ static int GetScroll(int size, int end, int page, int pos) {
     int out = 0;
     if (end > page) {
         ScrollButtonData button = GetButton(size, end, page, 0);
-        out = (int)(0.5 +
-                    pos * (double)(end - page) / (double)(size - button.size));
+        out = static_cast<int>(0.5 +
+                    pos * static_cast<double>(end - page) / static_cast<double>(size - button.size));
         out = max(0, min(out, end - page));
     }
     return out;
@@ -95,7 +95,7 @@ void ApplyScrollOffset(int& offset, int page, int scroll, bool up) {
 // ================================================================================================
 // WgScrollbar
 
-WgScrollbar::~WgScrollbar() {}
+WgScrollbar::~WgScrollbar() = default;
 
 WgScrollbar::WgScrollbar(GuiContext* gui)
     : GuiWidget(gui), scrollbar_action_(0), scrollbar_grab_position_(0) {
@@ -212,7 +212,7 @@ bool WgScrollbarH::isVertical() const { return false; }
 
 static const int SCROLLBAR_SIZE = 14;
 
-WgScrollRegion::~WgScrollRegion() {}
+WgScrollRegion::~WgScrollRegion() = default;
 
 WgScrollRegion::WgScrollRegion(GuiContext* gui)
     : GuiWidget(gui),

--- a/src/Core/WidgetsSimple.cpp
+++ b/src/Core/WidgetsSimple.cpp
@@ -9,7 +9,7 @@ namespace Vortex {
 // ================================================================================================
 // WgSeperator
 
-WgSeperator::~WgSeperator() {}
+WgSeperator::~WgSeperator() = default;
 
 WgSeperator::WgSeperator(GuiContext* gui) : GuiWidget(gui) { height_ = 2; }
 
@@ -22,7 +22,7 @@ void WgSeperator::onDraw() {
 // ================================================================================================
 // WgLabel
 
-WgLabel::~WgLabel() {}
+WgLabel::~WgLabel() = default;
 
 WgLabel::WgLabel(GuiContext* gui) : GuiWidget(gui) {}
 
@@ -40,7 +40,7 @@ void WgLabel::onDraw() {
 // ================================================================================================
 // WgButton
 
-WgButton::~WgButton() {}
+WgButton::~WgButton() = default;
 
 WgButton::WgButton(GuiContext* gui) : GuiWidget(gui) {}
 
@@ -89,7 +89,7 @@ void WgButton::onDraw() {
 // ================================================================================================
 // WgCheckbox
 
-WgCheckbox::~WgCheckbox() {}
+WgCheckbox::~WgCheckbox() = default;
 
 WgCheckbox::WgCheckbox(GuiContext* gui) : GuiWidget(gui) {}
 
@@ -141,7 +141,7 @@ recti WgCheckbox::GetCheckboxRect() const {
 // ================================================================================================
 // WgSlider
 
-WgSlider::~WgSlider() {}
+WgSlider::~WgSlider() = default;
 
 WgSlider::WgSlider(GuiContext* gui) : GuiWidget(gui) {
     slider_begin_ = 0.0;
@@ -191,7 +191,7 @@ void WgSlider::onDraw() {
 
     // Draw the draggable button graphic.
     if (slider_begin_ != slider_end_) {
-        int boxX = (int)((double)bar.w * (value.get() - slider_begin_) /
+        int boxX = static_cast<int>(static_cast<double>(bar.w) * (value.get() - slider_begin_) /
                          (slider_end_ - slider_begin_));
         recti box = {bar.x + min(max(boxX, 0), bar.w) - 4, bar.y - 8, 8, 16};
 
@@ -216,7 +216,7 @@ void WgSlider::SliderDrag(int x, int y) {
     recti r = rect_;
     r.w = max(r.w, 1);
     double val = slider_begin_ + (slider_end_ - slider_begin_) *
-                                     ((double)(x - r.x) / (double)r.w);
+                                     (static_cast<double>(x - r.x) / static_cast<double>(r.w));
     SliderUpdateValue(val);
 }
 

--- a/src/Core/WidgetsSimple.cpp
+++ b/src/Core/WidgetsSimple.cpp
@@ -191,8 +191,9 @@ void WgSlider::onDraw() {
 
     // Draw the draggable button graphic.
     if (slider_begin_ != slider_end_) {
-        int boxX = static_cast<int>(static_cast<double>(bar.w) * (value.get() - slider_begin_) /
-                         (slider_end_ - slider_begin_));
+        int boxX = static_cast<int>(static_cast<double>(bar.w) *
+                                    (value.get() - slider_begin_) /
+                                    (slider_end_ - slider_begin_));
         recti box = {bar.x + min(max(boxX, 0), bar.w) - 4, bar.y - 8, 8, 16};
 
         button.base.draw(box, 0);
@@ -215,8 +216,9 @@ void WgSlider::SliderUpdateValue(double v) {
 void WgSlider::SliderDrag(int x, int y) {
     recti r = rect_;
     r.w = max(r.w, 1);
-    double val = slider_begin_ + (slider_end_ - slider_begin_) *
-                                     (static_cast<double>(x - r.x) / static_cast<double>(r.w));
+    double val = slider_begin_ +
+                 (slider_end_ - slider_begin_) *
+                     (static_cast<double>(x - r.x) / static_cast<double>(r.w));
     SliderUpdateValue(val);
 }
 

--- a/src/Core/WidgetsText.cpp
+++ b/src/Core/WidgetsText.cpp
@@ -24,7 +24,7 @@ enum LineEditDragType {
     DT_REGULAR_DRAG,
 };
 
-WgLineEdit::~WgLineEdit() {}
+WgLineEdit::~WgLineEdit() = default;
 
 WgLineEdit::WgLineEdit(GuiContext* gui)
     : GuiWidget(gui), lineedit_show_background_(1) {
@@ -169,7 +169,7 @@ void WgLineEdit::onMouseRelease(MouseRelease& evt) {
 void WgLineEdit::onTextInput(TextInput& evt) {
     if (isCapturingText() && is_editable_ && !evt.handled) {
         DeleteSection();
-        if ((int)lineedit_text_.length() < lineedit_max_length_) {
+        if (static_cast<int>(lineedit_text_.length()) < lineedit_max_length_) {
             std::string input(evt.text);
 
             // replace newlines with spaces
@@ -235,22 +235,22 @@ void WgLineEdit::onTick() {
         lineedit_blink_time_ = 0.f;
     }
     lineedit_cursor_.x =
-        min(max(lineedit_cursor_.x, 0), (int)lineedit_text_.length());
+        min(max(lineedit_cursor_.x, 0), static_cast<int>(lineedit_text_.length()));
     lineedit_cursor_.y =
-        min(max(lineedit_cursor_.y, 0), (int)lineedit_text_.length());
+        min(max(lineedit_cursor_.y, 0), static_cast<int>(lineedit_text_.length()));
 
     // Update text offset
 
     float dt = gui_->getDeltaTime();
-    float barW = (float)(rect_.w - 12);
-    float textW = (float)Text::getSize().x;
+    float barW = static_cast<float>(rect_.w - 12);
+    float textW = static_cast<float>(Text::getSize().x);
     float cursorX =
-        (float)Text::getCursorPos(vec2i{0, 0}, lineedit_cursor_.y).x;
+        static_cast<float>(Text::getCursorPos(vec2i{0, 0}, lineedit_cursor_.y).x);
     float target =
         min(max(lineedit_scroll_offset_, cursorX - barW + 12), cursorX - 12);
     target = max(0.f, min(target, textW - barW));
 
-    float delta = max((float)fabs(lineedit_scroll_offset_ - target) * 10.f * dt,
+    float delta = max(fabs(lineedit_scroll_offset_ - target) * 10.f * dt,
                       dt * 256.f);
     float smooth = (lineedit_scroll_offset_ < target)
                        ? min(lineedit_scroll_offset_ + delta, target)
@@ -338,7 +338,7 @@ void WgLineEdit::DeleteSection() {
 
 vec2i WgLineEdit::TextPosition() const {
     recti r = rect_;
-    return {r.x - (int)lineedit_scroll_offset_ + 6, r.y + r.h / 2};
+    return {r.x - static_cast<int>(lineedit_scroll_offset_) + 6, r.y + r.h / 2};
 }
 
 // ================================================================================================

--- a/src/Core/WidgetsText.cpp
+++ b/src/Core/WidgetsText.cpp
@@ -234,24 +234,24 @@ void WgLineEdit::onTick() {
             Text::getCharIndex(vec2i{tp.x, tp.y}, {mp.x, tp.y});
         lineedit_blink_time_ = 0.f;
     }
-    lineedit_cursor_.x =
-        min(max(lineedit_cursor_.x, 0), static_cast<int>(lineedit_text_.length()));
-    lineedit_cursor_.y =
-        min(max(lineedit_cursor_.y, 0), static_cast<int>(lineedit_text_.length()));
+    lineedit_cursor_.x = min(max(lineedit_cursor_.x, 0),
+                             static_cast<int>(lineedit_text_.length()));
+    lineedit_cursor_.y = min(max(lineedit_cursor_.y, 0),
+                             static_cast<int>(lineedit_text_.length()));
 
     // Update text offset
 
     float dt = gui_->getDeltaTime();
     float barW = static_cast<float>(rect_.w - 12);
     float textW = static_cast<float>(Text::getSize().x);
-    float cursorX =
-        static_cast<float>(Text::getCursorPos(vec2i{0, 0}, lineedit_cursor_.y).x);
+    float cursorX = static_cast<float>(
+        Text::getCursorPos(vec2i{0, 0}, lineedit_cursor_.y).x);
     float target =
         min(max(lineedit_scroll_offset_, cursorX - barW + 12), cursorX - 12);
     target = max(0.f, min(target, textW - barW));
 
-    float delta = max(fabs(lineedit_scroll_offset_ - target) * 10.f * dt,
-                      dt * 256.f);
+    float delta =
+        max(fabs(lineedit_scroll_offset_ - target) * 10.f * dt, dt * 256.f);
     float smooth = (lineedit_scroll_offset_ < target)
                        ? min(lineedit_scroll_offset_ + delta, target)
                        : max(lineedit_scroll_offset_ - delta, target);

--- a/src/Core/Xmr.cpp
+++ b/src/Core/Xmr.cpp
@@ -23,7 +23,7 @@ using namespace Vortex;
 class xstring {
    public:
     ~xstring() { free(data); }
-    explicit xstring(int n) :  cap(n) {
+    explicit xstring(int n) : cap(n) {
         if (cap < 4) cap = 4;
         data = static_cast<char*>(malloc(cap));
     }
@@ -81,8 +81,9 @@ static bool IsWhiteSpace(char c) {
 static bool IsNameChar(char c) {
     static const uint32_t b[4] = {0xFFFFFBFE, 0xD7FFEFFF, 0xFFFFFFFF,
                                   0xD7FFFFFF};
-    return (static_cast<unsigned char>(c) < 128) ? ((b[c >> 5] & (1 << (c & 31))) != 0)
-                                    : true;
+    return (static_cast<unsigned char>(c) < 128)
+               ? ((b[c >> 5] & (1 << (c & 31))) != 0)
+               : true;
 }
 
 static bool IsNumber(const char* str) {
@@ -224,10 +225,10 @@ class XmrReader {
 
 XmrReader::XmrReader()
     : xmrErrorMessage_(16),
-      
-      xmrTextBuffer_(256)
-      {
-    xmrValueBuffer_ = static_cast<int*>(malloc(sizeof(int) * xmrValueCapacity_));
+
+      xmrTextBuffer_(256) {
+    xmrValueBuffer_ =
+        static_cast<int*>(malloc(sizeof(int) * xmrValueCapacity_));
 }
 
 XmrReader::~XmrReader() { free(xmrValueBuffer_); }
@@ -388,8 +389,8 @@ const char* XmrReader::parseString(const char* p) {
 void XmrReader::addValue(int pos) {
     if (xmrNumValues_ == xmrValueCapacity_) {
         xmrValueCapacity_ *= 2;
-        xmrValueBuffer_ =
-            static_cast<int*>(realloc(xmrValueBuffer_, sizeof(int) * xmrValueCapacity_));
+        xmrValueBuffer_ = static_cast<int*>(
+            realloc(xmrValueBuffer_, sizeof(int) * xmrValueCapacity_));
     }
     xmrValueBuffer_[xmrNumValues_] = pos;
     ++xmrNumValues_;

--- a/src/Core/Xmr.cpp
+++ b/src/Core/Xmr.cpp
@@ -23,14 +23,14 @@ using namespace Vortex;
 class xstring {
    public:
     ~xstring() { free(data); }
-    xstring(int n) : data(nullptr), size(0), cap(n) {
+    explicit xstring(int n) :  cap(n) {
         if (cap < 4) cap = 4;
-        data = (char*)malloc(cap);
+        data = static_cast<char*>(malloc(cap));
     }
     void append(char c) {
         if (size == cap) {
             cap *= 2;
-            data = (char*)realloc(data, cap);
+            data = static_cast<char*>(realloc(data, cap));
         }
         data[size++] = c;
     }
@@ -39,7 +39,7 @@ class xstring {
         if (newSize > cap) {
             cap *= 2;
             if (newSize > cap) cap = newSize;
-            data = (char*)realloc(data, cap);
+            data = static_cast<char*>(realloc(data, cap));
         }
         memcpy(data + size, str, n);
         size = newSize;
@@ -61,8 +61,8 @@ class xstring {
         }
         append(buf, n);
     }
-    char* data;
-    int size, cap;
+    char* data = nullptr;
+    int size = 0, cap;
 };
 
 // ================================================================================================
@@ -81,7 +81,7 @@ static bool IsWhiteSpace(char c) {
 static bool IsNameChar(char c) {
     static const uint32_t b[4] = {0xFFFFFBFE, 0xD7FFEFFF, 0xFFFFFFFF,
                                   0xD7FFFFFF};
-    return ((unsigned char)c < 128) ? ((b[c >> 5] & (1 << (c & 31))) != 0)
+    return (static_cast<unsigned char>(c) < 128) ? ((b[c >> 5] & (1 << (c & 31))) != 0)
                                     : true;
 }
 
@@ -120,14 +120,14 @@ static const char* SkipSpaceExceptNewline(const char* p) {
 static bool StrEq(const char* a, const char* b) { return !strcmp(a, b); }
 
 static char* CopyStr(const xstring* str) {
-    char* dst = (char*)malloc(str->size + 1);
+    char* dst = static_cast<char*>(malloc(str->size + 1));
     memcpy(dst, str->data, str->size);
     dst[str->size] = 0;
     return dst;
 }
 
 static void SetError(XmrDoc* doc, const xstring* str) {
-    if (doc->lastError != NO_ERROR) free((char*)(doc->lastError));
+    if (doc->lastError != NO_ERROR) free(const_cast<char*>(doc->lastError));
     doc->lastError = str ? CopyStr(str) : NO_ERROR;
 }
 
@@ -135,14 +135,14 @@ static XmrAttrib* NewAttrib(const char* str, int strsize, const int* vals,
                             int numVals) {
     // Allocate the attribute object and strings in a single memory block.
     int basesize = sizeof(XmrAttrib) + sizeof(char*) * numVals;
-    char* data = (char*)malloc(basesize + strsize);
+    char* data = static_cast<char*>(malloc(basesize + strsize));
 
     // Copy the attribute data.
-    XmrAttrib* out = (XmrAttrib*)data;
+    XmrAttrib* out = reinterpret_cast<XmrAttrib*>(data);
     out->name = data + basesize;
     out->nextPtr = nullptr;
     out->numValues = numVals;
-    out->values = (char**)(data + sizeof(XmrAttrib));
+    out->values = reinterpret_cast<char**>(data + sizeof(XmrAttrib));
 
     memcpy(out->name, str, strsize);
     for (int i = 0; i < numVals; ++i) {
@@ -165,13 +165,13 @@ static XmrAttrib* NewAttrib(const char* name, const char* vals, int num) {
 
     // Allocate the attribute object and strings in a single memory block.
     int basesize = sizeof(XmrAttrib) + sizeof(char*) * num;
-    char* data = (char*)malloc(basesize + nameLen + valLen);
+    char* data = static_cast<char*>(malloc(basesize + nameLen + valLen));
 
     // Copy the attribute data.
-    XmrAttrib* out = (XmrAttrib*)data;
+    XmrAttrib* out = reinterpret_cast<XmrAttrib*>(data);
     out->nextPtr = nullptr;
     out->numValues = num;
-    out->values = (char**)(data + sizeof(XmrAttrib));
+    out->values = reinterpret_cast<char**>(data + sizeof(XmrAttrib));
     out->name = data + basesize;
 
     char* ptr = out->name;
@@ -215,21 +215,19 @@ class XmrReader {
 
    private:
     xstring xmrErrorMessage_;
-    XmrResult xmrResult_;
-    const char* xmrErrorPosition_;
+    XmrResult xmrResult_ = XMR_SUCCESS;
+    const char* xmrErrorPosition_ = nullptr;
     xstring xmrTextBuffer_;
     int* xmrValueBuffer_;
-    int xmrNumValues_, xmrValueCapacity_;
+    int xmrNumValues_ = 0, xmrValueCapacity_ = 16;
 };
 
 XmrReader::XmrReader()
     : xmrErrorMessage_(16),
-      xmrResult_(XMR_SUCCESS),
-      xmrErrorPosition_(nullptr),
-      xmrTextBuffer_(256),
-      xmrNumValues_(0),
-      xmrValueCapacity_(16) {
-    xmrValueBuffer_ = (int*)malloc(sizeof(int) * xmrValueCapacity_);
+      
+      xmrTextBuffer_(256)
+      {
+    xmrValueBuffer_ = static_cast<int*>(malloc(sizeof(int) * xmrValueCapacity_));
 }
 
 XmrReader::~XmrReader() { free(xmrValueBuffer_); }
@@ -244,11 +242,11 @@ XmrResult XmrReader::load(const char* buffer, XmrDoc& doc) {
         // Find the error line and position.
         int line = 1, pos = 1;
         for (p = buffer; *p && p < xmrErrorPosition_; ++p) {
-            if ((uint8_t)(*p) == 0xA)
+            if (static_cast<uint8_t>(*p) == 0xA)
                 ++line, pos = 1;  // newline character.
-            else if ((uint8_t)(*p) < 128)
+            else if (static_cast<uint8_t>(*p) < 128)
                 ++pos;  // single-byte character.
-            else if (((uint8_t)(*p) & 192) == 192)
+            else if ((static_cast<uint8_t>(*p) & 192) == 192)
                 ++pos;  // first byte of multi-byte character.
         }
 
@@ -256,9 +254,9 @@ XmrResult XmrReader::load(const char* buffer, XmrDoc& doc) {
         xstring err(16);
         if (*p) {
             err.append("line ");
-            err.append((long)line);
+            err.append(static_cast<long>(line));
             err.append(", pos ");
-            err.append((long)pos);
+            err.append(static_cast<long>(pos));
             err.append(": ");
         }
         err.append(xmrErrorMessage_.data, xmrErrorMessage_.size);
@@ -391,7 +389,7 @@ void XmrReader::addValue(int pos) {
     if (xmrNumValues_ == xmrValueCapacity_) {
         xmrValueCapacity_ *= 2;
         xmrValueBuffer_ =
-            (int*)realloc(xmrValueBuffer_, sizeof(int) * xmrValueCapacity_);
+            static_cast<int*>(realloc(xmrValueBuffer_, sizeof(int) * xmrValueCapacity_));
     }
     xmrValueBuffer_[xmrNumValues_] = pos;
     ++xmrNumValues_;
@@ -502,9 +500,9 @@ static XmrNode* NewNode(const char* n) {
     int alen = sizeof(XmrNode);
     int nlen = strlen(n) + 1;
 
-    char* data = (char*)malloc(alen + nlen);
+    char* data = static_cast<char*>(malloc(alen + nlen));
     char* str = data + alen;
-    XmrNode* out = (XmrNode*)data;
+    XmrNode* out = reinterpret_cast<XmrNode*>(data);
 
     out->name = str;
     out->nextPtr = nullptr;
@@ -688,7 +686,7 @@ static int Read(const XmrAttrib* a, int* out, int n) {
         n = a->numValues;
     for (int i = 0; i < n; ++i) {
         char *end, *str = a->values[i];
-        int v = (int)strtol(str, &end, 0);
+        int v = static_cast<int>(strtol(str, &end, 0));
         if (end != str) out[read++] = v;
     }
     return read;
@@ -702,7 +700,7 @@ static int Read(const XmrAttrib* a, float* out, int n) {
         n = a->numValues;
     for (int i = 0; i < n; ++i) {
         char *end, *str = a->values[i];
-        float v = (float)strtod(str, &end);
+        float v = static_cast<float>(strtod(str, &end));
         if (end != str) out[read++] = v;
     }
     return read;

--- a/src/Dialogs/AdjustSync.cpp
+++ b/src/Dialogs/AdjustSync.cpp
@@ -92,7 +92,7 @@ void DialogAdjustSync::myCreateWidgets() {
         WgButton* button = myLayout.add<WgButton>();
         button->text.set(moveText[i]);
         button->onPress.bind(this, &DialogAdjustSync::onAction,
-                             (int)ACT_INC_OFS_ONE + i);
+                             static_cast<int>(ACT_INC_OFS_ONE) + i);
         button->setTooltip(moveTooltip[i]);
     }
 
@@ -189,7 +189,7 @@ void DialogAdjustSync::onAction(int id) {
             int rows = ROWS_PER_BEAT;
             if (id == ACT_DEC_OFS_HALF || id == ACT_INC_OFS_HALF) rows /= 2;
             if (id == ACT_DEC_OFS_HALF || id == ACT_DEC_OFS_ONE) rows *= -1;
-            double seconds = (double)rows * SecPerRow(gTempo->getBpm(0));
+            double seconds = static_cast<double>(rows) * SecPerRow(gTempo->getBpm(0));
             gTempo->setOffset(gTempo->getOffset() + seconds);
         } break;
     };

--- a/src/Dialogs/AdjustSync.cpp
+++ b/src/Dialogs/AdjustSync.cpp
@@ -189,7 +189,8 @@ void DialogAdjustSync::onAction(int id) {
             int rows = ROWS_PER_BEAT;
             if (id == ACT_DEC_OFS_HALF || id == ACT_INC_OFS_HALF) rows /= 2;
             if (id == ACT_DEC_OFS_HALF || id == ACT_DEC_OFS_ONE) rows *= -1;
-            double seconds = static_cast<double>(rows) * SecPerRow(gTempo->getBpm(0));
+            double seconds =
+                static_cast<double>(rows) * SecPerRow(gTempo->getBpm(0));
             gTempo->setOffset(gTempo->getOffset() + seconds);
         } break;
     };

--- a/src/Dialogs/AdjustTempo.cpp
+++ b/src/Dialogs/AdjustTempo.cpp
@@ -201,7 +201,8 @@ void DialogAdjustTempo::onAction(int id) {
             break;
         case ACT_INSERT_BEATS:
         case ACT_REMOVE_BEATS:
-            int numRows = static_cast<int>(ROWS_PER_BEAT * myBeatsToInsert + 0.5);
+            int numRows =
+                static_cast<int>(ROWS_PER_BEAT * myBeatsToInsert + 0.5);
             if (id == ACT_REMOVE_BEATS) numRows *= -1;
             gEditing->insertRows(gView->getCursorRow(), numRows,
                                  (myInsertTarget == 0));

--- a/src/Dialogs/AdjustTempo.cpp
+++ b/src/Dialogs/AdjustTempo.cpp
@@ -29,7 +29,7 @@ enum Actions {
     ACT_REMOVE_BEATS,
 };
 
-DialogAdjustTempo::~DialogAdjustTempo() {}
+DialogAdjustTempo::~DialogAdjustTempo() = default;
 
 DialogAdjustTempo::DialogAdjustTempo() {
     setTitle("ADJUST TEMPO");
@@ -112,7 +112,7 @@ void DialogAdjustTempo::myCreateWidgets() {
     WgButton* insert = myLayout.add<WgButton>();
     insert->text.set("Insert beats");
     insert->onPress.bind(this, &DialogAdjustTempo::onAction,
-                         (int)ACT_INSERT_BEATS);
+                         static_cast<int>(ACT_INSERT_BEATS));
     insert->setTooltip(
         "Insert the above number of beats at the cursor position\n"
         "All notes and tempo changes after the cursor will be shifted down");
@@ -120,7 +120,7 @@ void DialogAdjustTempo::myCreateWidgets() {
     WgButton* remove = myLayout.add<WgButton>();
     remove->text.set("Delete beats");
     remove->onPress.bind(this, &DialogAdjustTempo::onAction,
-                         (int)ACT_REMOVE_BEATS);
+                         static_cast<int>(ACT_REMOVE_BEATS));
     remove->setTooltip(
         "Delete the above number of beats at the cursor position\n"
         "All notes and tempo changes after the cursor will be shifted up\n"
@@ -201,7 +201,7 @@ void DialogAdjustTempo::onAction(int id) {
             break;
         case ACT_INSERT_BEATS:
         case ACT_REMOVE_BEATS:
-            int numRows = (int)(ROWS_PER_BEAT * myBeatsToInsert + 0.5);
+            int numRows = static_cast<int>(ROWS_PER_BEAT * myBeatsToInsert + 0.5);
             if (id == ACT_REMOVE_BEATS) numRows *= -1;
             gEditing->insertRows(gView->getCursorRow(), numRows,
                                  (myInsertTarget == 0));

--- a/src/Dialogs/AdjustTempoSM5.cpp
+++ b/src/Dialogs/AdjustTempoSM5.cpp
@@ -29,7 +29,7 @@ enum Actions {
     ACT_LABEL_SET,
 };
 
-DialogAdjustTempoSM5::~DialogAdjustTempoSM5() {}
+DialogAdjustTempoSM5::~DialogAdjustTempoSM5() = default;
 
 DialogAdjustTempoSM5::DialogAdjustTempoSM5() {
     setTitle("ADJUST TEMPO (SM5)");
@@ -60,7 +60,7 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setStep(0.001);
     spinner->setRange(0, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_DELAY_SET);
+                           static_cast<int>(ACT_DELAY_SET));
     spinner->setTooltip("Stop length at the current beat, in seconds");
 
     myLayout.row().col(84).col(154);
@@ -69,7 +69,7 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setPrecision(3, 6);
     spinner->setRange(0, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_WARP_SET);
+                           static_cast<int>(ACT_WARP_SET));
     spinner->setTooltip("Warp length at the current beat, in beats");
 
     myLayout.row().col(84).col(75).col(75);
@@ -79,7 +79,7 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setPrecision(0, 0);
     spinner->setRange(1, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_TIME_SIG_SET);
+                           static_cast<int>(ACT_TIME_SIG_SET));
     spinner->setTooltip("Beats per measure");
 
     spinner = myLayout.add<WgSpinner>();
@@ -87,7 +87,7 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setPrecision(0, 0);
     spinner->setRange(1, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_TIME_SIG_SET);
+                           static_cast<int>(ACT_TIME_SIG_SET));
     spinner->setTooltip("Beat note type");
 
     myLayout.row().col(84).col(154);
@@ -97,7 +97,7 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setPrecision(0, 0);
     spinner->setRange(0, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_TICK_COUNT_SET);
+                           static_cast<int>(ACT_TICK_COUNT_SET));
     spinner->setTooltip("Hold combo ticks per beat");
 
     myLayout.row().col(84).col(75).col(75);
@@ -107,7 +107,7 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setPrecision(0, 0);
     spinner->setRange(0, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_COMBO_SET);
+                           static_cast<int>(ACT_COMBO_SET));
     spinner->setTooltip("Combo hit multiplier");
 
     spinner = myLayout.add<WgSpinner>();
@@ -115,7 +115,7 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setPrecision(0, 0);
     spinner->setRange(0, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_COMBO_SET);
+                           static_cast<int>(ACT_COMBO_SET));
     spinner->setTooltip("Combo miss multiplier");
 
     myLayout.row().col(84).col(52).col(56).col(38);
@@ -126,7 +126,7 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setStep(0.1);
     spinner->setRange(-1000, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_SPEED_SET);
+                           static_cast<int>(ACT_SPEED_SET));
     spinner->setTooltip("Stretch ratio");
 
     spinner = myLayout.add<WgSpinner>();
@@ -135,13 +135,13 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setStep(0.1);
     spinner->setRange(0, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_SPEED_SET);
+                           static_cast<int>(ACT_SPEED_SET));
     spinner->setTooltip("Delay time");
 
     WgCycleButton* cycler = myLayout.add<WgCycleButton>();
     cycler->value.bind(&mySpeedUnit);
     cycler->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                          (int)ACT_SPEED_SET);
+                          static_cast<int>(ACT_SPEED_SET));
     cycler->setTooltip("Delay unit (beats/time)");
     cycler->addItem("B");
     cycler->addItem("T");
@@ -154,7 +154,7 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setStep(0.1);
     spinner->setRange(-100000, 100000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_SCROLL_SET);
+                           static_cast<int>(ACT_SCROLL_SET));
     spinner->setTooltip("Scroll ratio");
 
     spinner = myLayout.add<WgSpinner>("Fakes");
@@ -162,14 +162,14 @@ void DialogAdjustTempoSM5::myCreateWidgets() {
     spinner->setPrecision(3, 6);
     spinner->setRange(0, 1000);
     spinner->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                           (int)ACT_FAKE_SET);
+                           static_cast<int>(ACT_FAKE_SET));
     spinner->setTooltip("Fake region, in beats");
 
     WgLineEdit* text = myLayout.add<WgLineEdit>("Label");
     text->text.bind(&myLabelText);
     text->setMaxLength(1000);
     text->onChange.bind(this, &DialogAdjustTempoSM5::onAction,
-                        (int)ACT_LABEL_SET);
+                        static_cast<int>(ACT_LABEL_SET));
     text->setTooltip("Label text");
 }
 
@@ -190,7 +190,7 @@ void DialogAdjustTempoSM5::onTick() {
         auto segs = gTempo->getSegments();
 
         myDelay = segs->getRow<Delay>(row).seconds;
-        myWarp = segs->getRow<Warp>(row).numRows / (double)ROWS_PER_BEAT;
+        myWarp = segs->getRow<Warp>(row).numRows / static_cast<double>ROWS_PER_BEAT;
 
         auto sig = segs->getRecent<TimeSignature>(row);
         myTimeSigBpm = sig.rowsPerMeasure / ROWS_PER_BEAT;
@@ -208,7 +208,7 @@ void DialogAdjustTempoSM5::onTick() {
         mySpeedUnit = speed.unit;
 
         myScrollRatio = segs->getRecent<Scroll>(row).ratio;
-        myFakeBeats = segs->getRow<Fake>(row).numRows / (double)ROWS_PER_BEAT;
+        myFakeBeats = segs->getRow<Fake>(row).numRows / static_cast<double>ROWS_PER_BEAT;
 
         myLabelText = segs->getRow<Label>(row).str;
     }
@@ -223,11 +223,11 @@ void DialogAdjustTempoSM5::onAction(int id) {
             gTempo->addSegment(Delay(row, myDelay));
         } break;
         case ACT_WARP_SET: {
-            int rows = max(0, (int)(ROWS_PER_BEAT * myWarp));
+            int rows = max(0, static_cast<int>(ROWS_PER_BEAT * myWarp));
             gTempo->addSegment(Warp(row, rows));
         } break;
         case ACT_TIME_SIG_SET: {
-            int rowsPerMeasure = ROWS_PER_BEAT * max(1, (int)myTimeSigBpm);
+            int rowsPerMeasure = ROWS_PER_BEAT * max(1, myTimeSigBpm);
             int beatNote = max(1, myTimeSigNote);
             gTempo->addSegment(TimeSignature(row, rowsPerMeasure, beatNote));
         } break;
@@ -250,7 +250,7 @@ void DialogAdjustTempoSM5::onAction(int id) {
             gTempo->addSegment(Scroll(row, myScrollRatio));
         } break;
         case ACT_FAKE_SET: {
-            int rows = max(0, (int)(ROWS_PER_BEAT * myFakeBeats));
+            int rows = max(0, static_cast<int>(ROWS_PER_BEAT * myFakeBeats));
             gTempo->addSegment(Fake(row, rows));
         } break;
         case ACT_LABEL_SET: {

--- a/src/Dialogs/AdjustTempoSM5.cpp
+++ b/src/Dialogs/AdjustTempoSM5.cpp
@@ -190,7 +190,8 @@ void DialogAdjustTempoSM5::onTick() {
         auto segs = gTempo->getSegments();
 
         myDelay = segs->getRow<Delay>(row).seconds;
-        myWarp = segs->getRow<Warp>(row).numRows / static_cast<double>ROWS_PER_BEAT;
+        myWarp =
+            segs->getRow<Warp>(row).numRows / static_cast<double> ROWS_PER_BEAT;
 
         auto sig = segs->getRecent<TimeSignature>(row);
         myTimeSigBpm = sig.rowsPerMeasure / ROWS_PER_BEAT;
@@ -208,7 +209,8 @@ void DialogAdjustTempoSM5::onTick() {
         mySpeedUnit = speed.unit;
 
         myScrollRatio = segs->getRecent<Scroll>(row).ratio;
-        myFakeBeats = segs->getRow<Fake>(row).numRows / static_cast<double>ROWS_PER_BEAT;
+        myFakeBeats =
+            segs->getRow<Fake>(row).numRows / static_cast<double> ROWS_PER_BEAT;
 
         myLabelText = segs->getRow<Label>(row).str;
     }

--- a/src/Dialogs/ChartList.cpp
+++ b/src/Dialogs/ChartList.cpp
@@ -118,13 +118,13 @@ struct DialogChartList::ChartList : public WgScrollRegion {
     Vector<ChartButton*> myButtons;
     TileRect2 myButtonTex;
 
-    ~ChartList() {
+    ~ChartList() override {
         for (auto button : myButtons) {
             delete button;
         }
     }
 
-    ChartList(GuiContext* gui) : WgScrollRegion(gui) {
+    explicit ChartList(GuiContext* gui) : WgScrollRegion(gui) {
         setScrollType(SCROLL_NEVER, SCROLL_WHEN_NEEDED);
 
         Canvas c(32, 16);

--- a/src/Dialogs/ChartProperties.cpp
+++ b/src/Dialogs/ChartProperties.cpp
@@ -35,7 +35,7 @@ enum NoteItemType {
 static const char* noteItemLabels[] = {"steps", "jumps", "mines",
                                        "holds", "rolls", "warps"};
 
-DialogChartProperties::~DialogChartProperties() {}
+DialogChartProperties::~DialogChartProperties() = default;
 
 DialogChartProperties::DialogChartProperties()
     : myDifficulty(0), myRating(1), myStyle(0) {
@@ -94,7 +94,7 @@ void DialogChartProperties::myCreateChartProperties() {
     diff->value.bind(&myDifficulty);
     diff->onChange.bind(this, &DCP::mySetDifficulty);
     for (int i = 0; i < NUM_DIFFICULTIES; ++i) {
-        diff->addItem(GetDifficultyName((Difficulty)i));
+        diff->addItem(GetDifficultyName(static_cast<Difficulty>(i)));
     }
     diff->setTooltip("Difficulty type of the chart");
 
@@ -122,13 +122,13 @@ void DialogChartProperties::mySetStepArtist() {
 }
 
 void DialogChartProperties::mySetDifficulty() {
-    gChart->setDifficulty((Difficulty)myDifficulty);
+    gChart->setDifficulty(static_cast<Difficulty>(myDifficulty));
 }
 
 void DialogChartProperties::mySetRating() { gChart->setMeter(myRating); }
 
 void DialogChartProperties::myCalcRating() {
-    int rating = (int)(gChart->getEstimatedMeter() * 10 + 0.5);
+    int rating = static_cast<int>(gChart->getEstimatedMeter() * 10 + 0.5);
     if (rating == 190) {
         HudInfo("{g:calculate} Estimated rating: 19 or higher");
     } else {
@@ -200,7 +200,7 @@ void DialogChartProperties::myUpdateNoteInfo() {
 
     double density = 0.0;
     if (gNotes->begin() < gNotes->end()) {
-        density = (double)count[0] /
+        density = static_cast<double>(count[0]) /
                   max(1.0, (gNotes->end() - 1)->time - gNotes->begin()->time);
     }
 
@@ -256,8 +256,8 @@ void DialogChartProperties::mySelectNotes(int type) {
 
 class DialogChartProperties::BreakdownWidget : public GuiWidget {
    public:
-    ~BreakdownWidget();
-    BreakdownWidget(GuiContext* gui);
+    ~BreakdownWidget() override;
+    explicit BreakdownWidget(GuiContext* gui);
 
     void updateBreakdown(WgLabel* measureCount);
     void selectStream(vec2i rows);

--- a/src/Dialogs/CustomSnap.cpp
+++ b/src/Dialogs/CustomSnap.cpp
@@ -7,7 +7,7 @@
 
 namespace Vortex {
 
-DialogCustomSnap::~DialogCustomSnap() {}
+DialogCustomSnap::~DialogCustomSnap() = default;
 
 DialogCustomSnap::DialogCustomSnap() {
     myCustomSnap = gView->getCustomSnap();

--- a/src/Dialogs/DancingBot.cpp
+++ b/src/Dialogs/DancingBot.cpp
@@ -266,7 +266,7 @@ void FeetPlanner::plan(int pn) {
 // ================================================================================================
 // Dancing Bot Dialog.
 
-DialogDancingBot::~DialogDancingBot() {}
+DialogDancingBot::~DialogDancingBot() = default;
 
 DialogDancingBot::DialogDancingBot() {
     setTitle("DANCING BOT");
@@ -335,7 +335,7 @@ void DialogDancingBot::onDraw() {
             for (int y = 0; y < style->padHeight; ++y) {
                 int tile = myPadLayout[y * style->padWidth + x];
                 vec2i pos = myGetDrawPos({x, y});
-                myPadSpr[tile].draw(&batch, pos.x, pos.y, (uint8_t)255);
+                myPadSpr[tile].draw(&batch, pos.x, pos.y, static_cast<uint8_t>(255));
                 if (tile == TT_BUTTON) myPushArrow(&batch, x, y);
             }
         }
@@ -344,10 +344,10 @@ void DialogDancingBot::onDraw() {
         for (int col = 0; col < prevNotes.size(); ++col) {
             auto n = prevNotes[col];
             double dist = n ? (time - n->endtime) : 1000.0;
-            int alpha = min(max((int)((1.5 - dist * 6.0) * 255.0), 0), 255);
+            int alpha = min(max(static_cast<int>((1.5 - dist * 6.0) * 255.0), 0), 255);
             if (alpha > 0) {
                 vec2i pos = myGetDrawPos(style->padColPositions[col]);
-                myPadSpr[2].draw(&batch, pos.x, pos.y, (uint8_t)alpha);
+                myPadSpr[2].draw(&batch, pos.x, pos.y, static_cast<uint8_t>(alpha));
             }
         }
         batch.flush();
@@ -416,7 +416,7 @@ void DialogDancingBot::myPushArrow(QuadBatchTC* batch, int x, int y) {
     static float rot[9] = {2, 2, 3, 1, 0, 3, 1, 0, 0};
     int i = (y % 3) * 3 + (x % 3);
     vec2f pos = ToVec2f(myGetDrawPos({x, y}));
-    myPadSpr[spr[i] + 3].draw(batch, pos.x, pos.y, rot[i] * (float)(M_PI / 2.0),
+    myPadSpr[spr[i] + 3].draw(batch, pos.x, pos.y, rot[i] * static_cast<float>(M_PI / 2.0),
                               1.f);
 }
 
@@ -499,12 +499,12 @@ void DialogDancingBot::myGetFeetPositions(vec3f* out, int pn) {
             double startTime = max(curTime, endtime - 0.5);
             double delta = LerpDelta(startTime, endtime, time);
             curPos =
-                SmoothStep(curPos, endPos, (float)min(max(delta, 0.0), 1.0));
+                SmoothStep(curPos, endPos, static_cast<float>(min(max(delta, 0.0), 1.0)));
         }
 
         // Determine feet scale.
         double dt = min(fabs(curTime - time), fabs(endtime - time));
-        float scale = (float)min(1.0, 0.8 + dt * 6.0);
+        float scale = static_cast<float>(min(1.0, 0.8 + dt * 6.0));
 
         out[f] = {curPos.x, curPos.y, scale};
     }

--- a/src/Dialogs/DancingBot.cpp
+++ b/src/Dialogs/DancingBot.cpp
@@ -335,7 +335,8 @@ void DialogDancingBot::onDraw() {
             for (int y = 0; y < style->padHeight; ++y) {
                 int tile = myPadLayout[y * style->padWidth + x];
                 vec2i pos = myGetDrawPos({x, y});
-                myPadSpr[tile].draw(&batch, pos.x, pos.y, static_cast<uint8_t>(255));
+                myPadSpr[tile].draw(&batch, pos.x, pos.y,
+                                    static_cast<uint8_t>(255));
                 if (tile == TT_BUTTON) myPushArrow(&batch, x, y);
             }
         }
@@ -344,10 +345,12 @@ void DialogDancingBot::onDraw() {
         for (int col = 0; col < prevNotes.size(); ++col) {
             auto n = prevNotes[col];
             double dist = n ? (time - n->endtime) : 1000.0;
-            int alpha = min(max(static_cast<int>((1.5 - dist * 6.0) * 255.0), 0), 255);
+            int alpha =
+                min(max(static_cast<int>((1.5 - dist * 6.0) * 255.0), 0), 255);
             if (alpha > 0) {
                 vec2i pos = myGetDrawPos(style->padColPositions[col]);
-                myPadSpr[2].draw(&batch, pos.x, pos.y, static_cast<uint8_t>(alpha));
+                myPadSpr[2].draw(&batch, pos.x, pos.y,
+                                 static_cast<uint8_t>(alpha));
             }
         }
         batch.flush();
@@ -416,8 +419,8 @@ void DialogDancingBot::myPushArrow(QuadBatchTC* batch, int x, int y) {
     static float rot[9] = {2, 2, 3, 1, 0, 3, 1, 0, 0};
     int i = (y % 3) * 3 + (x % 3);
     vec2f pos = ToVec2f(myGetDrawPos({x, y}));
-    myPadSpr[spr[i] + 3].draw(batch, pos.x, pos.y, rot[i] * static_cast<float>(M_PI / 2.0),
-                              1.f);
+    myPadSpr[spr[i] + 3].draw(batch, pos.x, pos.y,
+                              rot[i] * static_cast<float>(M_PI / 2.0), 1.f);
 }
 
 vec2i DialogDancingBot::myGetDrawPos(vec2i colRow) {
@@ -498,8 +501,8 @@ void DialogDancingBot::myGetFeetPositions(vec3f* out, int pn) {
         if (endtime > curTime) {
             double startTime = max(curTime, endtime - 0.5);
             double delta = LerpDelta(startTime, endtime, time);
-            curPos =
-                SmoothStep(curPos, endPos, static_cast<float>(min(max(delta, 0.0), 1.0)));
+            curPos = SmoothStep(curPos, endPos,
+                                static_cast<float>(min(max(delta, 0.0), 1.0)));
         }
 
         // Determine feet scale.

--- a/src/Dialogs/Dialog.cpp
+++ b/src/Dialogs/Dialog.cpp
@@ -34,7 +34,7 @@ void EditorDialog::setId(DialogId id) { myId = id; }
 DialogId EditorDialog::getId(const char* name) {
     for (int i = 0; i < NUM_DIALOG_IDS; ++i) {
         if (strcmp(IdStrings[i], name) == 0) {
-            return (DialogId)i;
+            return static_cast<DialogId>(i);
         }
     }
     return NUM_DIALOG_IDS;

--- a/src/Dialogs/GenerateNotes.cpp
+++ b/src/Dialogs/GenerateNotes.cpp
@@ -40,7 +40,7 @@ void DialogGenerateNotes::myCreateWidgets() {
     myLayout.row().col(60).col(116);
     spacingDroplist_ = myLayout.add<WgDroplist>("Spacing");
     spacingDroplist_->value.bind(&spacingValue_);
-    for (auto & SpacingString : SpacingStrings) {
+    for (auto& SpacingString : SpacingStrings) {
         spacingDroplist_->addItem(SpacingString);
     }
 

--- a/src/Dialogs/GenerateNotes.cpp
+++ b/src/Dialogs/GenerateNotes.cpp
@@ -25,7 +25,7 @@ static SnapType SpacingTypes[] = {ST_4TH,  ST_8TH,  ST_12TH,
 static const int IFP_SIZE = 24;
 static const int IFP_SPACING = 4;
 
-DialogGenerateNotes::~DialogGenerateNotes() {}
+DialogGenerateNotes::~DialogGenerateNotes() = default;
 
 DialogGenerateNotes::DialogGenerateNotes()
     : footSelectionIndex_(0), spacingValue_(0) {
@@ -40,8 +40,8 @@ void DialogGenerateNotes::myCreateWidgets() {
     myLayout.row().col(60).col(116);
     spacingDroplist_ = myLayout.add<WgDroplist>("Spacing");
     spacingDroplist_->value.bind(&spacingValue_);
-    for (int i = 0; i < 6; ++i) {
-        spacingDroplist_->addItem(SpacingStrings[i]);
+    for (auto & SpacingString : SpacingStrings) {
+        spacingDroplist_->addItem(SpacingString);
     }
 
     myLayout.row().col(180);

--- a/src/Dialogs/LabelBreakdown.cpp
+++ b/src/Dialogs/LabelBreakdown.cpp
@@ -95,13 +95,13 @@ struct DialogLabelBreakdown::LabelList : public WgScrollRegion {
     TileRect2 myButtonTex;
     int myDisplayType;
 
-    ~LabelList() {
+    ~LabelList() override {
         for (auto button : myButtons) {
             delete button;
         }
     }
 
-    LabelList(GuiContext* gui) : WgScrollRegion(gui) {
+    explicit LabelList(GuiContext* gui) : WgScrollRegion(gui) {
         setScrollType(SCROLL_NEVER, SCROLL_WHEN_NEEDED);
 
         Canvas c(32, 16);
@@ -131,8 +131,7 @@ struct DialogLabelBreakdown::LabelList : public WgScrollRegion {
 
         // Update the properties of each button.
         int y = rect_.y - scroll_position_y_;
-        for (int i = 0; i < myButtons.size(); ++i) {
-            auto button = myButtons[i];
+        for (auto button : myButtons) {
             button->arrange({rect_.x, y, viewW, 20});
             button->tick();
             y += 21;
@@ -193,7 +192,7 @@ struct DialogLabelBreakdown::LabelList : public WgScrollRegion {
 
     std::string displayTime(int row) const {
         if (myDisplayType == BEAT) {
-            return Str::val((double)row / ROWS_PER_BEAT, 3, 3);
+            return Str::val(static_cast<double>(row) / ROWS_PER_BEAT, 3, 3);
         } else if (myDisplayType == ROW) {
             return Str::val(row);
         } else {
@@ -222,7 +221,7 @@ struct DialogLabelBreakdown::LabelList : public WgScrollRegion {
 // ================================================================================================
 // DialogLabelList
 
-DialogLabelBreakdown::~DialogLabelBreakdown() {}
+DialogLabelBreakdown::~DialogLabelBreakdown() = default;
 
 DialogLabelBreakdown::DialogLabelBreakdown() {
     setTitle("LABELS");

--- a/src/Dialogs/NewChart.cpp
+++ b/src/Dialogs/NewChart.cpp
@@ -14,7 +14,7 @@
 
 namespace Vortex {
 
-DialogNewChart::~DialogNewChart() {}
+DialogNewChart::~DialogNewChart() = default;
 
 DialogNewChart::DialogNewChart() : myDifficulty(0), myRating(1), myStyle(0) {
     setTitle("NEW CHART");
@@ -38,7 +38,7 @@ void DialogNewChart::myCreateWidgets() {
     diffs->value.bind(&myDifficulty);
     diffs->setTooltip("Difficulty type of the chart");
     for (int i = 0; i < NUM_DIFFICULTIES; ++i) {
-        diffs->addItem(GetDifficultyName((Difficulty)i));
+        diffs->addItem(GetDifficultyName(static_cast<Difficulty>(i)));
     }
 
     WgSpinner* rating = myLayout.add<WgSpinner>();
@@ -66,7 +66,7 @@ void DialogNewChart::myCreateWidgets() {
 
 void DialogNewChart::myCreateChart() {
     if (gSimfile->isOpen()) {
-        auto difficulty = (Difficulty)myDifficulty;
+        auto difficulty = static_cast<Difficulty>(myDifficulty);
         gSimfile->addChart(gStyle->get(myStyle), myStepArtist, difficulty,
                            myRating);
         requestClose();

--- a/src/Dialogs/SongProperties.cpp
+++ b/src/Dialogs/SongProperties.cpp
@@ -23,7 +23,7 @@ namespace Vortex {
 enum BannerSize { BANNER_W = 418, BANNER_H = 164 };
 
 struct DialogSongProperties::BannerWidget : public GuiWidget {
-    BannerWidget(GuiContext* gui) : GuiWidget(gui) {
+    explicit BannerWidget(GuiContext* gui) : GuiWidget(gui) {
         width_ = BANNER_W;
         height_ = BANNER_H;
     }

--- a/src/Dialogs/TempoBreakdown.cpp
+++ b/src/Dialogs/TempoBreakdown.cpp
@@ -18,7 +18,7 @@ static int GetTempoListH() {
     auto segments = gTempo->getSegments();
     int h = 0;
     if (segments) {
-        for (const auto & segment : *segments) {
+        for (const auto& segment : *segments) {
             if (segment.size()) {
                 h += 26 + segment.size() * 16;
             }
@@ -54,7 +54,7 @@ struct DialogTempoBreakdown::TempoList : public WgScrollRegion {
         Draw::fill({view.x + view.w / 2, view.y, 1, view.h}, Color32(26));
 
         auto segments = gTempo->getSegments();
-        for (const auto & segment : *segments) {
+        for (const auto& segment : *segments) {
             if (segment.size()) {
                 auto meta = Segment::meta[segment.type()];
                 auto seg = segment.begin(), segEnd = segment.end();

--- a/src/Dialogs/TempoBreakdown.cpp
+++ b/src/Dialogs/TempoBreakdown.cpp
@@ -18,10 +18,9 @@ static int GetTempoListH() {
     auto segments = gTempo->getSegments();
     int h = 0;
     if (segments) {
-        for (auto list = segments->begin(), listEnd = segments->end();
-             list != listEnd; ++list) {
-            if (list->size()) {
-                h += 26 + list->size() * 16;
+        for (const auto & segment : *segments) {
+            if (segment.size()) {
+                h += 26 + segment.size() * 16;
             }
         }
     }
@@ -29,9 +28,9 @@ static int GetTempoListH() {
 }
 
 struct DialogTempoBreakdown::TempoList : public WgScrollRegion {
-    ~TempoList() {}
+    ~TempoList() override = default;
 
-    TempoList(GuiContext* gui) : WgScrollRegion(gui) {
+    explicit TempoList(GuiContext* gui) : WgScrollRegion(gui) {
         setScrollType(SCROLL_NEVER, SCROLL_WHEN_NEEDED);
     }
 
@@ -55,11 +54,10 @@ struct DialogTempoBreakdown::TempoList : public WgScrollRegion {
         Draw::fill({view.x + view.w / 2, view.y, 1, view.h}, Color32(26));
 
         auto segments = gTempo->getSegments();
-        for (auto list = segments->begin(), listEnd = segments->end();
-             list != listEnd; ++list) {
-            if (list->size()) {
-                auto meta = Segment::meta[list->type()];
-                auto seg = list->begin(), segEnd = list->end();
+        for (const auto & segment : *segments) {
+            if (segment.size()) {
+                auto meta = Segment::meta[segment.type()];
+                auto seg = segment.begin(), segEnd = segment.end();
 
                 Draw::fill({x, y, view.w, 20}, Color32(26));
                 Text::arrange(Text::MC, style, meta->plural);

--- a/src/Dialogs/WaveformSettings.cpp
+++ b/src/Dialogs/WaveformSettings.cpp
@@ -146,7 +146,8 @@ void DialogWaveformSettings::myToggleOverlayFilter() {
 }
 
 void DialogWaveformSettings::myEnableFilter() {
-    gWaveform->enableFilter(static_cast<Waveform::FilterType>(filterType_), filterStrength_);
+    gWaveform->enableFilter(static_cast<Waveform::FilterType>(filterType_),
+                            filterStrength_);
 }
 
 void DialogWaveformSettings::myDisableFilter() { gWaveform->disableFilter(); }

--- a/src/Dialogs/WaveformSettings.cpp
+++ b/src/Dialogs/WaveformSettings.cpp
@@ -6,7 +6,7 @@
 
 namespace Vortex {
 
-DialogWaveformSettings::~DialogWaveformSettings() {}
+DialogWaveformSettings::~DialogWaveformSettings() = default;
 
 DialogWaveformSettings::DialogWaveformSettings() {
     presetIndex_ = 0;
@@ -127,7 +127,7 @@ DialogWaveformSettings::DialogWaveformSettings() {
 }
 
 void DialogWaveformSettings::myApplyPreset() {
-    gWaveform->setPreset((Waveform::Preset)presetIndex_);
+    gWaveform->setPreset(static_cast<Waveform::Preset>(presetIndex_));
     settingsColorScheme_ = gWaveform->getColors();
     luminanceValue_ = gWaveform->getLuminance();
     waveShape_ = gWaveform->getWaveShape();
@@ -137,8 +137,8 @@ void DialogWaveformSettings::myApplyPreset() {
 void DialogWaveformSettings::myUpdateSettings() {
     gWaveform->setColors(settingsColorScheme_);
     gWaveform->setAntiAliasing(antiAliasingMode_);
-    gWaveform->setLuminance((Waveform::Luminance)luminanceValue_);
-    gWaveform->setWaveShape((Waveform::WaveShape)waveShape_);
+    gWaveform->setLuminance(static_cast<Waveform::Luminance>(luminanceValue_));
+    gWaveform->setWaveShape(static_cast<Waveform::WaveShape>(waveShape_));
 }
 
 void DialogWaveformSettings::myToggleOverlayFilter() {
@@ -146,7 +146,7 @@ void DialogWaveformSettings::myToggleOverlayFilter() {
 }
 
 void DialogWaveformSettings::myEnableFilter() {
-    gWaveform->enableFilter((Waveform::FilterType)filterType_, filterStrength_);
+    gWaveform->enableFilter(static_cast<Waveform::FilterType>(filterType_), filterStrength_);
 }
 
 void DialogWaveformSettings::myDisableFilter() { gWaveform->disableFilter(); }

--- a/src/Dialogs/Zoom.cpp
+++ b/src/Dialogs/Zoom.cpp
@@ -12,7 +12,7 @@ enum Actions {
     ACT_SCALE,
 };
 
-DialogZoom::~DialogZoom() {}
+DialogZoom::~DialogZoom() = default;
 
 DialogZoom::DialogZoom() {
     setTitle("ZOOM");
@@ -24,7 +24,7 @@ void DialogZoom::myCreateWidgets() {
 
     WgSlider* slider = myLayout.add<WgSlider>("Zoom");
     slider->value.bind(&myZoomLevel);
-    slider->onChange.bind(this, &DialogZoom::onAction, (int)ACT_ZOOM);
+    slider->onChange.bind(this, &DialogZoom::onAction, static_cast<int>(ACT_ZOOM));
     slider->setRange(1.0, 19.0);
     slider->setTooltip("Zoom Level");
 
@@ -33,11 +33,11 @@ void DialogZoom::myCreateWidgets() {
     spinner->setPrecision(2, 2);
     spinner->setRange(1.0, 19.0);
     spinner->setStep(1.0);
-    spinner->onChange.bind(this, &DialogZoom::onAction, (int)ACT_ZOOM);
+    spinner->onChange.bind(this, &DialogZoom::onAction, static_cast<int>(ACT_ZOOM));
 
     slider = myLayout.add<WgSlider>("Scale");
     slider->value.bind(&myScaleLevel);
-    slider->onChange.bind(this, &DialogZoom::onAction, (int)ACT_SCALE);
+    slider->onChange.bind(this, &DialogZoom::onAction, static_cast<int>(ACT_SCALE));
     slider->setRange(1.0, 10.0);
     slider->setTooltip("Note Scale");
 
@@ -46,7 +46,7 @@ void DialogZoom::myCreateWidgets() {
     spinner->setPrecision(2, 2);
     spinner->setRange(1.0, 10.0);
     spinner->setStep(0.25);
-    spinner->onChange.bind(this, &DialogZoom::onAction, (int)ACT_SCALE);
+    spinner->onChange.bind(this, &DialogZoom::onAction, static_cast<int>(ACT_SCALE));
 }
 
 void DialogZoom::onTick() {

--- a/src/Dialogs/Zoom.cpp
+++ b/src/Dialogs/Zoom.cpp
@@ -24,7 +24,8 @@ void DialogZoom::myCreateWidgets() {
 
     WgSlider* slider = myLayout.add<WgSlider>("Zoom");
     slider->value.bind(&myZoomLevel);
-    slider->onChange.bind(this, &DialogZoom::onAction, static_cast<int>(ACT_ZOOM));
+    slider->onChange.bind(this, &DialogZoom::onAction,
+                          static_cast<int>(ACT_ZOOM));
     slider->setRange(1.0, 19.0);
     slider->setTooltip("Zoom Level");
 
@@ -33,11 +34,13 @@ void DialogZoom::myCreateWidgets() {
     spinner->setPrecision(2, 2);
     spinner->setRange(1.0, 19.0);
     spinner->setStep(1.0);
-    spinner->onChange.bind(this, &DialogZoom::onAction, static_cast<int>(ACT_ZOOM));
+    spinner->onChange.bind(this, &DialogZoom::onAction,
+                           static_cast<int>(ACT_ZOOM));
 
     slider = myLayout.add<WgSlider>("Scale");
     slider->value.bind(&myScaleLevel);
-    slider->onChange.bind(this, &DialogZoom::onAction, static_cast<int>(ACT_SCALE));
+    slider->onChange.bind(this, &DialogZoom::onAction,
+                          static_cast<int>(ACT_SCALE));
     slider->setRange(1.0, 10.0);
     slider->setTooltip("Note Scale");
 
@@ -46,7 +49,8 @@ void DialogZoom::myCreateWidgets() {
     spinner->setPrecision(2, 2);
     spinner->setRange(1.0, 10.0);
     spinner->setStep(0.25);
-    spinner->onChange.bind(this, &DialogZoom::onAction, static_cast<int>(ACT_SCALE));
+    spinner->onChange.bind(this, &DialogZoom::onAction,
+                           static_cast<int>(ACT_SCALE));
 }
 
 void DialogZoom::onTick() {

--- a/src/Editor/Aubio.cpp
+++ b/src/Editor/Aubio.cpp
@@ -13,7 +13,7 @@ namespace Vortex {
 
 fvec_t *new_fvec(uint_t length) {
     fvec_t *s;
-    if ((sint_t)length <= 0) {
+    if (static_cast<sint_t>(length) <= 0) {
         return nullptr;
     }
     s = AUBIO_NEW(fvec_t);
@@ -33,7 +33,7 @@ void fvec_zeros(fvec_t *s) { memset(s->data, 0, s->length * sizeof(smpl_t)); }
 
 cvec_t *new_cvec(uint_t length) {
     cvec_t *s;
-    if ((sint_t)length <= 0) {
+    if (static_cast<sint_t>(length) <= 0) {
         return nullptr;
     }
     s = AUBIO_NEW(cvec_t);
@@ -53,7 +53,7 @@ void del_cvec(cvec_t *s) {
 
 lvec_t *new_lvec(uint_t length) {
     lvec_t *s;
-    if ((sint_t)length <= 0) {
+    if (static_cast<sint_t>(length) <= 0) {
         return nullptr;
     }
     s = AUBIO_NEW(lvec_t);
@@ -141,7 +141,7 @@ fvec_t *new_aubio_window(aubio_window_type window_type, uint_t length) {
 
 smpl_t fvec_median(fvec_t *input) {
     uint_t n = input->length;
-    smpl_t *arr = (smpl_t *)input->data;
+    smpl_t *arr = input->data;
     uint_t low, high;
     uint_t median;
     uint_t middle, ll, hh;
@@ -239,7 +239,7 @@ smpl_t fvec_mean(fvec_t *s) {
     for (j = 0; j < s->length; j++) {
         tmp += s->data[j];
     }
-    return tmp / (smpl_t)(s->length);
+    return tmp / static_cast<smpl_t>(s->length);
 }
 
 smpl_t fvec_quadratic_peak_pos(fvec_t *x, uint_t pos) {

--- a/src/Editor/Butterworth.cpp
+++ b/src/Editor/Butterworth.cpp
@@ -100,8 +100,8 @@ double *binomial_mult(int n, double *p) {
     int i, j;
     double *a;
 
-    a = (double *)calloc(2 * n, sizeof(double));
-    if (a == NULL) return (NULL);
+    a = static_cast<double *>(calloc(2 * n, sizeof(double)));
+    if (a == nullptr) return (nullptr);
 
     for (i = 0; i < n; ++i) {
         for (j = i; j > 0; --j) {
@@ -151,8 +151,8 @@ double *trinomial_mult(int n, double *b, double *c) {
     int i, j;
     double *a;
 
-    a = (double *)calloc(4 * n, sizeof(double));
-    if (a == NULL) return (NULL);
+    a = static_cast<double *>(calloc(4 * n, sizeof(double)));
+    if (a == nullptr) return (nullptr);
 
     a[2] = c[0];
     a[3] = c[1];
@@ -201,15 +201,15 @@ double *dcof_bwlp(int n, double fcf) {
     double *rcof;  // binomial coefficients
     double *dcof;  // dk coefficients
 
-    rcof = (double *)calloc(2 * n, sizeof(double));
-    if (rcof == NULL) return (NULL);
+    rcof = static_cast<double *>(calloc(2 * n, sizeof(double)));
+    if (rcof == nullptr) return (nullptr);
 
     theta = M_PI * fcf;
     st = sin(theta);
     ct = cos(theta);
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * (double)(2 * k + 1) / (double)(2 * n);
+        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = sin(parg);
         cparg = cos(parg);
         a = 1.0 + st * sparg;
@@ -263,11 +263,11 @@ double *dcof_bwbp(int n, double f1f, double f2f) {
     s2t = 2.0 * st * ct;        // sine of 2*theta
     c2t = 2.0 * ct * ct - 1.0;  // cosine of 2*theta
 
-    rcof = (double *)calloc(2 * n, sizeof(double));
-    tcof = (double *)calloc(2 * n, sizeof(double));
+    rcof = static_cast<double *>(calloc(2 * n, sizeof(double)));
+    tcof = static_cast<double *>(calloc(2 * n, sizeof(double)));
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * (double)(2 * k + 1) / (double)(2 * n);
+        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = sin(parg);
         cparg = cos(parg);
         a = 1.0 + s2t * sparg;
@@ -316,11 +316,11 @@ double *dcof_bwbs(int n, double f1f, double f2f) {
     s2t = 2.0 * st * ct;        // sine of 2*theta
     c2t = 2.0 * ct * ct - 1.0;  // cosine 0f 2*theta
 
-    rcof = (double *)calloc(2 * n, sizeof(double));
-    tcof = (double *)calloc(2 * n, sizeof(double));
+    rcof = static_cast<double *>(calloc(2 * n, sizeof(double)));
+    tcof = static_cast<double *>(calloc(2 * n, sizeof(double)));
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * (double)(2 * k + 1) / (double)(2 * n);
+        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = sin(parg);
         cparg = cos(parg);
         a = 1.0 + s2t * sparg;
@@ -351,8 +351,8 @@ int *ccof_bwlp(int n) {
     int m;
     int i;
 
-    ccof = (int *)calloc(n + 1, sizeof(int));
-    if (ccof == NULL) return (NULL);
+    ccof = static_cast<int *>(calloc(n + 1, sizeof(int)));
+    if (ccof == nullptr) return (nullptr);
 
     ccof[0] = 1;
     ccof[1] = n;
@@ -378,7 +378,7 @@ int *ccof_bwhp(int n) {
     int i;
 
     ccof = ccof_bwlp(n);
-    if (ccof == NULL) return (NULL);
+    if (ccof == nullptr) return (nullptr);
 
     for (i = 0; i <= n; ++i)
         if (i % 2) ccof[i] = -ccof[i];
@@ -397,11 +397,11 @@ int *ccof_bwbp(int n) {
     int *ccof;
     int i;
 
-    ccof = (int *)calloc(2 * n + 1, sizeof(int));
-    if (ccof == NULL) return (NULL);
+    ccof = static_cast<int *>(calloc(2 * n + 1, sizeof(int)));
+    if (ccof == nullptr) return (nullptr);
 
     tcof = ccof_bwhp(n);
-    if (tcof == NULL) return (NULL);
+    if (tcof == nullptr) return (nullptr);
 
     for (i = 0; i < n; ++i) {
         ccof[2 * i] = tcof[i];
@@ -427,7 +427,7 @@ double *ccof_bwbs(int n, double f1f, double f2f) {
     alpha =
         -2.0 * cos(M_PI * (f2f + f1f) / 2.0) / cos(M_PI * (f2f - f1f) / 2.0);
 
-    ccof = (double *)calloc(2 * n + 1, sizeof(double));
+    ccof = static_cast<double *>(calloc(2 * n + 1, sizeof(double)));
 
     ccof[0] = 1.0;
 
@@ -462,12 +462,12 @@ double sf_bwlp(int n, double fcf) {
 
     omega = M_PI * fcf;
     fomega = sin(omega);
-    parg0 = M_PI / (double)(2 * n);
+    parg0 = M_PI / static_cast<double>(2 * n);
 
     m = n / 2;
     sf = 1.0;
     for (k = 0; k < n / 2; ++k)
-        sf *= 1.0 + fomega * sin((double)(2 * k + 1) * parg0);
+        sf *= 1.0 + fomega * sin(static_cast<double>(2 * k + 1) * parg0);
 
     fomega = sin(omega / 2.0);
 
@@ -493,12 +493,12 @@ double sf_bwhp(int n, double fcf) {
 
     omega = M_PI * fcf;
     fomega = sin(omega);
-    parg0 = M_PI / (double)(2 * n);
+    parg0 = M_PI / static_cast<double>(2 * n);
 
     m = n / 2;
     sf = 1.0;
     for (k = 0; k < n / 2; ++k)
-        sf *= 1.0 + fomega * sin((double)(2 * k + 1) * parg0);
+        sf *= 1.0 + fomega * sin(static_cast<double>(2 * k + 1) * parg0);
 
     fomega = cos(omega / 2.0);
 
@@ -529,7 +529,7 @@ double sf_bwbp(int n, double f1f, double f2f) {
     sfi = 0.0;
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * (double)(2 * k + 1) / (double)(2 * n);
+        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = ctt + sin(parg);
         cparg = cos(parg);
         a = (sfr + sfi) * (sparg - cparg);
@@ -563,7 +563,7 @@ double sf_bwbs(int n, double f1f, double f2f) {
     sfi = 0.0;
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * (double)(2 * k + 1) / (double)(2 * n);
+        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = tt + sin(parg);
         cparg = cos(parg);
         a = (sfr + sfi) * (sparg - cparg);
@@ -585,7 +585,7 @@ void ButterLowPassCoefs(int order, double frequency, double *outB,
     double sf = sf_bwlp(order, frequency);
 
     for (int i = 0; i <= order; ++i) outA[i] = dcof[i];
-    for (int i = 0; i <= order; ++i) outB[i] = (double)ccof[i] * sf;
+    for (int i = 0; i <= order; ++i) outB[i] = static_cast<double>(ccof[i]) * sf;
 
     free(dcof);
     free(ccof);
@@ -598,7 +598,7 @@ void ButterHighPassCoefs(int order, double frequency, double *outB,
     double sf = sf_bwhp(order, frequency);
 
     for (int i = 0; i <= order; ++i) outA[i] = dcof[i];
-    for (int i = 0; i <= order; ++i) outB[i] = (double)ccof[i] * sf;
+    for (int i = 0; i <= order; ++i) outB[i] = static_cast<double>(ccof[i]) * sf;
 
     free(dcof);
     free(ccof);

--- a/src/Editor/Butterworth.cpp
+++ b/src/Editor/Butterworth.cpp
@@ -209,7 +209,8 @@ double *dcof_bwlp(int n, double fcf) {
     ct = cos(theta);
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
+        parg =
+            M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = sin(parg);
         cparg = cos(parg);
         a = 1.0 + st * sparg;
@@ -267,7 +268,8 @@ double *dcof_bwbp(int n, double f1f, double f2f) {
     tcof = static_cast<double *>(calloc(2 * n, sizeof(double)));
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
+        parg =
+            M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = sin(parg);
         cparg = cos(parg);
         a = 1.0 + s2t * sparg;
@@ -320,7 +322,8 @@ double *dcof_bwbs(int n, double f1f, double f2f) {
     tcof = static_cast<double *>(calloc(2 * n, sizeof(double)));
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
+        parg =
+            M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = sin(parg);
         cparg = cos(parg);
         a = 1.0 + s2t * sparg;
@@ -529,7 +532,8 @@ double sf_bwbp(int n, double f1f, double f2f) {
     sfi = 0.0;
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
+        parg =
+            M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = ctt + sin(parg);
         cparg = cos(parg);
         a = (sfr + sfi) * (sparg - cparg);
@@ -563,7 +567,8 @@ double sf_bwbs(int n, double f1f, double f2f) {
     sfi = 0.0;
 
     for (k = 0; k < n; ++k) {
-        parg = M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
+        parg =
+            M_PI * static_cast<double>(2 * k + 1) / static_cast<double>(2 * n);
         sparg = tt + sin(parg);
         cparg = cos(parg);
         a = (sfr + sfi) * (sparg - cparg);
@@ -585,7 +590,8 @@ void ButterLowPassCoefs(int order, double frequency, double *outB,
     double sf = sf_bwlp(order, frequency);
 
     for (int i = 0; i <= order; ++i) outA[i] = dcof[i];
-    for (int i = 0; i <= order; ++i) outB[i] = static_cast<double>(ccof[i]) * sf;
+    for (int i = 0; i <= order; ++i)
+        outB[i] = static_cast<double>(ccof[i]) * sf;
 
     free(dcof);
     free(ccof);
@@ -598,7 +604,8 @@ void ButterHighPassCoefs(int order, double frequency, double *outB,
     double sf = sf_bwhp(order, frequency);
 
     for (int i = 0; i <= order; ++i) outA[i] = dcof[i];
-    for (int i = 0; i <= order; ++i) outB[i] = static_cast<double>(ccof[i]) * sf;
+    for (int i = 0; i <= order; ++i)
+        outB[i] = static_cast<double>(ccof[i]) * sf;
 
     free(dcof);
     free(ccof);

--- a/src/Editor/Common.cpp
+++ b/src/Editor/Common.cpp
@@ -32,8 +32,8 @@ static void Ascii85enc(std::string& out, const uint8_t* in, int size) {
         if (blocks[i] == 0 && i != blocks.size() - 1) {
             Str::append(out, 'z');
         } else
-            for (int j = 0; j != 5; ++j) {
-                Str::append(out, 33 + (blocks[i] / a85div[j]) % 85);
+            for (unsigned int j : a85div) {
+                Str::append(out, 33 + (blocks[i] / j) % 85);
             }
     }
 
@@ -141,7 +141,7 @@ RowType ToRowType(int rowIndex) {
         int mod[8] = {48, 24, 16, 12, 8, 6, 4, 3};
         for (int i = 0; i < 192; ++i) {
             for (int j = 0; j < 8 && i % mod[j] != 0; ++j) {
-                map[i] = (RowType)(map[i] + 1);
+                map[i] = static_cast<RowType>(map[i] + 1);
             }
         }
     }

--- a/src/Editor/ConvertToOgg.cpp
+++ b/src/Editor/ConvertToOgg.cpp
@@ -50,7 +50,7 @@ void WriteWaveHeader(WaveHeader* out, int numFrames, int samplerate) {
 }
 
 struct OggConversionPipe : public System::CommandPipe {
-    int read() {
+    int read() override {
         if (terminateFlag.stop_requested()) {
             return 0;
         }
@@ -64,7 +64,7 @@ struct OggConversionPipe : public System::CommandPipe {
             samples[p++] = *srcR++;
         }
         framesLeft -= numFrames;
-        *progress = (uint8_t)(100 - (uint64_t)(100 * framesLeft / totalFrames));
+        *progress = static_cast<uint8_t>(100 - static_cast<uint64_t>(100 * framesLeft / totalFrames));
         return numFrames * 4;
     }
     uint8_t* progress;
@@ -90,7 +90,7 @@ void OggConversionThread::exec() {
     pipe->firstChunk = true;
     pipe->progress = &progress;
     pipe->terminateFlag = getStopToken();
-    WriteWaveHeader((WaveHeader*)(pipe->samples), music.getNumFrames(),
+    WriteWaveHeader(reinterpret_cast<WaveHeader*>(pipe->samples), music.getNumFrames(),
                     music.getFrequency());
 
     // Encode the PCM file with the oggenc2 command line utility.

--- a/src/Editor/ConvertToOgg.cpp
+++ b/src/Editor/ConvertToOgg.cpp
@@ -64,7 +64,8 @@ struct OggConversionPipe : public System::CommandPipe {
             samples[p++] = *srcR++;
         }
         framesLeft -= numFrames;
-        *progress = static_cast<uint8_t>(100 - static_cast<uint64_t>(100 * framesLeft / totalFrames));
+        *progress = static_cast<uint8_t>(
+            100 - static_cast<uint64_t>(100 * framesLeft / totalFrames));
         return numFrames * 4;
     }
     uint8_t* progress;
@@ -90,8 +91,8 @@ void OggConversionThread::exec() {
     pipe->firstChunk = true;
     pipe->progress = &progress;
     pipe->terminateFlag = getStopToken();
-    WriteWaveHeader(reinterpret_cast<WaveHeader*>(pipe->samples), music.getNumFrames(),
-                    music.getFrequency());
+    WriteWaveHeader(reinterpret_cast<WaveHeader*>(pipe->samples),
+                    music.getNumFrames(), music.getFrequency());
 
     // Encode the PCM file with the oggenc2 command line utility.
     std::string cmd = Str::fmt("oggenc2.exe -q6 -o \"%1\" -").arg(outPath);

--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -162,8 +162,8 @@ struct EditingImpl : public Editing {
                     gNotes->modify(edit, false);
                 } else {
                     edit.add.append({row, row, static_cast<uint32_t>(col),
-                                     static_cast<uint32_t>(myCurPlayer), NOTE_STEP_OR_HOLD,
-                                     quant});
+                                     static_cast<uint32_t>(myCurPlayer),
+                                     NOTE_STEP_OR_HOLD, quant});
                     if (evt.keyflags & Keyflag::SHIFT) {
                         edit.add.begin()->type = NOTE_MINE;
                         gNotes->modify(edit, false);
@@ -324,8 +324,7 @@ struct EditingImpl : public Editing {
             if (pnote.endRow < pnote.startRow) {
                 auto hold = gNotes->getNoteIntersecting(note.row, col);
                 if (hold && hold->endrow > hold->row) {
-                    if (note.row > hold->row &&
-                        note.row <= hold->endrow &&
+                    if (note.row > hold->row && note.row <= hold->endrow &&
                         note.endrow > hold->endrow) {
                         note.row = static_cast<uint32_t>(hold->row);
                     }
@@ -545,9 +544,9 @@ struct EditingImpl : public Editing {
 
     template <typename T>
     static T readFromBuffer(Vector<uint8_t>& buffer, int& pos) {
-        if (pos + (int)sizeof(T) <= buffer.size()) {
+        if (pos + sizeof(T) <= buffer.size()) {
             pos += sizeof(T);
-            return *(T*)(buffer.data() + pos - sizeof(T));
+            return *static_cast<T*>(buffer.data() + pos - sizeof(T));
         }
         pos = buffer.size();
         return 0;
@@ -671,7 +670,7 @@ struct EditingImpl : public Editing {
         // outside the selection range.
         if (gSelection->getType() == Selection::REGION) {
             auto region = gSelection->getSelectedRegion();
-            for (auto & it : edit.add) {
+            for (auto& it : edit.add) {
                 if (it.row > region.endRow) it.row = -1;
             }
             edit.add.cleanup();
@@ -1032,11 +1031,11 @@ Editing* gEditing = nullptr;
 
 void Editing::create(XmrNode& settings) {
     gEditing = new EditingImpl();
-    ((EditingImpl*)gEditing)->loadSettings(settings);
+    static_cast<EditingImpl*>(gEditing)->loadSettings(settings);
 }
 
 void Editing::destroy() {
-    delete (EditingImpl*)gEditing;
+    delete static_cast<EditingImpl*>(gEditing);
     gEditing = nullptr;
 }
 

--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -77,7 +77,7 @@ struct EditingImpl : public Editing {
     // ================================================================================================
     // EditingImpl :: constructor and destructor.
 
-    ~EditingImpl() {}
+    ~EditingImpl() = default;
 
     EditingImpl() {
         myCurPlayer = 0;
@@ -103,7 +103,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void saveSettings(XmrNode& settings) {
+    void saveSettings(XmrNode& settings) override {
         XmrNode* editing = settings.addChild("editing");
 
         editing->addAttrib("useJumpToNextNote", myUseJumpToNextNote);
@@ -161,8 +161,8 @@ struct EditingImpl : public Editing {
                     edit.rem.append(CompressNote(*note));
                     gNotes->modify(edit, false);
                 } else {
-                    edit.add.append({row, row, (uint32_t)col,
-                                     (uint32_t)myCurPlayer, NOTE_STEP_OR_HOLD,
+                    edit.add.append({row, row, static_cast<uint32_t>(col),
+                                     static_cast<uint32_t>(myCurPlayer), NOTE_STEP_OR_HOLD,
                                      quant});
                     if (evt.keyflags & Keyflag::SHIFT) {
                         edit.add.begin()->type = NOTE_MINE;
@@ -288,7 +288,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void onChanges(int changes) {
+    void onChanges(int changes) override {
         if (changes & VCM_CHART_CHANGED) {
             if (myCurPlayer >= gStyle->getNumPlayers()) {
                 myCurPlayer = 0;
@@ -324,10 +324,10 @@ struct EditingImpl : public Editing {
             if (pnote.endRow < pnote.startRow) {
                 auto hold = gNotes->getNoteIntersecting(note.row, col);
                 if (hold && hold->endrow > hold->row) {
-                    if ((int)note.row > hold->row &&
-                        (int)note.row <= hold->endrow &&
-                        (int)note.endrow > hold->endrow) {
-                        note.row = (uint32_t)hold->row;
+                    if (note.row > hold->row &&
+                        note.row <= hold->endrow &&
+                        note.endrow > hold->endrow) {
+                        note.row = static_cast<uint32_t>(hold->row);
                     }
                 }
             }
@@ -347,7 +347,7 @@ struct EditingImpl : public Editing {
         pnote.mode = PLACE_NONE;
     }
 
-    void deleteSelection() {
+    void deleteSelection() override {
         if (gSelection->getType() == Selection::TEMPO) {
             gTempo->removeSelectedSegments();
         } else {
@@ -355,7 +355,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void changeHoldsToRolls() {
+    void changeHoldsToRolls() override {
         if (gChart->isClosed()) return;
 
         NoteEdit edit;
@@ -392,7 +392,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void changeHoldsToType(NoteType type) {
+    void changeHoldsToType(NoteType type) override {
         NoteEdit edit;
         gSelection->getSelectedNotes(edit.add);
 
@@ -453,7 +453,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void changeNotesToType(NoteType type) {
+    void changeNotesToType(NoteType type) override {
         static const NotesMan::EditDescription descs[NUM_NOTE_TYPES] = {
             {"Converted %1 step to step.", "Converted %1 steps to steps."},
             {"Converted %1 step to mine.", "Converted %1 steps to mines."},
@@ -465,7 +465,7 @@ struct EditingImpl : public Editing {
         changeNoteTypeToType(NOTE_STEP_OR_HOLD, type, &descs[type]);
     }
 
-    void changeMinesToType(NoteType type) {
+    void changeMinesToType(NoteType type) override {
         static const NotesMan::EditDescription descs[NUM_NOTE_TYPES] = {
             {"Converted %1 mine to step.", "Converted %1 mines to steps."},
             {"Converted %1 mine to mine.", "Converted %1 mines to mines."},
@@ -477,7 +477,7 @@ struct EditingImpl : public Editing {
         changeNoteTypeToType(NOTE_MINE, type, &descs[type]);
     }
 
-    void changeFakesToType(NoteType type) {
+    void changeFakesToType(NoteType type) override {
         static const NotesMan::EditDescription descs[NUM_NOTE_TYPES] = {
             {"Converted %1 fake to step.", "Converted %1 fakes to steps."},
             {"Converted %1 fake to mine.", "Converted %1 fakes to mines."},
@@ -489,7 +489,7 @@ struct EditingImpl : public Editing {
         changeNoteTypeToType(NOTE_FAKE, type, &descs[type]);
     }
 
-    void changeLiftsToType(NoteType type) {
+    void changeLiftsToType(NoteType type) override {
         static const NotesMan::EditDescription descs[NUM_NOTE_TYPES] = {
             {"Converted %1 lift to step.", "Converted %1 lifts to steps."},
             {"Converted %1 lift to mine.", "Converted %1 lifts to mines."},
@@ -501,7 +501,7 @@ struct EditingImpl : public Editing {
         changeNoteTypeToType(NOTE_LIFT, type, &descs[type]);
     }
 
-    void changePlayerNumber() {
+    void changePlayerNumber() override {
         int numPlayers = gStyle->getNumPlayers();
 
         // Check if the current style actually supports more than 1 player.
@@ -602,7 +602,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void mirrorNotes(MirrorType type) {
+    void mirrorNotes(MirrorType type) override {
         NoteEdit edit;
         gSelection->getSelectedNotes(edit.add);
 
@@ -650,7 +650,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void scaleNotes(int numerator, int denominator) {
+    void scaleNotes(int numerator, int denominator) override {
         NoteEdit edit;
         gSelection->getSelectedNotes(edit.add);
         edit.rem = edit.add;
@@ -671,9 +671,8 @@ struct EditingImpl : public Editing {
         // outside the selection range.
         if (gSelection->getType() == Selection::REGION) {
             auto region = gSelection->getSelectedRegion();
-            for (auto it = edit.add.begin(), end = edit.add.end(); it != end;
-                 ++it) {
-                if (it->row > region.endRow) it->row = -1;
+            for (auto & it : edit.add) {
+                if (it.row > region.endRow) it.row = -1;
             }
             edit.add.cleanup();
         }
@@ -693,7 +692,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void insertRows(int row, int numRows, bool curChartOnly) {
+    void insertRows(int row, int numRows, bool curChartOnly) override {
         if (gSimfile->isOpen()) {
             gHistory->startChain();
             gTempo->insertRows(row, numRows, curChartOnly);
@@ -719,7 +718,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void injectBoundingBpmChange() {
+    void injectBoundingBpmChange() override {
         if (gSimfile->isClosed() || !gView->isTimeBased()) {
             return;
         }
@@ -729,7 +728,7 @@ struct EditingImpl : public Editing {
         gTempo->injectBoundingBpmChange(anchor_row);
     }
 
-    void shiftAnchorRowToMousePosition(bool is_destructive) {
+    void shiftAnchorRowToMousePosition(bool is_destructive) override {
         if (gSimfile->isClosed() || !gView->isTimeBased()) {
             return;
         }
@@ -777,7 +776,7 @@ struct EditingImpl : public Editing {
     // ================================================================================================
     // EditingImpl :: routine functions.
 
-    void convertRoutineToCouples() {
+    void convertRoutineToCouples() override {
         const char* title = "Convert Routine to ITG Couples";
 
         // Find all routine charts.
@@ -846,7 +845,7 @@ struct EditingImpl : public Editing {
         gHistory->finishChain(title);
     }
 
-    void convertCouplesToRoutine() {
+    void convertCouplesToRoutine() override {
         auto segments = gTempo->getSegments();
 
         // Find all doubles charts.
@@ -924,7 +923,7 @@ struct EditingImpl : public Editing {
         gHistory->finishChain("Convert ITG Couples to Routine");
     }
 
-    void exportNotesAsLuaTable() {
+    void exportNotesAsLuaTable() override {
         const Chart* chart = gChart->get();
         if (!chart) {
             HudInfo("No notes to export, open a chart first.");
@@ -976,7 +975,7 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void drawGhostNotes() {
+    void drawGhostNotes() override {
         for (int col = 0; col < SIM_MAX_COLUMNS; ++col) {
             auto& pnote = myPlacingNotes[col];
             pnote.endRow = gView->getCursorRow();
@@ -986,28 +985,28 @@ struct EditingImpl : public Editing {
         }
     }
 
-    void toggleJumpToNextNote() {
+    void toggleJumpToNextNote() override {
         myUseJumpToNextNote = !myUseJumpToNextNote;
         gMenubar->update(Menubar::USE_JUMP_TO_NEXT_NOTE);
     }
 
-    bool hasJumpToNextNote() { return myUseJumpToNextNote; }
+    bool hasJumpToNextNote() override { return myUseJumpToNextNote; }
 
-    void toggleUndoRedoJump() {
+    void toggleUndoRedoJump() override {
         myUseUndoRedoJump = !myUseUndoRedoJump;
         gMenubar->update(Menubar::USE_UNDO_REDO_JUMP);
     }
 
-    bool hasUndoRedoJump() { return myUseUndoRedoJump; }
+    bool hasUndoRedoJump() override { return myUseUndoRedoJump; }
 
-    void toggleTimeBasedCopy() {
+    void toggleTimeBasedCopy() override {
         myUseTimeBasedCopy = !myUseTimeBasedCopy;
         gMenubar->update(Menubar::USE_TIME_BASED_COPY);
     }
 
-    bool hasTimeBasedCopy() { return myUseTimeBasedCopy; }
+    bool hasTimeBasedCopy() override { return myUseTimeBasedCopy; }
 
-    void setVisualSyncAnchor(VisualSyncAnchor anchor) {
+    void setVisualSyncAnchor(VisualSyncAnchor anchor) override {
         myVisualSyncAnchor = anchor;
         switch (myVisualSyncAnchor) {
             case VisualSyncAnchor::RECEPTORS:
@@ -1022,7 +1021,7 @@ struct EditingImpl : public Editing {
         gMenubar->update(Menubar::VISUAL_SYNC_ANCHOR);
     }
 
-    VisualSyncAnchor getVisualSyncMode() { return myVisualSyncAnchor; }
+    VisualSyncAnchor getVisualSyncMode() override { return myVisualSyncAnchor; }
 
 };  // EditingImpl
 

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -345,7 +345,8 @@ struct EditorImpl : public Editor, public InputHandler {
             if (dialog && dialog->isPinned()) {
                 auto r = dialog->getInnerRect();
                 if (r.w > 0 && r.h > 0) {
-                    auto name = EditorDialog::getName(static_cast<DialogId>(id));
+                    auto name =
+                        EditorDialog::getName(static_cast<DialogId>(id));
                     XmrNode* node = dialogs->addChild(name);
                     long vals[] = {r.x, r.y, r.w, r.h};
                     node->addAttrib("rect", vals, 4);
@@ -613,7 +614,9 @@ struct EditorImpl : public Editor, public InputHandler {
 
     int getNumRecentFiles() override { return myRecentFiles.size(); }
 
-    const std::string& getRecentFile(int index) override { return myRecentFiles[index]; }
+    const std::string& getRecentFile(int index) override {
+        return myRecentFiles[index];
+    }
 
     // ================================================================================================
     // EditorImpl :: dialog management.
@@ -633,7 +636,9 @@ struct EditorImpl : public Editor, public InputHandler {
         }
     }
 
-    void openDialog(int dialogId) override { myDialogs[dialogId].requestOpen = true; }
+    void openDialog(int dialogId) override {
+        myDialogs[dialogId].requestOpen = true;
+    }
 
     void handleDialogs() {
         for (int id = 0; id < NUM_DIALOG_IDS; ++id) {
@@ -732,7 +737,9 @@ struct EditorImpl : public Editor, public InputHandler {
         }
     }
 
-    void onMenuAction(int id) override { Action::perform(static_cast<Action::Type>(id)); }
+    void onMenuAction(int id) override {
+        Action::perform(static_cast<Action::Type>(id));
+    }
 
     void onExitProgram() override {
         if (closeSimfile()) {
@@ -902,12 +909,12 @@ Editor* gEditor = nullptr;
 
 void Editor::create() {
     gEditor = new EditorImpl;
-    ((EditorImpl*)gEditor)->init();
+    static_cast<EditorImpl*>(gEditor)->init();
 }
 
 void Editor::destroy() {
-    ((EditorImpl*)gEditor)->shutdown();
-    delete (EditorImpl*)gEditor;
+    static_cast<EditorImpl*>(gEditor)->shutdown();
+    delete static_cast<EditorImpl*>(gEditor);
     gEditor = nullptr;
 }
 

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -138,7 +138,7 @@ struct EditorImpl : public Editor, public InputHandler {
     // ================================================================================================
     // EditorImpl :: constructor and destructor.
 
-    ~EditorImpl() {}
+    ~EditorImpl() = default;
 
     EditorImpl() {
         gSystem->setWindowTitle("ArrowVortex");
@@ -334,7 +334,7 @@ struct EditorImpl : public Editor, public InputHandler {
         XmrNode* interface = settings.addChild("interface");
 
         interface->addAttrib("fontPath", myFontPath.c_str());
-        interface->addAttrib("fontSize", (long)myFontSize);
+        interface->addAttrib("fontSize", static_cast<long>(myFontSize));
     }
 
     void saveDialogSettings(XmrNode& settings) {
@@ -345,7 +345,7 @@ struct EditorImpl : public Editor, public InputHandler {
             if (dialog && dialog->isPinned()) {
                 auto r = dialog->getInnerRect();
                 if (r.w > 0 && r.h > 0) {
-                    auto name = EditorDialog::getName((DialogId)id);
+                    auto name = EditorDialog::getName(static_cast<DialogId>(id));
                     XmrNode* node = dialogs->addChild(name);
                     long vals[] = {r.x, r.y, r.w, r.h};
                     node->addAttrib("rect", vals, 4);
@@ -409,7 +409,7 @@ struct EditorImpl : public Editor, public InputHandler {
         return out;
     }
 
-    bool closeSimfile() {
+    bool closeSimfile() override {
         // Check if a simfile is currently open.
         if (gSimfile->isClosed()) return true;
 
@@ -440,14 +440,14 @@ struct EditorImpl : public Editor, public InputHandler {
         return true;
     }
 
-    bool openSimfile() {
+    bool openSimfile() override {
         std::string filters(loadFilters, sizeof(loadFilters));
         std::string path =
             gSystem->openFileDlg("Open file", std::string(), filters);
         return openSimfile(path);
     }
 
-    bool openSimfile(const std::string& path) {
+    bool openSimfile(const std::string& path) override {
         bool result = false;
         if (path.length() && closeSimfile()) {
             if (gSimfile->load(path)) {
@@ -460,14 +460,14 @@ struct EditorImpl : public Editor, public InputHandler {
         return result;
     }
 
-    bool openSimfile(int recentFileIndex) {
+    bool openSimfile(int recentFileIndex) override {
         if (recentFileIndex >= 0 || recentFileIndex < myRecentFiles.size()) {
             return openSimfile(myRecentFiles[recentFileIndex]);
         }
         return false;
     }
 
-    bool openNextSimfile(bool iterateForward) {
+    bool openNextSimfile(bool iterateForward) override {
         // Check if a simfile is currently open.
         if (gSimfile->isClosed()) return false;
 
@@ -515,7 +515,7 @@ struct EditorImpl : public Editor, public InputHandler {
         return openSimfile(path);
     }
 
-    bool saveSimfile(bool showSaveAsDialog) {
+    bool saveSimfile(bool showSaveAsDialog) override {
         // Check if a simfile is currently open.
         if (gSimfile->isClosed()) return true;
 
@@ -606,14 +606,14 @@ struct EditorImpl : public Editor, public InputHandler {
         gMenubar->update(Menubar::RECENT_FILES);
     }
 
-    void clearRecentFiles() {
+    void clearRecentFiles() override {
         myRecentFiles.clear();
         gMenubar->update(Menubar::RECENT_FILES);
     }
 
-    int getNumRecentFiles() { return myRecentFiles.size(); }
+    int getNumRecentFiles() override { return myRecentFiles.size(); }
 
-    const std::string& getRecentFile(int index) { return myRecentFiles[index]; }
+    const std::string& getRecentFile(int index) override { return myRecentFiles[index]; }
 
     // ================================================================================================
     // EditorImpl :: dialog management.
@@ -622,23 +622,23 @@ struct EditorImpl : public Editor, public InputHandler {
         XmrNode* dialogs = settings.child("dialogs");
         if (dialogs) {
             for (int id = 0; id < NUM_DIALOG_IDS; ++id) {
-                auto name = EditorDialog::getName((DialogId)id);
+                auto name = EditorDialog::getName(static_cast<DialogId>(id));
                 XmrNode* node = dialogs->child(name);
                 int r[4] = {0, 0, 0, 0};
                 if (node && node->get("rect", r, 4)) {
                     recti rect = {r[0], r[1], r[2], r[3]};
-                    handleDialogOpening((DialogId)id, rect);
+                    handleDialogOpening(static_cast<DialogId>(id), rect);
                 }
             }
         }
     }
 
-    void openDialog(int dialogId) { myDialogs[dialogId].requestOpen = true; }
+    void openDialog(int dialogId) override { myDialogs[dialogId].requestOpen = true; }
 
     void handleDialogs() {
         for (int id = 0; id < NUM_DIALOG_IDS; ++id) {
             if (myDialogs[id].requestOpen) {
-                handleDialogOpening((DialogId)id, {0, 0, 0, 0});
+                handleDialogOpening(static_cast<DialogId>(id), {0, 0, 0, 0});
             }
         }
     }
@@ -711,12 +711,12 @@ struct EditorImpl : public Editor, public InputHandler {
         entry.requestOpen = false;
     }
 
-    void onDialogClosed(int id) { myDialogs[id].ptr = nullptr; }
+    void onDialogClosed(int id) override { myDialogs[id].ptr = nullptr; }
 
     // ================================================================================================
     // EditorImpl :: event handling.
 
-    void onCommandLineArgs(const std::string* args, int numArgs) {
+    void onCommandLineArgs(const std::string* args, int numArgs) override {
         if (numArgs >= 2 && args[1].length()) {
             Path argPath(gSystem->getRunDir(), args[1]);
             std::string simfilePath = findSimfile(argPath, false);
@@ -724,7 +724,7 @@ struct EditorImpl : public Editor, public InputHandler {
         }
     }
 
-    void onFileDrop(FileDrop& evt) {
+    void onFileDrop(FileDrop& evt) override {
         if (evt.count >= 1) {
             Path dropPath(evt.files[0]);
             std::string simfilePath = findSimfile(dropPath, false);
@@ -732,9 +732,9 @@ struct EditorImpl : public Editor, public InputHandler {
         }
     }
 
-    void onMenuAction(int id) { Action::perform((Action::Type)id); }
+    void onMenuAction(int id) override { Action::perform(static_cast<Action::Type>(id)); }
 
-    void onExitProgram() {
+    void onExitProgram() override {
         if (closeSimfile()) {
             gSystem->terminate();
         }
@@ -759,7 +759,7 @@ struct EditorImpl : public Editor, public InputHandler {
         myChanges = 0;
     }
 
-    void onKeyPress(KeyPress& press) {
+    void onKeyPress(KeyPress& press) override {
         // if(press.key == Key::V)
         //{
         //	VerifySaveLoadIdentity(*gSimfile->getSimfile());
@@ -769,7 +769,7 @@ struct EditorImpl : public Editor, public InputHandler {
     // ================================================================================================
     // EditorImpl :: misc functions.
 
-    void reportChanges(int changes) { myChanges |= changes; }
+    void reportChanges(int changes) override { myChanges |= changes; }
 
     void updateTitle() {
         std::string title, subtitle;
@@ -798,7 +798,7 @@ struct EditorImpl : public Editor, public InputHandler {
                      RGBAtoColor32(255, 255, 255, 26));
     }
 
-    void tick() {
+    void tick() override {
         InputEvents& events = gSystem->getEvents();
         handleInputs(events);
         notifyChanges();
@@ -879,18 +879,18 @@ struct EditorImpl : public Editor, public InputHandler {
         GuiMain::frameEnd();
     }
 
-    bool hasMultithreading() const { return myUseMultithreading; }
+    bool hasMultithreading() const override { return myUseMultithreading; }
 
-    void setBackgroundStyle(int style) {
-        myBackgroundStyle = (BackgroundStyle)style;
+    void setBackgroundStyle(int style) override {
+        myBackgroundStyle = static_cast<BackgroundStyle>(style);
         gMenubar->update(Menubar::VIEW_BACKGROUND);
     }
 
-    int getBackgroundStyle() const { return myBackgroundStyle; }
+    int getBackgroundStyle() const override { return myBackgroundStyle; }
 
-    int getDefaultSaveFormat() const { return myDefaultSaveFormat; }
+    int getDefaultSaveFormat() const override { return myDefaultSaveFormat; }
 
-    GuiContext* getGui() const { return gui_; }
+    GuiContext* getGui() const override { return gui_; }
 
 };  // EditorImpl
 };  // anonymous namespace

--- a/src/Editor/FindOnsets.cpp
+++ b/src/Editor/FindOnsets.cpp
@@ -416,14 +416,14 @@ static void aubio_pvoc_do(aubio_pvoc_t *pv, fvec_t *datanew, cvec_t *fftgrain) {
 // ================================================================================================
 // Peak picker.
 
-static aubio_peakpicker_t *new_aubio_peakpicker(void) {
+static aubio_peakpicker_t *new_aubio_peakpicker() {
     aubio_peakpicker_t *t = AUBIO_NEW(aubio_peakpicker_t);
     t->threshold = 0.1; /* 0.0668; 0.33; 0.082; 0.033; */
     t->win_post = 5;
     t->win_pre = 1;
 
-    t->thresholdfn = (aubio_thresholdfn_t)(fvec_median); /* (fvec_mean); */
-    t->pickerfn = (aubio_pickerfn_t)(fvec_peakpick);
+    t->thresholdfn = static_cast<aubio_thresholdfn_t>(fvec_median); /* (fvec_mean); */
+    t->pickerfn = static_cast<aubio_pickerfn_t>(fvec_peakpick);
 
     t->scratch = new_fvec(t->win_post + t->win_pre + 1);
     t->onset_keep = new_fvec(t->win_post + t->win_pre + 1);
@@ -543,7 +543,7 @@ static void aubio_scale_do(aubio_scale_t *s, fvec_t *input) {
 
 static aubio_hist_t *new_aubio_hist(smpl_t flow, smpl_t fhig, uint_t nelems) {
     aubio_hist_t *s = AUBIO_NEW(aubio_hist_t);
-    smpl_t step = (fhig - flow) / (smpl_t)(nelems);
+    smpl_t step = (fhig - flow) / static_cast<smpl_t>(nelems);
     smpl_t accum = step;
     uint_t i;
     s->nelems = nelems;
@@ -572,7 +572,7 @@ static void aubio_hist_dyn_notnull(aubio_hist_t *s, fvec_t *input) {
     sint_t tmp = 0;
     smpl_t ilow = fvec_min(input);
     smpl_t ihig = fvec_max(input);
-    smpl_t step = (ihig - ilow) / (smpl_t)(s->nelems);
+    smpl_t step = (ihig - ilow) / static_cast<smpl_t>(s->nelems);
 
     /* readapt */
     aubio_scale_set_limits(s->scaler, ilow, ihig, 0, s->nelems);
@@ -590,8 +590,8 @@ static void aubio_hist_dyn_notnull(aubio_hist_t *s, fvec_t *input) {
     /* run accum */
     for (i = 0; i < input->length; i++) {
         if (input->data[i] != 0) {
-            tmp = (sint_t)FLOOR(input->data[i]);
-            if ((tmp >= 0) && (tmp < (sint_t)s->nelems))
+            tmp = static_cast<sint_t>(FLOOR(input->data[i]));
+            if ((tmp >= 0) && (tmp < static_cast<sint_t>(s->nelems)))
                 s->hist->data[tmp] += 1;
         }
     }
@@ -608,7 +608,7 @@ static smpl_t aubio_hist_mean(aubio_hist_t *s) {
     uint_t j;
     smpl_t tmp = 0.0;
     for (j = 0; j < s->nelems; j++) tmp += s->hist->data[j];
-    return tmp / (smpl_t)(s->nelems);
+    return tmp / static_cast<smpl_t>(s->nelems);
 }
 
 // ================================================================================================
@@ -908,7 +908,7 @@ static uint_t aubio_onset_set_minioi(aubio_onset_t *o, uint_t minioi) {
 }
 
 static uint_t aubio_onset_set_minioi_s(aubio_onset_t *o, smpl_t minioi) {
-    return aubio_onset_set_minioi(o, (uint_t)(minioi * o->samplerate));
+    return aubio_onset_set_minioi(o, static_cast<uint_t>(minioi * o->samplerate));
 }
 
 static uint_t aubio_onset_set_minioi_ms(aubio_onset_t *o, smpl_t minioi) {
@@ -969,7 +969,7 @@ static void aubio_onset_do(aubio_onset_t *o, fvec_t *input, fvec_t *onset) {
             isonset = 0;
         } else {
             uint_t new_onset =
-                o->total_frames + (uint_t)ROUND(isonset * o->hop_size);
+                o->total_frames + static_cast<uint_t>(ROUND(isonset * o->hop_size));
             if (o->last_onset + o->minioi < new_onset) {
                 // AUBIO_DBG ("accepted detection, marking as onset\n");
                 o->last_onset = new_onset;

--- a/src/Editor/FindOnsets.cpp
+++ b/src/Editor/FindOnsets.cpp
@@ -422,7 +422,8 @@ static aubio_peakpicker_t *new_aubio_peakpicker() {
     t->win_post = 5;
     t->win_pre = 1;
 
-    t->thresholdfn = static_cast<aubio_thresholdfn_t>(fvec_median); /* (fvec_mean); */
+    t->thresholdfn =
+        static_cast<aubio_thresholdfn_t>(fvec_median); /* (fvec_mean); */
     t->pickerfn = static_cast<aubio_pickerfn_t>(fvec_peakpick);
 
     t->scratch = new_fvec(t->win_post + t->win_pre + 1);
@@ -908,7 +909,8 @@ static uint_t aubio_onset_set_minioi(aubio_onset_t *o, uint_t minioi) {
 }
 
 static uint_t aubio_onset_set_minioi_s(aubio_onset_t *o, smpl_t minioi) {
-    return aubio_onset_set_minioi(o, static_cast<uint_t>(minioi * o->samplerate));
+    return aubio_onset_set_minioi(o,
+                                  static_cast<uint_t>(minioi * o->samplerate));
 }
 
 static uint_t aubio_onset_set_minioi_ms(aubio_onset_t *o, smpl_t minioi) {
@@ -969,7 +971,8 @@ static void aubio_onset_do(aubio_onset_t *o, fvec_t *input, fvec_t *onset) {
             isonset = 0;
         } else {
             uint_t new_onset =
-                o->total_frames + static_cast<uint_t>(ROUND(isonset * o->hop_size));
+                o->total_frames +
+                static_cast<uint_t>(ROUND(isonset * o->hop_size));
             if (o->last_onset + o->minioi < new_onset) {
                 // AUBIO_DBG ("accepted detection, marking as onset\n");
                 o->last_onset = new_onset;

--- a/src/Editor/FindTempo.cpp
+++ b/src/Editor/FindTempo.cpp
@@ -86,8 +86,8 @@ struct IntervalTester {
 
 // Creates weights for a hamming window of length n.
 static void CreateHammingWindow(real* out, int n) {
-    const real t = 6.2831853071795864 / (real)(n - 1);
-    for (int i = 0; i < n; ++i) out[i] = 0.54 - 0.46 * cos((real)i * t);
+    const real t = 6.2831853071795864 / static_cast<real>(n - 1);
+    for (int i = 0; i < n; ++i) out[i] = 0.54 - 0.46 * cos(static_cast<real>(i) * t);
 }
 
 // Normalizes the given fitness value based the given 3rd order poly
@@ -203,9 +203,9 @@ static real GetConfidenceForBPM(const GapData& gapdata, IntervalTester& test,
 
     // Make a histogram of i strengths for every position in the interval.
     real intervalf = test.samplerate * 60.0 / bpm;
-    int interval = (int)(intervalf + 0.5);
+    int interval = static_cast<int>(intervalf + 0.5);
     for (int i = 0; i < numOnsets; ++i) {
-        int pos = (int)fmod((real)onsets[i].pos, intervalf);
+        int pos = static_cast<int>(fmod(static_cast<real>(onsets[i].pos), intervalf));
         wrappedPos[i] = pos;
         wrappedOnsets[pos] += onsets[i].strength;
     }
@@ -235,8 +235,8 @@ static real GetConfidenceForBPM(const GapData& gapdata, IntervalTester& test,
 IntervalTester::IntervalTester(int samplerate, int numOnsets,
                                const Onset* onsets)
     : samplerate(samplerate), numOnsets(numOnsets), onsets(onsets) {
-    minInterval = (int)(samplerate * 60.0 / MaximumBPM + 0.5);
-    maxInterval = (int)(samplerate * 60.0 / MinimumBPM + 0.5);
+    minInterval = static_cast<int>(samplerate * 60.0 / MaximumBPM + 0.5);
+    maxInterval = static_cast<int>(samplerate * 60.0 / MinimumBPM + 0.5);
     numIntervals = maxInterval - minInterval;
 
     fitness = AlignedMalloc<real>(numIntervals);
@@ -268,7 +268,7 @@ static vec2i FillIntervalRange(IntervalTester& test, GapData& gapdata,
          ++i, ++interval, ++fit) {
         if (*fit == 0) {
             *fit = GetConfidenceForInterval(gapdata, interval);
-            NormalizeFitness(*fit, test.coefs, (real)interval);
+            NormalizeFitness(*fit, test.coefs, static_cast<real>(interval));
             *fit = std::max(*fit, 0.1);
         }
     }
@@ -350,7 +350,7 @@ static void CalculateBPM(SerializedTempo* data, Onset* onsets, int numOnsets) {
     real maxFitness = 0.001;
     for (int i = 0; i < test.numIntervals; i += IntervalDelta) {
         NormalizeFitness(test.fitness[i], test.coefs,
-                         (real)(test.minInterval + i));
+                         static_cast<real>(test.minInterval + i));
         maxFitness = std::max(maxFitness, test.fitness[i]);
     }
 
@@ -412,10 +412,10 @@ static void ComputeSlopes(const float* samples, real* out, int numFrames,
     }
 
     // Slide window over the samples.
-    real scalar = 1.0 / (real)wh;
+    real scalar = 1.0 / static_cast<real>(wh);
     for (int i = wh, end = numFrames - wh; i < end; ++i) {
         // Determine slope value.
-        out[i] = std::max(0.0, (real)(sumR - sumL) * scalar);
+        out[i] = std::max(0.0, (sumR - sumL) * scalar);
 
         // Move window.
         real cur = abs(samples[i]);
@@ -438,10 +438,10 @@ static real GetBaseOffsetValue(const GapData& gapdata, int samplerate,
 
     // Make a histogram of onset strengths for every position in the interval.
     real intervalf = samplerate * 60.0 / bpm;
-    int interval = (int)(intervalf + 0.5);
+    int interval = static_cast<int>(intervalf + 0.5);
     memset(wrappedOnsets, 0, sizeof(real) * interval);
     for (int i = 0; i < numOnsets; ++i) {
-        int pos = (int)fmod((real)onsets[i].pos, intervalf);
+        int pos = static_cast<int>(fmod(static_cast<real>(onsets[i].pos), intervalf));
         wrappedPos[i] = pos;
         wrappedOnsets[pos] += 1.0;
     }
@@ -461,7 +461,7 @@ static real GetBaseOffsetValue(const GapData& gapdata, int samplerate,
         }
     }
 
-    return (real)offsetPos / (real)samplerate;
+    return static_cast<real>(offsetPos) / static_cast<real>(samplerate);
 }
 
 // Compares each offset to its corresponding offbeat value, and selects the most
@@ -480,13 +480,13 @@ static real AdjustForOffbeats(SerializedTempo* data, real offset, real bpm) {
     if (offbeat > secondsPerBeat) offbeat -= secondsPerBeat;
 
     // Calculate the support for both sample positions.
-    real end = (real)numFrames;
+    real end = static_cast<real>(numFrames);
     real interval = secondsPerBeat * samplerate;
     real posA = offset * samplerate, sumA = 0.0;
     real posB = offbeat * samplerate, sumB = 0.0;
     for (; posA < end && posB < end; posA += interval, posB += interval) {
-        sumA += slopes[(int)posA];
-        sumB += slopes[(int)posB];
+        sumA += slopes[static_cast<int>(posA)];
+        sumB += slopes[static_cast<int>(posB)];
     }
     AlignedFree(slopes);
 
@@ -504,7 +504,7 @@ static void CalculateOffset(SerializedTempo* data, Onset* onsets,
     real maxInterval = 0.0;
     for (auto& t : tempo)
         maxInterval = std::max(maxInterval, samplerate * 60.0 / t.bpm);
-    GapData gapdata((int)(maxInterval + 1.0), 1, numOnsets, onsets);
+    GapData gapdata(static_cast<int>(maxInterval + 1.0), 1, numOnsets, onsets);
 
     // Fill in onset values for each BPM.
     for (auto& t : tempo)
@@ -525,14 +525,14 @@ static const char* sProgressText[]{
 class TempoDetectorImp : public TempoDetector, public BackgroundThread {
    public:
     TempoDetectorImp(int firstFrame, int numFrames);
-    ~TempoDetectorImp();
+    ~TempoDetectorImp() override;
 
-    void exec();
+    void exec() override;
 
     bool hasSamples() { return (data_.samples != nullptr); }
-    const char* getProgress() const { return sProgressText[data_.progress]; }
-    bool hasResult() const { return isDone(); }
-    const Vector<TempoResult>& getResult() const { return data_.result; }
+    const char* getProgress() const override { return sProgressText[data_.progress]; }
+    bool hasResult() const override { return isDone(); }
+    const Vector<TempoResult>& getResult() const override { return data_.result; }
 
    private:
     SerializedTempo data_;
@@ -554,7 +554,7 @@ TempoDetectorImp::TempoDetectorImp(int firstFrame, int numFrames) {
     const short* l = music.samplesL() + firstFrame;
     const short* r = music.samplesR() + firstFrame;
     for (int i = 0; i < numFrames; ++i, ++l, ++r) {
-        data_.samples[i] = (float)((int)*l + (int)*r) / 65536.0f;
+        data_.samples[i] = static_cast<float>(static_cast<int>(*l) + static_cast<int>(*r)) / 65536.0f;
     }
 
     start();
@@ -581,7 +581,7 @@ void TempoDetectorImp::exec() {
         for (int j = a; j < b; ++j) {
             v += abs(data->samples[j]);
         }
-        v /= (float)std::max(1, b - a);
+        v /= static_cast<float>(std::max(1, b - a));
         onsets[i].strength = v;
     }
 
@@ -608,8 +608,8 @@ TempoDetector* TempoDetector::New(double time, double len) {
     }
 
     // Check if the number of frames is non-zero.
-    int firstFrame = std::max(0, (int)(time * music.getFrequency()));
-    int numFrames = std::max(0, (int)(len * music.getFrequency()));
+    int firstFrame = std::max(0, static_cast<int>(time * music.getFrequency()));
+    int numFrames = std::max(0, static_cast<int>(len * music.getFrequency()));
     numFrames = std::min(numFrames, music.getNumFrames() - firstFrame);
     if (numFrames <= 0) {
         HudInfo("There is no audio selected to perform BPM detection on.");

--- a/src/Editor/FindTempo.cpp
+++ b/src/Editor/FindTempo.cpp
@@ -87,7 +87,8 @@ struct IntervalTester {
 // Creates weights for a hamming window of length n.
 static void CreateHammingWindow(real* out, int n) {
     const real t = 6.2831853071795864 / static_cast<real>(n - 1);
-    for (int i = 0; i < n; ++i) out[i] = 0.54 - 0.46 * cos(static_cast<real>(i) * t);
+    for (int i = 0; i < n; ++i)
+        out[i] = 0.54 - 0.46 * cos(static_cast<real>(i) * t);
 }
 
 // Normalizes the given fitness value based the given 3rd order poly
@@ -205,7 +206,8 @@ static real GetConfidenceForBPM(const GapData& gapdata, IntervalTester& test,
     real intervalf = test.samplerate * 60.0 / bpm;
     int interval = static_cast<int>(intervalf + 0.5);
     for (int i = 0; i < numOnsets; ++i) {
-        int pos = static_cast<int>(fmod(static_cast<real>(onsets[i].pos), intervalf));
+        int pos =
+            static_cast<int>(fmod(static_cast<real>(onsets[i].pos), intervalf));
         wrappedPos[i] = pos;
         wrappedOnsets[pos] += onsets[i].strength;
     }
@@ -441,7 +443,8 @@ static real GetBaseOffsetValue(const GapData& gapdata, int samplerate,
     int interval = static_cast<int>(intervalf + 0.5);
     memset(wrappedOnsets, 0, sizeof(real) * interval);
     for (int i = 0; i < numOnsets; ++i) {
-        int pos = static_cast<int>(fmod(static_cast<real>(onsets[i].pos), intervalf));
+        int pos =
+            static_cast<int>(fmod(static_cast<real>(onsets[i].pos), intervalf));
         wrappedPos[i] = pos;
         wrappedOnsets[pos] += 1.0;
     }
@@ -530,9 +533,13 @@ class TempoDetectorImp : public TempoDetector, public BackgroundThread {
     void exec() override;
 
     bool hasSamples() { return (data_.samples != nullptr); }
-    const char* getProgress() const override { return sProgressText[data_.progress]; }
+    const char* getProgress() const override {
+        return sProgressText[data_.progress];
+    }
     bool hasResult() const override { return isDone(); }
-    const Vector<TempoResult>& getResult() const override { return data_.result; }
+    const Vector<TempoResult>& getResult() const override {
+        return data_.result;
+    }
 
    private:
     SerializedTempo data_;
@@ -554,7 +561,9 @@ TempoDetectorImp::TempoDetectorImp(int firstFrame, int numFrames) {
     const short* l = music.samplesL() + firstFrame;
     const short* r = music.samplesR() + firstFrame;
     for (int i = 0; i < numFrames; ++i, ++l, ++r) {
-        data_.samples[i] = static_cast<float>(static_cast<int>(*l) + static_cast<int>(*r)) / 65536.0f;
+        data_.samples[i] =
+            static_cast<float>(static_cast<int>(*l) + static_cast<int>(*r)) /
+            65536.0f;
     }
 
     start();

--- a/src/Editor/History.cpp
+++ b/src/Editor/History.cpp
@@ -37,7 +37,7 @@ struct HistoryImpl : public History {
     };
 
     struct EntryList {
-        EntryList() : head(nullptr) {}
+        EntryList()  = default;
         void add(Entry* entry) {
             if (head) {
                 auto it = head;
@@ -57,7 +57,7 @@ struct HistoryImpl : public History {
             }
             head = prev;
         }
-        Entry* head;
+        Entry* head = nullptr;
     };
 
     // ================================================================================================
@@ -83,13 +83,13 @@ struct HistoryImpl : public History {
                 hasTempo ? 'y' : 'n');
 #endif
 
-        uint8_t* mem = (uint8_t*)malloc(header.size() + size);
+        uint8_t* mem = static_cast<uint8_t*>(malloc(header.size() + size));
         memcpy(mem, header.data(), header.size());
         memcpy(mem + header.size(), data, size);
 
-        Entry* entry = (Entry*)mem;
+        Entry* entry = reinterpret_cast<Entry*>(mem);
         entry->next = nullptr;
-        return (Entry*)entry;
+        return entry;
     }
 
     static EntryData DecodeEntry(const Entry* in) {
@@ -147,14 +147,14 @@ struct HistoryImpl : public History {
 
     EntryList myEntries;
 
-    int mySavedEntries;
-    int myAppliedEntries;
-    int myTotalEntries;
+    int mySavedEntries = 0;
+    int myAppliedEntries = 0;
+    int myTotalEntries = 0;
 
     Simfile* mySimfile;
 
     EntryList myChain;
-    int myOpenChains;
+    int myOpenChains = 0;
 
     Vector<Callback> myCallbacks;
 
@@ -164,17 +164,15 @@ struct HistoryImpl : public History {
     ~HistoryImpl() { clearEverything(); }
 
     HistoryImpl()
-        : mySavedEntries(0),
-          myAppliedEntries(0),
-          myTotalEntries(0),
-          myOpenChains(0) {
+        
+          {
         myCallbacks.push_back({ApplyChain, ReleaseChain});
     }
 
     // ================================================================================================
     // HistoryImpl :: adding callbacks.
 
-    EditId addCallback(ApplyFunc apply, ReleaseFunc release) {
+    EditId addCallback(ApplyFunc apply, ReleaseFunc release) override {
         EditId out = myCallbacks.size();
         myCallbacks.push_back({apply, release});
         return out;
@@ -199,7 +197,7 @@ struct HistoryImpl : public History {
 
     void addEntry(EditId id, const void* data, uint32_t size,
                   Chart* targetChart, Tempo* targetTempo) {
-        if (id == 0 || id > (size_t)myCallbacks.size()) {
+        if (id == 0 || id > static_cast<size_t>(myCallbacks.size())) {
             HudError("History edit has invalid ID!");
             return;
         }
@@ -224,17 +222,17 @@ struct HistoryImpl : public History {
         }
     }
 
-    void addEntry(EditId id, const void* data, uint32_t size) {
+    void addEntry(EditId id, const void* data, uint32_t size) override {
         addEntry(id, data, size, nullptr, nullptr);
     }
 
     void addEntry(EditId id, const void* data, uint32_t size,
-                  Tempo* targetTempo) {
+                  Tempo* targetTempo) override {
         addEntry(id, data, size, nullptr, targetTempo);
     }
 
     void addEntry(EditId id, const void* data, uint32_t size,
-                  Chart* targetChart) {
+                  Chart* targetChart) override {
         addEntry(id, data, size, targetChart, nullptr);
     }
 
@@ -277,7 +275,7 @@ struct HistoryImpl : public History {
     // ================================================================================================
     // HistoryImpl :: history interactions.
 
-    void onKeyPress(KeyPress& evt) {
+    void onKeyPress(KeyPress& evt) override {
         if (evt.handled == false && (evt.keyflags & Keyflag::CTRL)) {
             if (evt.key == Key::Z) {
                 undoEntry();
@@ -287,17 +285,17 @@ struct HistoryImpl : public History {
         }
     }
 
-    void onFileOpen(Simfile* simfile) { mySimfile = simfile; }
+    void onFileOpen(Simfile* simfile) override { mySimfile = simfile; }
 
-    void onFileSaved() { mySavedEntries = myAppliedEntries; }
+    void onFileSaved() override { mySavedEntries = myAppliedEntries; }
 
-    void onFileClosed() {
+    void onFileClosed() override {
         clearEverything();
         mySavedEntries = 0;
         mySimfile = nullptr;
     }
 
-    bool hasUnsavedChanges() const {
+    bool hasUnsavedChanges() const override {
         return (mySavedEntries != myAppliedEntries);
     }
 
@@ -343,9 +341,9 @@ struct HistoryImpl : public History {
         return msg;
     }
 
-    void startChain() { ++myOpenChains; }
+    void startChain() override { ++myOpenChains; }
 
-    void finishChain(std::string msg) {
+    void finishChain(std::string msg) override {
         myOpenChains = max(0, myOpenChains - 1);
         if (myChain.head && myOpenChains == 0) {
             clearUnappliedEntries();

--- a/src/Editor/History.cpp
+++ b/src/Editor/History.cpp
@@ -37,7 +37,7 @@ struct HistoryImpl : public History {
     };
 
     struct EntryList {
-        EntryList()  = default;
+        EntryList() = default;
         void add(Entry* entry) {
             if (head) {
                 auto it = head;
@@ -164,8 +164,8 @@ struct HistoryImpl : public History {
     ~HistoryImpl() { clearEverything(); }
 
     HistoryImpl()
-        
-          {
+
+    {
         myCallbacks.push_back({ApplyChain, ReleaseChain});
     }
 

--- a/src/Editor/History.cpp
+++ b/src/Editor/History.cpp
@@ -415,7 +415,7 @@ History* gHistory = nullptr;
 void History::create() { gHistory = new HistoryImpl; }
 
 void History::destroy() {
-    delete (HistoryImpl*)gHistory;
+    delete static_cast<HistoryImpl*>(gHistory);
     gHistory = nullptr;
 }
 

--- a/src/Editor/LoadMp3.cpp
+++ b/src/Editor/LoadMp3.cpp
@@ -152,7 +152,7 @@ static int XingParse(XingHeader *xing, struct mad_bitptr ptr,
     if (xing->flags & XING_TOC) {
         if (bitlen < 800) goto fail;
 
-        for (unsigned char & i : xing->toc)
+        for (unsigned char &i : xing->toc)
             i = static_cast<unsigned char>(mad_bit_read(&ptr, 8));
 
         bitlen -= 800;

--- a/src/Editor/LoadMp3.cpp
+++ b/src/Editor/LoadMp3.cpp
@@ -90,7 +90,7 @@ static long ID3TagQuery(const uint8_t *data, id3_length_t length) {
 
         case TAGTYPE_ID3V2_FOOTER:
             ID3ParseHeader(&data, &version, &flags, &size);
-            return -(int)size - 10;
+            return -static_cast<int>(size) - 10;
 
         case TAGTYPE_NONE:
             break;
@@ -152,8 +152,8 @@ static int XingParse(XingHeader *xing, struct mad_bitptr ptr,
     if (xing->flags & XING_TOC) {
         if (bitlen < 800) goto fail;
 
-        for (int i = 0; i < 100; ++i)
-            xing->toc[i] = (unsigned char)mad_bit_read(&ptr, 8);
+        for (unsigned char & i : xing->toc)
+            i = static_cast<unsigned char>(mad_bit_read(&ptr, 8));
 
         bitlen -= 800;
     }
@@ -177,7 +177,7 @@ fail:
 
 struct MP3Loader : public SoundSource {
     MP3Loader();
-    ~MP3Loader();
+    ~MP3Loader() override;
 
     int getFrequency() override { return frequency; }
     int getNumFrames() override { return 0; }
@@ -348,7 +348,7 @@ static inline short ScaleSample(mad_fixed_t sample) {
         sample = MAD_F_ONE - 1;
     else if (sample < -MAD_F_ONE)
         sample = -MAD_F_ONE;
-    return (short)(sample >> (MAD_F_FRACBITS + 1 - 16));
+    return static_cast<short>(sample >> (MAD_F_FRACBITS + 1 - 16));
 }
 
 void MP3Loader::synthDecodedFrame() {

--- a/src/Editor/Menubar.cpp
+++ b/src/Editor/Menubar.cpp
@@ -62,7 +62,7 @@ struct MenuBarImpl : public Menubar {
     static void sep(Item* menu) { menu->addSeperator(); }
 
     static void add(Item* menu, Action::Type action, const char* str) {
-        std::string notation = gShortcuts->getNotation(action);
+        std::string notation = gShortcuts->getNotation(action, false);
         if (notation.length()) {
             std::string combined(str);
             Str::append(combined, '\t');
@@ -523,16 +523,17 @@ struct MenuBarImpl : public Menubar {
         myUpdateFunctions[VIEW_NOTESKIN] = [] {
             Item* hSkins = System::MenuItem::create();
             int numValid = 0;
-            int numTypes =
-                min(gNoteskin->getNumTypes(), static_cast<int>(Action::MAX_NOTESKINS));
+            int numTypes = min(gNoteskin->getNumTypes(),
+                               static_cast<int>(Action::MAX_NOTESKINS));
             int activeType = gNoteskin->getType();
             for (int type = 0; type < numTypes; ++type) {
                 if (gNoteskin->isSupported(type)) {
                     hSkins->addItem(SET_NOTESKIN_BEGIN + type,
                                     gNoteskin->getName(type));
                     if (type == activeType) {
-                        hSkins->setChecked(
-                            static_cast<Action::Type>(SET_NOTESKIN_BEGIN + type), true);
+                        hSkins->setChecked(static_cast<Action::Type>(
+                                               SET_NOTESKIN_BEGIN + type),
+                                           true);
                     }
                     ++numValid;
                 }
@@ -607,7 +608,7 @@ Menubar* gMenubar = nullptr;
 void Menubar::create() { gMenubar = new MenuBarImpl; }
 
 void Menubar::destroy() {
-    delete (MenuBarImpl*)gMenubar;
+    delete static_cast<MenuBarImpl*>(gMenubar);
     gMenubar = nullptr;
 }
 

--- a/src/Editor/Menubar.cpp
+++ b/src/Editor/Menubar.cpp
@@ -50,7 +50,7 @@ struct MenuBarImpl : public Menubar {
     // ================================================================================================
     // MenuBarImpl :: constructor and destructor.
 
-    ~MenuBarImpl() {}
+    ~MenuBarImpl() = default;
 
     MenuBarImpl() { registerUpdateFunctions(); }
 
@@ -89,7 +89,7 @@ struct MenuBarImpl : public Menubar {
         menu->addSubmenu(sub, str);
     }
 
-    void init(Item* menu) {
+    void init(Item* menu) override {
         using namespace Action;
 
         // File menu.
@@ -413,7 +413,7 @@ struct MenuBarImpl : public Menubar {
         myUpdateFunctions[RECENT_FILES] = [] {
             Item* recent = newMenu();
             int numFiles = min(gEditor->getNumRecentFiles(),
-                               (int)Action::MAX_RECENT_FILES);
+                               static_cast<int>(Action::MAX_RECENT_FILES));
             if (numFiles > 0) {
                 recent->addItem(FILE_CLEAR_RECENT_FILES, "Clear list");
                 recent->addSeperator();
@@ -524,7 +524,7 @@ struct MenuBarImpl : public Menubar {
             Item* hSkins = System::MenuItem::create();
             int numValid = 0;
             int numTypes =
-                min(gNoteskin->getNumTypes(), (int)Action::MAX_NOTESKINS);
+                min(gNoteskin->getNumTypes(), static_cast<int>(Action::MAX_NOTESKINS));
             int activeType = gNoteskin->getType();
             for (int type = 0; type < numTypes; ++type) {
                 if (gNoteskin->isSupported(type)) {
@@ -532,14 +532,14 @@ struct MenuBarImpl : public Menubar {
                                     gNoteskin->getName(type));
                     if (type == activeType) {
                         hSkins->setChecked(
-                            (Action::Type)(SET_NOTESKIN_BEGIN + type), true);
+                            static_cast<Action::Type>(SET_NOTESKIN_BEGIN + type), true);
                     }
                     ++numValid;
                 }
             }
             // If the active type was zero, set it to the first skin in the list
             if (!activeType) {
-                hSkins->setChecked((Action::Type)(SET_NOTESKIN_BEGIN), true);
+                hSkins->setChecked((SET_NOTESKIN_BEGIN), true);
             }
             MENU->myViewMenu->replaceSubmenu(13, hSkins, "Noteskins",
                                              (numValid == 0));
@@ -586,7 +586,7 @@ struct MenuBarImpl : public Menubar {
         };
     }
 
-    void update(Property prop) {
+    void update(Property prop) override {
         if (prop == ALL_PROPERTIES) {
             for (int i = 1; i < NUM_PROPERTIES; ++i) {
                 myUpdateFunctions[i]();

--- a/src/Editor/Minimap.cpp
+++ b/src/Editor/Minimap.cpp
@@ -61,18 +61,18 @@ struct SetPixelData {
 
 static void SetPixels(const SetPixelData& spd, int x, double tor,
                       uint32_t color) {
-    int y =
-        clamp(static_cast<int>((tor - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
+    int y = clamp(static_cast<int>((tor - spd.startOfs) * spd.pixPerOfs), 0,
+                  MAP_HEIGHT - 1);
     uint32_t* dst = spd.pixels + y * MAP_WIDTH + x;
     for (int i = 0; i < spd.noteW; ++i, ++dst) *dst = color;
 }
 
 static void SetPixels(const SetPixelData& spd, int x, double tor, double end,
                       uint32_t color) {
-    int yt =
-        clamp(static_cast<int>((tor - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
-    int yb =
-        clamp(static_cast<int>((end - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
+    int yt = clamp(static_cast<int>((tor - spd.startOfs) * spd.pixPerOfs), 0,
+                   MAP_HEIGHT - 1);
+    int yb = clamp(static_cast<int>((end - spd.startOfs) * spd.pixPerOfs), 0,
+                   MAP_HEIGHT - 1);
     for (int y = yt; y <= yb; ++y) {
         uint32_t* dst = spd.pixels + y * MAP_WIDTH + x;
         for (int i = 0; i < spd.noteW; ++i, ++dst) *dst = color;
@@ -107,7 +107,8 @@ struct MinimapImpl : public Minimap {
 
         VortexAssert(TEXTURE_SIZE * TEXTURE_SIZE == MAP_HEIGHT * MAP_WIDTH);
         // Split the texture area into vertical strips from left to right.
-        float u = 0.f, du = static_cast<float>(MAP_WIDTH) / static_cast<float>(TEXTURE_SIZE);
+        float u = 0.f, du = static_cast<float>(MAP_WIDTH) /
+                            static_cast<float>(TEXTURE_SIZE);
         for (int i = 0; i < NUM_PIECES; ++i, u += du) {
             float v[8] = {u, 0, u + du, 0, u, 1, u + du, 1};
             memcpy(myUvs + i * 8, v, sizeof(float) * 8);
@@ -177,13 +178,14 @@ struct MinimapImpl : public Minimap {
     }
 
     void renderDensity(SetPixelData& spd, const int* colx) {
-        auto first = gNotes->begin(), end = gNotes->end(), it = first,
-             last = end - 1;
+        auto first = gNotes->begin(), end = gNotes->end();
+        const ExpandedNote* it = first;
+        const ExpandedNote* last = end - 1;
 
         if (gView->isTimeBased()) {
             double sec = myChartBeginOfs;
-            double secPerPix =
-                (myChartEndOfs - myChartBeginOfs) / static_cast<double>(myNotesH);
+            double secPerPix = (myChartEndOfs - myChartBeginOfs) /
+                               static_cast<double>(myNotesH);
             for (int y = 0; y < myNotesH; ++y) {
                 double density = 0.0;
                 for (; it != end && it->time < sec; ++it);
@@ -200,8 +202,8 @@ struct MinimapImpl : public Minimap {
             }
         } else {
             double row = myChartBeginOfs;
-            double rowPerPix =
-                (myChartEndOfs - myChartBeginOfs) / static_cast<double>(myNotesH);
+            double rowPerPix = (myChartEndOfs - myChartBeginOfs) /
+                               static_cast<double>(myNotesH);
             for (int y = 0; y < myNotesH; ++y) {
                 double density = 0.0;
                 for (; it != end && it->row < row; ++it);
@@ -250,8 +252,9 @@ struct MinimapImpl : public Minimap {
             topY = chartRect.y;
             bottomY = chartRect.y + chartRect.h;
 
-            double t =
-                clamp(static_cast<double>(y - topY) / static_cast<double>(bottomY - topY), 0.0, 1.0);
+            double t = clamp(static_cast<double>(y - topY) /
+                                 static_cast<double>(bottomY - topY),
+                             0.0, 1.0);
             if (gView->hasReverseScroll()) t = 1.0 - t;
 
             tor = myChartBeginOfs + (myChartEndOfs - myChartBeginOfs) * t;
@@ -308,7 +311,8 @@ struct MinimapImpl : public Minimap {
         // Update the texture strips.
         for (int i = 0; i < NUM_PIECES; ++i) {
             uint32_t* buf = buffer.data();
-            auto src = reinterpret_cast<const uint8_t*>(buf + i * MAP_WIDTH * TEXTURE_SIZE);
+            auto src = reinterpret_cast<const uint8_t*>(buf + i * MAP_WIDTH *
+                                                                  TEXTURE_SIZE);
             myImage.modify(i * MAP_WIDTH, 0, MAP_WIDTH, TEXTURE_SIZE, src);
         }
     }
@@ -343,15 +347,17 @@ struct MinimapImpl : public Minimap {
 
     void drawRegion(int x, int w, double ofsA, double ofsB, uint32_t color) {
         recti chartRect = myGetMapRect();
-        double pixPerOfs =
-            static_cast<double>(chartRect.h) / (myChartEndOfs - myChartBeginOfs);
+        double pixPerOfs = static_cast<double>(chartRect.h) /
+                           (myChartEndOfs - myChartBeginOfs);
         int baseY = chartRect.y;
         if (gView->hasReverseScroll()) {
             baseY += chartRect.h;
             pixPerOfs = -pixPerOfs;
         }
-        int y1 = baseY + static_cast<int>((ofsA - myChartBeginOfs) * pixPerOfs + 0.5);
-        int y2 = baseY + static_cast<int>((ofsB - myChartBeginOfs) * pixPerOfs + 0.5);
+        int y1 = baseY +
+                 static_cast<int>((ofsA - myChartBeginOfs) * pixPerOfs + 0.5);
+        int y2 = baseY +
+                 static_cast<int>((ofsB - myChartBeginOfs) * pixPerOfs + 0.5);
         if (y1 > y2) swapValues(y1, y2);
 
         Draw::fill({x, y1, w, max(y2 - y1, 1)}, color);
@@ -438,7 +444,7 @@ Minimap* gMinimap = nullptr;
 void Minimap::create() { gMinimap = new MinimapImpl; }
 
 void Minimap::destroy() {
-    delete (MinimapImpl*)gMinimap;
+    delete static_cast<MinimapImpl*>(gMinimap);
     gMinimap = nullptr;
 }
 

--- a/src/Editor/Minimap.cpp
+++ b/src/Editor/Minimap.cpp
@@ -62,7 +62,7 @@ struct SetPixelData {
 static void SetPixels(const SetPixelData& spd, int x, double tor,
                       uint32_t color) {
     int y =
-        clamp((int)((tor - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
+        clamp(static_cast<int>((tor - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
     uint32_t* dst = spd.pixels + y * MAP_WIDTH + x;
     for (int i = 0; i < spd.noteW; ++i, ++dst) *dst = color;
 }
@@ -70,9 +70,9 @@ static void SetPixels(const SetPixelData& spd, int x, double tor,
 static void SetPixels(const SetPixelData& spd, int x, double tor, double end,
                       uint32_t color) {
     int yt =
-        clamp((int)((tor - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
+        clamp(static_cast<int>((tor - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
     int yb =
-        clamp((int)((end - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
+        clamp(static_cast<int>((end - spd.startOfs) * spd.pixPerOfs), 0, MAP_HEIGHT - 1);
     for (int y = yt; y <= yb; ++y) {
         uint32_t* dst = spd.pixels + y * MAP_WIDTH + x;
         for (int i = 0; i < spd.noteW; ++i, ++dst) *dst = color;
@@ -97,7 +97,7 @@ struct MinimapImpl : public Minimap {
     // ================================================================================================
     // MinimapImpl :: constructor and destructor.
 
-    ~MinimapImpl() {}
+    ~MinimapImpl() = default;
 
     MinimapImpl() {
         myMode = NOTES;
@@ -107,7 +107,7 @@ struct MinimapImpl : public Minimap {
 
         VortexAssert(TEXTURE_SIZE * TEXTURE_SIZE == MAP_HEIGHT * MAP_WIDTH);
         // Split the texture area into vertical strips from left to right.
-        float u = 0.f, du = (float)MAP_WIDTH / (float)TEXTURE_SIZE;
+        float u = 0.f, du = static_cast<float>(MAP_WIDTH) / static_cast<float>(TEXTURE_SIZE);
         for (int i = 0; i < NUM_PIECES; ++i, u += du) {
             float v[8] = {u, 0, u + du, 0, u, 1, u + du, 1};
             memcpy(myUvs + i * 8, v, sizeof(float) * 8);
@@ -162,7 +162,7 @@ struct MinimapImpl : public Minimap {
             64, 192, 192, 128, 255, 64, 255, 64, 64, 128, 128, 255,
         };
         density = round(density * 10.0) * (512.0 * 0.1 / 16.0);
-        int coloring = clamp((int)density, 0, 511);
+        int coloring = clamp(static_cast<int>(density), 0, 511);
         int ci = coloring >> 8;
         ci *= 3;
         int bf = coloring & 255;
@@ -171,7 +171,7 @@ struct MinimapImpl : public Minimap {
         int b = BlendI32(colors[ci + 2], colors[ci + 5], bf);
         uint32_t col = Color32(r, g, b);
 
-        int w = clamp((int)(density * 0.05), 4, MAP_WIDTH) / 2;
+        int w = clamp(static_cast<int>(density * 0.05), 4, MAP_WIDTH) / 2;
         uint32_t* dst = pixels + y * MAP_WIDTH + MAP_WIDTH / 2 - w;
         for (int i = -w; i < w; ++i, ++dst) *dst = col;
     }
@@ -183,7 +183,7 @@ struct MinimapImpl : public Minimap {
         if (gView->isTimeBased()) {
             double sec = myChartBeginOfs;
             double secPerPix =
-                (double)(myChartEndOfs - myChartBeginOfs) / (double)myNotesH;
+                (myChartEndOfs - myChartBeginOfs) / static_cast<double>(myNotesH);
             for (int y = 0; y < myNotesH; ++y) {
                 double density = 0.0;
                 for (; it != end && it->time < sec; ++it);
@@ -201,7 +201,7 @@ struct MinimapImpl : public Minimap {
         } else {
             double row = myChartBeginOfs;
             double rowPerPix =
-                (double)(myChartEndOfs - myChartBeginOfs) / (double)myNotesH;
+                (myChartEndOfs - myChartBeginOfs) / static_cast<double>(myNotesH);
             for (int y = 0; y < myNotesH; ++y) {
                 double density = 0.0;
                 for (; it != end && it->row < row; ++it);
@@ -251,7 +251,7 @@ struct MinimapImpl : public Minimap {
             bottomY = chartRect.y + chartRect.h;
 
             double t =
-                clamp((double)(y - topY) / (double)(bottomY - topY), 0.0, 1.0);
+                clamp(static_cast<double>(y - topY) / static_cast<double>(bottomY - topY), 0.0, 1.0);
             if (gView->hasReverseScroll()) t = 1.0 - t;
 
             tor = myChartBeginOfs + (myChartEndOfs - myChartBeginOfs) * t;
@@ -259,7 +259,7 @@ struct MinimapImpl : public Minimap {
         return tor;
     }
 
-    void onChanges(int changes) {
+    void onChanges(int changes) override {
         int bits = VCM_NOTES_CHANGED | VCM_TEMPO_CHANGED | VCM_VIEW_CHANGED |
                    VCM_END_ROW_CHANGED;
 
@@ -279,7 +279,7 @@ struct MinimapImpl : public Minimap {
             myChartEndOfs = timeEnd;
         } else {
             myChartBeginOfs = 0.0;
-            myChartEndOfs = (double)gSimfile->getEndRow();
+            myChartEndOfs = static_cast<double>(gSimfile->getEndRow());
         }
 
         if (gChart->isOpen()) {
@@ -294,7 +294,7 @@ struct MinimapImpl : public Minimap {
 
             auto rect = myGetMapRect();
             double pixPerOfs =
-                (double)rect.h / (myChartEndOfs - myChartBeginOfs);
+                static_cast<double>(rect.h) / (myChartEndOfs - myChartBeginOfs);
             SetPixelData spd = {buffer.data(), colw, pixPerOfs,
                                 myChartBeginOfs};
 
@@ -308,12 +308,12 @@ struct MinimapImpl : public Minimap {
         // Update the texture strips.
         for (int i = 0; i < NUM_PIECES; ++i) {
             uint32_t* buf = buffer.data();
-            auto src = (const uint8_t*)(buf + i * MAP_WIDTH * TEXTURE_SIZE);
+            auto src = reinterpret_cast<const uint8_t*>(buf + i * MAP_WIDTH * TEXTURE_SIZE);
             myImage.modify(i * MAP_WIDTH, 0, MAP_WIDTH, TEXTURE_SIZE, src);
         }
     }
 
-    void onMousePress(MousePress& evt) {
+    void onMousePress(MousePress& evt) override {
         if (evt.button == Mouse::LMB && !gTextOverlay->isOpen() &&
             evt.unhandled()) {
             if (IsInside(rect_, evt.x, evt.y)) {
@@ -324,14 +324,14 @@ struct MinimapImpl : public Minimap {
         }
     }
 
-    void onMouseRelease(MouseRelease& evt) {
+    void onMouseRelease(MouseRelease& evt) override {
         if (evt.button == Mouse::LMB && myIsDragging) {
             gView->setCursorOffset(myGetMapOffset(evt.y));
             myIsDragging = false;
         }
     }
 
-    void tick() {
+    void tick() override {
         vec2i size = gSystem->getWindowSize();
         rect_ = {size.x - 32, 8, 24, size.y - 16};
 
@@ -344,20 +344,20 @@ struct MinimapImpl : public Minimap {
     void drawRegion(int x, int w, double ofsA, double ofsB, uint32_t color) {
         recti chartRect = myGetMapRect();
         double pixPerOfs =
-            (double)chartRect.h / (myChartEndOfs - myChartBeginOfs);
+            static_cast<double>(chartRect.h) / (myChartEndOfs - myChartBeginOfs);
         int baseY = chartRect.y;
         if (gView->hasReverseScroll()) {
             baseY += chartRect.h;
             pixPerOfs = -pixPerOfs;
         }
-        int y1 = baseY + (int)((ofsA - myChartBeginOfs) * pixPerOfs + 0.5);
-        int y2 = baseY + (int)((ofsB - myChartBeginOfs) * pixPerOfs + 0.5);
+        int y1 = baseY + static_cast<int>((ofsA - myChartBeginOfs) * pixPerOfs + 0.5);
+        int y2 = baseY + static_cast<int>((ofsB - myChartBeginOfs) * pixPerOfs + 0.5);
         if (y1 > y2) swapValues(y1, y2);
 
         Draw::fill({x, y1, w, max(y2 - y1, 1)}, color);
     }
 
-    void draw() {
+    void draw() override {
         // If the text overlay is open, we hide the minimap to avoid clutter.
         if (gTextOverlay->isOpen()) return;
 
@@ -420,13 +420,13 @@ struct MinimapImpl : public Minimap {
         Renderer::popScissorRect();
     }
 
-    void setMode(Mode mode) {
+    void setMode(Mode mode) override {
         myMode = mode;
         gMenubar->update(Menubar::VIEW_MINIMAP);
         onChanges(VCM_ALL_CHANGES);
     }
 
-    Minimap::Mode getMode() const { return myMode; }
+    Minimap::Mode getMode() const override { return myMode; }
 
 };  // MinimapImpl
 

--- a/src/Editor/Music.cpp
+++ b/src/Editor/Music.cpp
@@ -117,17 +117,17 @@ struct MusicImpl : public Music, public MixSource {
         }
     }
 
-    void saveSettings(XmrNode& settings) {
+    void saveSettings(XmrNode& settings) override {
         XmrNode* audio = settings.addChild("audio");
 
-        audio->addAttrib("musicVolume", (long)myMusicVolume);
-        audio->addAttrib("tickOffsetMs", (long)myTickOffsetMs);
+        audio->addAttrib("musicVolume", static_cast<long>(myMusicVolume));
+        audio->addAttrib("tickOffsetMs", static_cast<long>(myTickOffsetMs));
     }
 
     // ================================================================================================
     // MusicImpl :: loading and unloading music.
 
-    void unload() {
+    void unload() override {
         terminateOggConversion();
 
         myMixer->close();
@@ -138,7 +138,7 @@ struct MusicImpl : public Music, public MixSource {
         myLoadState = LOADING_DONE;
     }
 
-    void load() {
+    void load() override {
         unload();
 
         if (gSimfile->isClosed()) return;
@@ -174,7 +174,7 @@ struct MusicImpl : public Music, public MixSource {
     void WriteTickSamples(short* dst, int startFrame, int numFrames,
                           const TickData& tick, int rate) {
         if (rate != 100) {
-            startFrame = (int)((int64_t)startFrame * 100 / rate);
+            startFrame = static_cast<int>(static_cast<int64_t>(startFrame) * 100 / rate);
         }
 
         const short* srcL = tick.sound.samplesL() + startFrame;
@@ -190,26 +190,26 @@ struct MusicImpl : public Music, public MixSource {
             int idx = 0;
             double srcPos = 0.0;
             const int tickEndPos = tick.sound.getNumFrames() - startFrame;
-            const double srcDelta = 100.0 / (double)rate;
+            const double srcDelta = 100.0 / static_cast<double>(rate);
             for (; numFrames > 0 && idx < tickEndPos; --numFrames) {
-                const float frac = (float)(srcPos - floor(srcPos));
+                const float frac = static_cast<float>(srcPos - floor(srcPos));
 
                 float sampleL =
-                    lerp((float)srcL[idx], (float)srcL[idx + 1], frac);
+                    lerp(static_cast<float>(srcL[idx]), static_cast<float>(srcL[idx + 1]), frac);
                 float sampleR =
-                    lerp((float)srcR[idx], (float)srcR[idx + 1], frac);
+                    lerp(static_cast<float>(srcR[idx]), static_cast<float>(srcR[idx + 1]), frac);
 
-                *dst++ = min(max(*dst + (short)sampleL, SHRT_MIN), SHRT_MAX);
-                *dst++ = min(max(*dst + (short)sampleR, SHRT_MIN), SHRT_MAX);
+                *dst++ = min(max(*dst + static_cast<short>(sampleL), SHRT_MIN), SHRT_MAX);
+                *dst++ = min(max(*dst + static_cast<short>(sampleR), SHRT_MIN), SHRT_MAX);
 
                 srcPos += srcDelta;
-                idx = (int)srcPos;
+                idx = static_cast<int>(srcPos);
             }
         }
     }
 
     void WriteTicks(short* buf, int frames, const TickData& tick, int rate) {
-        int playPos = (int)myPlayPosition;
+        int playPos = static_cast<int>(myPlayPosition);
         int count = tick.frames.size();
         const int* ticks = tick.frames.data();
 
@@ -245,7 +245,7 @@ struct MusicImpl : public Music, public MixSource {
         // silence.
         int framesLeft = frames;
         if (srcPos < 0) {
-            int n = min(framesLeft, (int)max(-srcPos, (int64_t)INT_MIN));
+            int n = min(framesLeft, static_cast<int>(max(-srcPos, static_cast<int64_t>INT_MIN)));
             memset(dst, 0, sizeof(short) * MIX_CHANNELS * n);
             dst += n * MIX_CHANNELS;
             framesLeft -= n;
@@ -255,8 +255,8 @@ struct MusicImpl : public Music, public MixSource {
         // Fill the remaining buffer with music samples.
         if (framesLeft > 0 && mySamples.isAllocated() && musicVolume > 0 &&
             !myIsMuted) {
-            int n = (int)min(max(mySamples.getNumFrames() - srcPos, (int64_t)0),
-                             (int64_t)framesLeft);
+            int n = static_cast<int>(min(max(mySamples.getNumFrames() - srcPos, static_cast<int64_t>(0)),
+                             static_cast<int64_t>(framesLeft)));
             const short* srcL = mySamples.samplesL() + srcPos;
             const short* srcR = mySamples.samplesR() + srcPos;
             if (musicVolume == 100) {
@@ -267,8 +267,8 @@ struct MusicImpl : public Music, public MixSource {
             } else {
                 int vol = ((musicVolume * musicVolume) << 15) / (100 * 100);
                 for (int i = 0; i < n; ++i) {
-                    *dst++ = (short)(((*srcL++) * vol) >> 15);
-                    *dst++ = (short)(((*srcR++) * vol) >> 15);
+                    *dst++ = static_cast<short>(((*srcL++) * vol) >> 15);
+                    *dst++ = static_cast<short>(((*srcR++) * vol) >> 15);
                 }
             }
             framesLeft -= n;
@@ -286,18 +286,18 @@ struct MusicImpl : public Music, public MixSource {
     }
 
     void writeFrames(short* buffer, int frames) override {
-        double srcAdvance = (double)frames;
+        double srcAdvance = static_cast<double>(frames);
         if (myMusicSpeed == 100) {
             // Source and target samplerate are equal.
             int64_t srcPos = llround(myPlayPosition);
             WriteSourceFrames(buffer, frames, srcPos);
         } else {
-            double rate = (double)myMusicSpeed / 100.0;
+            double rate = static_cast<double>(myMusicSpeed) / 100.0;
             srcAdvance *= rate;
 
             // Source and target samplerate are different, mix to temporary
             // buffer.
-            int64_t srcPos = (int64_t)(myPlayPosition);
+            int64_t srcPos = static_cast<int64_t>(myPlayPosition);
             int tmpFrames = frames * myMusicSpeed / 100;
             myMixBuffer.grow(tmpFrames * 2);
             WriteSourceFrames(myMixBuffer.data(), tmpFrames, srcPos);
@@ -310,19 +310,19 @@ struct MusicImpl : public Music, public MixSource {
 
             short* dst = buffer;
             for (int i = 0; i < frames; ++i) {
-                int index0 = min((int)tmpPos, tmpEnd);
+                int index0 = min(static_cast<int>(tmpPos), tmpEnd);
                 int index1 = min(index0 + 1, tmpEnd);
                 index0 *= MIX_CHANNELS;
                 index1 *= MIX_CHANNELS;
 
-                float w1 = (float)(tmpPos - floor(tmpPos));
+                float w1 = static_cast<float>(tmpPos - floor(tmpPos));
                 float w0 = 1.0f - w1;
 
-                float l = (float)tmpL[index0] * w0 + (float)tmpL[index1] * w1;
-                float r = (float)tmpR[index0] * w0 + (float)tmpR[index1] * w1;
+                float l = static_cast<float>(tmpL[index0]) * w0 + static_cast<float>(tmpL[index1]) * w1;
+                float r = static_cast<float>(tmpR[index0]) * w0 + static_cast<float>(tmpR[index1]) * w1;
 
-                *dst++ = (short)min(max((int)l, SHRT_MIN), SHRT_MAX);
-                *dst++ = (short)min(max((int)r, SHRT_MIN), SHRT_MAX);
+                *dst++ = static_cast<short>(min(max(static_cast<int>(l), SHRT_MIN), SHRT_MAX));
+                *dst++ = static_cast<short>(min(max(static_cast<int>(r), SHRT_MIN), SHRT_MAX));
 
                 tmpPos += rate;
             }
@@ -334,7 +334,7 @@ struct MusicImpl : public Music, public MixSource {
     // ================================================================================================
     // MusicImpl :: OggVorbis conversion.
 
-    void startOggConversion() {
+    void startOggConversion() override {
         if (gSimfile->isClosed()) return;
 
         std::string dir = gSimfile->getDir();
@@ -400,13 +400,13 @@ struct MusicImpl : public Music, public MixSource {
 
     void resumeStream() {
         if (!myIsPaused) {
-            myPlayPosition = myPlayStartTime * (double)mySamples.getFrequency();
+            myPlayPosition = myPlayStartTime * static_cast<double>(mySamples.getFrequency());
             myPlayTimer = Debug::getElapsedTime();
             myMixer->resume();
         }
     }
 
-    void tick() {
+    void tick() override {
         if (myLoadState != LOADING_DONE && myInfoBox) {
             if (mySamples.getLoadingProgress() > 0) {
                 myInfoBox->setProgress(mySamples.getLoadingProgress() * 0.01f);
@@ -439,49 +439,49 @@ struct MusicImpl : public Music, public MixSource {
         }
     }
 
-    void pause() {
+    void pause() override {
         if (!myIsPaused) {
             interruptStream();
             myIsPaused = true;
         }
     }
 
-    void play() {
+    void play() override {
         if (myIsPaused) {
             myIsPaused = false;
             resumeStream();
         }
     }
 
-    void seek(double seconds) {
+    void seek(double seconds) override {
         interruptStream();
         myPlayStartTime = seconds;
         resumeStream();
     }
 
-    double getPlayTime() {
+    double getPlayTime() override {
         double time = myPlayStartTime;
         if (!myIsPaused) {
-            double rate = (double)myMusicSpeed * 0.01;
+            double rate = static_cast<double>(myMusicSpeed) * 0.01;
             time += Debug::getElapsedTime(myPlayTimer) * rate;
         }
         return time;
     }
 
-    double getSongLength() {
-        return (double)mySamples.getNumFrames() /
-               (double)mySamples.getFrequency();
+    double getSongLength() override {
+        return static_cast<double>(mySamples.getNumFrames()) /
+               static_cast<double>(mySamples.getFrequency());
     }
 
-    const std::string& getTitle() { return myTitle; }
+    const std::string& getTitle() override { return myTitle; }
 
-    const std::string& getArtist() { return myArtist; }
+    const std::string& getArtist() override { return myArtist; }
 
-    bool isPaused() { return myIsPaused; }
+    bool isPaused() override { return myIsPaused; }
 
-    const Sound& getSamples() { return mySamples; }
+    const Sound& getSamples() override { return mySamples; }
 
-    void setSpeed(int speed) {
+    void setSpeed(int speed) override {
         speed = min(max(speed, 10), 400);
         if (myMusicSpeed != speed) {
             interruptStream();
@@ -491,9 +491,9 @@ struct MusicImpl : public Music, public MixSource {
         }
     }
 
-    int getSpeed() { return myMusicSpeed; }
+    int getSpeed() override { return myMusicSpeed; }
 
-    void setVolume(int vol) {
+    void setVolume(int vol) override {
         vol = min(max(vol, 0), 100);
         if (myMusicVolume != vol) {
             interruptStream();
@@ -504,9 +504,9 @@ struct MusicImpl : public Music, public MixSource {
         }
     }
 
-    int getVolume() { return myMusicVolume; }
+    int getVolume() override { return myMusicVolume; }
 
-    void setMuted(bool mute) {
+    void setMuted(bool mute) override {
         if (myIsMuted != mute) {
             interruptStream();
             myIsMuted = mute;
@@ -515,9 +515,9 @@ struct MusicImpl : public Music, public MixSource {
         }
     }
 
-    bool isMuted() { return myIsMuted; }
+    bool isMuted() override { return myIsMuted; }
 
-    void toggleBeatTick() {
+    void toggleBeatTick() override {
         interruptStream();
         myBeatTick.enabled = !myBeatTick.enabled;
         resumeStream();
@@ -526,7 +526,7 @@ struct MusicImpl : public Music, public MixSource {
 
     bool hasBeatTick() { return myBeatTick.enabled; }
 
-    void toggleNoteTick() {
+    void toggleNoteTick() override {
         interruptStream();
         myNoteTick.enabled = !myNoteTick.enabled;
         resumeStream();
@@ -541,14 +541,14 @@ struct MusicImpl : public Music, public MixSource {
     void updateBeatTicks() {
         myBeatTick.frames.clear();
 
-        double freq = (double)mySamples.getFrequency();
+        double freq = static_cast<double>(mySamples.getFrequency());
         double ofs = myTickOffsetMs / 1000.0;
 
         TempoTimeTracker tracker(gTempo->getTimingData());
         for (int row = 0, end = gSimfile->getEndRow(); row < end;
              row += ROWS_PER_BEAT) {
             double time = tracker.advance(row);
-            int frame = (int)((time + ofs) * freq);
+            int frame = static_cast<int>((time + ofs) * freq);
             myBeatTick.frames.push_back(frame);
         }
     }
@@ -556,18 +556,18 @@ struct MusicImpl : public Music, public MixSource {
     void updateNoteTicks() {
         myNoteTick.frames.clear();
 
-        double freq = (double)mySamples.getFrequency();
+        double freq = static_cast<double>(mySamples.getFrequency());
         double ofs = myTickOffsetMs / 1000.0;
 
         for (auto& note : *gNotes) {
             if (!(note.isMine | note.isWarped | note.isFake)) {
-                int frame = (int)((note.time + ofs) * freq);
+                int frame = static_cast<int>((note.time + ofs) * freq);
                 myNoteTick.frames.push_back(frame);
             }
         }
     }
 
-    void onChanges(int changes) {
+    void onChanges(int changes) override {
         const int bits = VCM_NOTES_CHANGED | VCM_TEMPO_CHANGED |
                          VCM_END_ROW_CHANGED | VCM_CHART_CHANGED;
 

--- a/src/Editor/Music.cpp
+++ b/src/Editor/Music.cpp
@@ -174,7 +174,8 @@ struct MusicImpl : public Music, public MixSource {
     void WriteTickSamples(short* dst, int startFrame, int numFrames,
                           const TickData& tick, int rate) {
         if (rate != 100) {
-            startFrame = static_cast<int>(static_cast<int64_t>(startFrame) * 100 / rate);
+            startFrame =
+                static_cast<int>(static_cast<int64_t>(startFrame) * 100 / rate);
         }
 
         const short* srcL = tick.sound.samplesL() + startFrame;
@@ -194,13 +195,15 @@ struct MusicImpl : public Music, public MixSource {
             for (; numFrames > 0 && idx < tickEndPos; --numFrames) {
                 const float frac = static_cast<float>(srcPos - floor(srcPos));
 
-                float sampleL =
-                    lerp(static_cast<float>(srcL[idx]), static_cast<float>(srcL[idx + 1]), frac);
-                float sampleR =
-                    lerp(static_cast<float>(srcR[idx]), static_cast<float>(srcR[idx + 1]), frac);
+                float sampleL = lerp(static_cast<float>(srcL[idx]),
+                                     static_cast<float>(srcL[idx + 1]), frac);
+                float sampleR = lerp(static_cast<float>(srcR[idx]),
+                                     static_cast<float>(srcR[idx + 1]), frac);
 
-                *dst++ = min(max(*dst + static_cast<short>(sampleL), SHRT_MIN), SHRT_MAX);
-                *dst++ = min(max(*dst + static_cast<short>(sampleR), SHRT_MIN), SHRT_MAX);
+                *dst++ = min(max(*dst + static_cast<short>(sampleL), SHRT_MIN),
+                             SHRT_MAX);
+                *dst++ = min(max(*dst + static_cast<short>(sampleR), SHRT_MIN),
+                             SHRT_MAX);
 
                 srcPos += srcDelta;
                 idx = static_cast<int>(srcPos);
@@ -245,7 +248,9 @@ struct MusicImpl : public Music, public MixSource {
         // silence.
         int framesLeft = frames;
         if (srcPos < 0) {
-            int n = min(framesLeft, static_cast<int>(max(-srcPos, static_cast<int64_t>INT_MIN)));
+            int n = min(
+                framesLeft,
+                static_cast<int>(max(-srcPos, static_cast<int64_t> INT_MIN)));
             memset(dst, 0, sizeof(short) * MIX_CHANNELS * n);
             dst += n * MIX_CHANNELS;
             framesLeft -= n;
@@ -255,8 +260,9 @@ struct MusicImpl : public Music, public MixSource {
         // Fill the remaining buffer with music samples.
         if (framesLeft > 0 && mySamples.isAllocated() && musicVolume > 0 &&
             !myIsMuted) {
-            int n = static_cast<int>(min(max(mySamples.getNumFrames() - srcPos, static_cast<int64_t>(0)),
-                             static_cast<int64_t>(framesLeft)));
+            int n = static_cast<int>(min(
+                max(mySamples.getNumFrames() - srcPos, static_cast<int64_t>(0)),
+                static_cast<int64_t>(framesLeft)));
             const short* srcL = mySamples.samplesL() + srcPos;
             const short* srcR = mySamples.samplesR() + srcPos;
             if (musicVolume == 100) {
@@ -318,11 +324,15 @@ struct MusicImpl : public Music, public MixSource {
                 float w1 = static_cast<float>(tmpPos - floor(tmpPos));
                 float w0 = 1.0f - w1;
 
-                float l = static_cast<float>(tmpL[index0]) * w0 + static_cast<float>(tmpL[index1]) * w1;
-                float r = static_cast<float>(tmpR[index0]) * w0 + static_cast<float>(tmpR[index1]) * w1;
+                float l = static_cast<float>(tmpL[index0]) * w0 +
+                          static_cast<float>(tmpL[index1]) * w1;
+                float r = static_cast<float>(tmpR[index0]) * w0 +
+                          static_cast<float>(tmpR[index1]) * w1;
 
-                *dst++ = static_cast<short>(min(max(static_cast<int>(l), SHRT_MIN), SHRT_MAX));
-                *dst++ = static_cast<short>(min(max(static_cast<int>(r), SHRT_MIN), SHRT_MAX));
+                *dst++ = static_cast<short>(
+                    min(max(static_cast<int>(l), SHRT_MIN), SHRT_MAX));
+                *dst++ = static_cast<short>(
+                    min(max(static_cast<int>(r), SHRT_MIN), SHRT_MAX));
 
                 tmpPos += rate;
             }
@@ -400,7 +410,8 @@ struct MusicImpl : public Music, public MixSource {
 
     void resumeStream() {
         if (!myIsPaused) {
-            myPlayPosition = myPlayStartTime * static_cast<double>(mySamples.getFrequency());
+            myPlayPosition =
+                myPlayStartTime * static_cast<double>(mySamples.getFrequency());
             myPlayTimer = Debug::getElapsedTime();
             myMixer->resume();
         }
@@ -595,11 +606,11 @@ Music* gMusic = nullptr;
 
 void Music::create(XmrNode& settings) {
     gMusic = new MusicImpl;
-    ((MusicImpl*)gMusic)->loadSettings(settings);
+    static_cast<MusicImpl*>(gMusic)->loadSettings(settings);
 }
 
 void Music::destroy() {
-    delete (MusicImpl*)gMusic;
+    delete static_cast<MusicImpl*>(gMusic);
     gMusic = nullptr;
 }
 

--- a/src/Editor/Notefield.cpp
+++ b/src/Editor/Notefield.cpp
@@ -71,13 +71,15 @@ struct DrawPosHelper {
         return getFunc(this, row, time);
     }
     static int RowBasedAdvance(DrawPosHelper* dp, int row) {
-        return static_cast<int>(dp->baseY + dp->deltaY * static_cast<double>(row));
+        return static_cast<int>(dp->baseY +
+                                dp->deltaY * static_cast<double>(row));
     }
     static int RowBasedGet(const DrawPosHelper* dp, int row, double time) {
         return static_cast<int>(dp->baseY + dp->deltaY * row);
     }
     static int TimeBasedAdvance(DrawPosHelper* dp, int row) {
-        return static_cast<int>(dp->baseY + dp->deltaY * dp->tracker.advance(row));
+        return static_cast<int>(dp->baseY +
+                                dp->deltaY * dp->tracker.advance(row));
     }
     static int TimeBasedGet(const DrawPosHelper* dp, int row, double time) {
         return static_cast<int>(dp->baseY + dp->deltaY * time);
@@ -168,9 +170,12 @@ struct NotefieldImpl : public Notefield {
                         bsum += src[2];
                         src += 4;
                     }
-                    int r = static_cast<int>(0.5f * static_cast<float>(rsum) / static_cast<float>(numPixels));
-                    int g = static_cast<int>(0.5f * static_cast<float>(gsum) / static_cast<float>(numPixels));
-                    int b = static_cast<int>(0.5f * static_cast<float>(bsum) / static_cast<float>(numPixels));
+                    int r = static_cast<int>(0.5f * static_cast<float>(rsum) /
+                                             static_cast<float>(numPixels));
+                    int g = static_cast<int>(0.5f * static_cast<float>(gsum) /
+                                             static_cast<float>(numPixels));
+                    int b = static_cast<int>(0.5f * static_cast<float>(bsum) /
+                                             static_cast<float>(numPixels));
                     mySongBgColor = RGBAtoColor32(r, g, b, 255);
                     mySongBg = Texture(img.width, img.height, img.pixels, false,
                                        Texture::RGBA);
@@ -265,13 +270,16 @@ struct NotefieldImpl : public Notefield {
         recti view = gView->getRect();
 
         // Background image.
-        auto style = static_cast<BackgroundStyle>(gEditor->getBackgroundStyle());
+        auto style =
+            static_cast<BackgroundStyle>(gEditor->getBackgroundStyle());
         if (mySongBg.handle() && myBgBrightness != 0) {
             recti r = view;
             vec2i size = mySongBg.size();
             if (style == BG_STYLE_LETTERBOX || style == BG_STYLE_CROP) {
-                double bgRatio = static_cast<double>(size.x) / static_cast<double>(size.y);
-                double viewRatio = static_cast<double>(r.w) / static_cast<double>(r.h);
+                double bgRatio =
+                    static_cast<double>(size.x) / static_cast<double>(size.y);
+                double viewRatio =
+                    static_cast<double>(r.w) / static_cast<double>(r.h);
 
                 if ((bgRatio > viewRatio) == (style == BG_STYLE_LETTERBOX)) {
                     r.h = size.y * r.w / size.x;
@@ -408,7 +416,7 @@ struct NotefieldImpl : public Notefield {
         auto& events = gTempo->getTimingData().events;
         auto batch = Renderer::batchC();
         if (gView->isTimeBased()) {
-            for (const auto & event : events) {
+            for (const auto& event : events) {
                 if (event.rowTime > event.time) {
                     int t = static_cast<int>(oy + dy * event.time);
                     int b = static_cast<int>(oy + dy * event.rowTime);
@@ -457,8 +465,8 @@ struct NotefieldImpl : public Notefield {
             // Calculate the beat pulse value for the receptors.
             double beat = gTempo->timeToBeat(gView->getCursorTime());
             float beatfrac = static_cast<float>(beat - floor(beat));
-            uint8_t beatpulse =
-                static_cast<uint8_t>(min(max(static_cast<int>((2 - beatfrac * 4) * 255), 0), 255));
+            uint8_t beatpulse = static_cast<uint8_t>(
+                min(max(static_cast<int>((2 - beatfrac * 4) * 255), 0), 255));
 
             // Draw the receptors.
             auto batch = Renderer::batchTC();
@@ -496,7 +504,8 @@ struct NotefieldImpl : public Notefield {
             if (!note) continue;
 
             double lum = 1.5 - (time - note->endtime) * 6.0;
-            uint8_t alpha = static_cast<uint8_t>(clamp(static_cast<int>(lum * 255.0), 0, 255));
+            uint8_t alpha = static_cast<uint8_t>(
+                clamp(static_cast<int>(lum * 255.0), 0, 255));
             if (alpha > 0) {
                 noteskin->recepGlow[c].draw(&batch, myColX[c], myY, alpha);
             }
@@ -660,7 +669,8 @@ struct NotefieldImpl : public Notefield {
     }
 
     void drawGhostNote(const Note& n) override {
-        if (n.col < 0 || static_cast<int>(n.col) >= gStyle->getNumCols()) return;
+        if (n.col < 0 || static_cast<int>(n.col) >= gStyle->getNumCols())
+            return;
 
         auto noteskin = gNoteskin->get();
         int numCols = gStyle->getNumCols();
@@ -716,22 +726,22 @@ struct NotefieldImpl : public Notefield {
     // ================================================================================================
     // NotefieldImpl :: toggle/check functions.
 
-    void NotefieldImpl::toggleShowWaveform() override {
+    void toggleShowWaveform() override {
         myShowWaveform = !myShowWaveform;
         gMenubar->update(Menubar::SHOW_WAVEFORM);
     }
 
-    void NotefieldImpl::toggleShowBeatLines() override {
+    void toggleShowBeatLines() override {
         myShowBeatLines = !myShowBeatLines;
         gMenubar->update(Menubar::SHOW_BEATLINES);
     }
 
-    void NotefieldImpl::toggleShowNotes() override {
+    void toggleShowNotes() override {
         myShowNotes = !myShowNotes;
         gMenubar->update(Menubar::SHOW_NOTES);
     }
 
-    void NotefieldImpl::toggleShowSongPreview() override {
+    void toggleShowSongPreview() override {
         myShowSongPreview = !myShowSongPreview;
     }
 
@@ -792,7 +802,7 @@ Notefield* gNotefield = nullptr;
 void Notefield::create() { gNotefield = new NotefieldImpl; }
 
 void Notefield::destroy() {
-    delete (NotefieldImpl*)gNotefield;
+    delete static_cast<NotefieldImpl*>(gNotefield);
     gNotefield = nullptr;
 }
 

--- a/src/Editor/Notefield.cpp
+++ b/src/Editor/Notefield.cpp
@@ -48,8 +48,8 @@ static int RoundUp(int value, int multiple) {
 }
 
 struct TweakInfoBox : public InfoBox {
-    void draw(recti r);
-    int height() { return 100; }
+    void draw(recti r) override;
+    int height() override { return 100; }
 };
 
 struct DrawPosHelper {
@@ -71,16 +71,16 @@ struct DrawPosHelper {
         return getFunc(this, row, time);
     }
     static int RowBasedAdvance(DrawPosHelper* dp, int row) {
-        return (int)(dp->baseY + dp->deltaY * (double)row);
+        return static_cast<int>(dp->baseY + dp->deltaY * static_cast<double>(row));
     }
     static int RowBasedGet(const DrawPosHelper* dp, int row, double time) {
-        return (int)(dp->baseY + dp->deltaY * row);
+        return static_cast<int>(dp->baseY + dp->deltaY * row);
     }
     static int TimeBasedAdvance(DrawPosHelper* dp, int row) {
-        return (int)(dp->baseY + dp->deltaY * dp->tracker.advance(row));
+        return static_cast<int>(dp->baseY + dp->deltaY * dp->tracker.advance(row));
     }
     static int TimeBasedGet(const DrawPosHelper* dp, int row, double time) {
-        return (int)(dp->baseY + dp->deltaY * time);
+        return static_cast<int>(dp->baseY + dp->deltaY * time);
     }
 
     typedef int (*AdvanceFunc)(DrawPosHelper*, int);
@@ -123,7 +123,7 @@ struct NotefieldImpl : public Notefield {
     // ================================================================================================
     // NotefieldImpl :: constructor and destructor.
 
-    ~NotefieldImpl() {}
+    ~NotefieldImpl() = default;
 
     NotefieldImpl() {
         mySongBgColor = RGBAtoColor32(255, 255, 255, 255);
@@ -145,7 +145,7 @@ struct NotefieldImpl : public Notefield {
     // ================================================================================================
     // NotefieldImpl :: member functions.
 
-    void onChanges(int changes) {
+    void onChanges(int changes) override {
         if (changes & VCM_BACKGROUND_PATH_CHANGED) {
             mySongBg = Texture();
             std::string filename;
@@ -168,9 +168,9 @@ struct NotefieldImpl : public Notefield {
                         bsum += src[2];
                         src += 4;
                     }
-                    int r = (int)(0.5f * (float)rsum / (float)numPixels);
-                    int g = (int)(0.5f * (float)gsum / (float)numPixels);
-                    int b = (int)(0.5f * (float)bsum / (float)numPixels);
+                    int r = static_cast<int>(0.5f * static_cast<float>(rsum) / static_cast<float>(numPixels));
+                    int g = static_cast<int>(0.5f * static_cast<float>(gsum) / static_cast<float>(numPixels));
+                    int b = static_cast<int>(0.5f * static_cast<float>(bsum) / static_cast<float>(numPixels));
                     mySongBgColor = RGBAtoColor32(r, g, b, 255);
                     mySongBg = Texture(img.width, img.height, img.pixels, false,
                                        Texture::RGBA);
@@ -183,7 +183,7 @@ struct NotefieldImpl : public Notefield {
         }
     }
 
-    void setBgAlpha(int percent) {
+    void setBgAlpha(int percent) override {
         percent = min(max(percent, 0), 100);
         if (myBgBrightness != percent) {
             myBgBrightness = percent;
@@ -191,12 +191,12 @@ struct NotefieldImpl : public Notefield {
         }
     }
 
-    int getBgAlpha() { return myBgBrightness; }
+    int getBgAlpha() override { return myBgBrightness; }
 
     // ================================================================================================
     // NotefieldImpl :: drawing routines.
 
-    void draw() {
+    void draw() override {
         int cx = CenterX(gView->getRect());
         int scale = gView->getNoteScale();
         bool drawWaveform = myShowWaveform && gView->isTimeBased();
@@ -265,13 +265,13 @@ struct NotefieldImpl : public Notefield {
         recti view = gView->getRect();
 
         // Background image.
-        auto style = (BackgroundStyle)gEditor->getBackgroundStyle();
+        auto style = static_cast<BackgroundStyle>(gEditor->getBackgroundStyle());
         if (mySongBg.handle() && myBgBrightness != 0) {
             recti r = view;
             vec2i size = mySongBg.size();
             if (style == BG_STYLE_LETTERBOX || style == BG_STYLE_CROP) {
-                double bgRatio = (double)size.x / (double)size.y;
-                double viewRatio = (double)r.w / (double)r.h;
+                double bgRatio = static_cast<double>(size.x) / static_cast<double>(size.y);
+                double viewRatio = static_cast<double>(r.w) / static_cast<double>(r.h);
 
                 if ((bgRatio > viewRatio) == (style == BG_STYLE_LETTERBOX)) {
                     r.h = size.y * r.w / size.x;
@@ -408,19 +408,18 @@ struct NotefieldImpl : public Notefield {
         auto& events = gTempo->getTimingData().events;
         auto batch = Renderer::batchC();
         if (gView->isTimeBased()) {
-            for (auto it = events.begin(), end = events.end(); it != end;
-                 ++it) {
-                if (it->rowTime > it->time) {
-                    int t = (int)(oy + dy * it->time);
-                    int b = (int)(oy + dy * it->rowTime);
+            for (const auto & event : events) {
+                if (event.rowTime > event.time) {
+                    int t = static_cast<int>(oy + dy * event.time);
+                    int b = static_cast<int>(oy + dy * event.rowTime);
                     if (validSegmentRegion(t, b, viewTop, viewBtm)) {
                         uint32_t col = RGBAtoColor32(26, 128, 128, 128);
                         Draw::fill(&batch, {myX, t, myW, b - t}, col);
                     }
                 }
-                if (it->endTime > it->rowTime) {
-                    int t = (int)(oy + dy * it->rowTime);
-                    int b = (int)(oy + dy * it->endTime);
+                if (event.endTime > event.rowTime) {
+                    int t = static_cast<int>(oy + dy * event.rowTime);
+                    int b = static_cast<int>(oy + dy * event.endTime);
                     if (validSegmentRegion(t, b, viewTop, viewBtm)) {
                         uint32_t col = RGBAtoColor32(128, 128, 51, 128);
                         Draw::fill(&batch, {myX, t, myW, b - t}, col);
@@ -431,8 +430,8 @@ struct NotefieldImpl : public Notefield {
             for (auto it = events.begin(), last = events.end() - 1; it < last;
                  ++it) {
                 if (it->spr == 0.0) {
-                    int t = (int)(oy + dy * it->row);
-                    int b = (int)(oy + dy * (it + 1)->row);
+                    int t = static_cast<int>(oy + dy * it->row);
+                    int b = static_cast<int>(oy + dy * (it + 1)->row);
                     if (validSegmentRegion(t, b, viewTop, viewBtm)) {
                         uint32_t col = RGBAtoColor32(128, 26, 51, 128);
                         Draw::fill(&batch, {myX, t, myW, b - t}, col);
@@ -457,15 +456,15 @@ struct NotefieldImpl : public Notefield {
 
             // Calculate the beat pulse value for the receptors.
             double beat = gTempo->timeToBeat(gView->getCursorTime());
-            float beatfrac = (float)(beat - floor(beat));
+            float beatfrac = static_cast<float>(beat - floor(beat));
             uint8_t beatpulse =
-                (uint8_t)min(max((int)((2 - beatfrac * 4) * 255), 0), 255);
+                static_cast<uint8_t>(min(max(static_cast<int>((2 - beatfrac * 4) * 255), 0), 255));
 
             // Draw the receptors.
             auto batch = Renderer::batchTC();
             for (int c = 0; c < cols; ++c) {
                 noteskin->recepOff[c].draw(&batch, myColX[c], myY,
-                                           (uint8_t)255);
+                                           static_cast<uint8_t>(255));
                 noteskin->recepOn[c].draw(&batch, myColX[c], myY, beatpulse);
             }
             batch.flush();
@@ -497,7 +496,7 @@ struct NotefieldImpl : public Notefield {
             if (!note) continue;
 
             double lum = 1.5 - (time - note->endtime) * 6.0;
-            uint8_t alpha = (uint8_t)clamp((int)(lum * 255.0), 0, 255);
+            uint8_t alpha = static_cast<uint8_t>(clamp(static_cast<int>(lum * 255.0), 0, 255));
             if (alpha > 0) {
                 noteskin->recepGlow[c].draw(&batch, myColX[c], myY, alpha);
             }
@@ -654,14 +653,14 @@ struct NotefieldImpl : public Notefield {
             if (note.isSelected) {
                 int y = drawPos.get(note.row, note.time);
                 if (y < -32 || y > maxY) continue;
-                select.draw(&batch, myColX[note.col], (int)y);
+                select.draw(&batch, myColX[note.col], y);
             }
         }
         batch.flush();
     }
 
-    void drawGhostNote(const Note& n) {
-        if (n.col < 0 || (int)n.col >= gStyle->getNumCols()) return;
+    void drawGhostNote(const Note& n) override {
+        if (n.col < 0 || static_cast<int>(n.col) >= gStyle->getNumCols()) return;
 
         auto noteskin = gNoteskin->get();
         int numCols = gStyle->getNumCols();
@@ -682,7 +681,7 @@ struct NotefieldImpl : public Notefield {
             auto& body = noteskin->holdBody[index];
             auto& tail = noteskin->holdTail[index];
 
-            int byi = (int)gView->rowToY(n.endrow);
+            int byi = gView->rowToY(n.endrow);
             int bodyY = noteskin->holdY[index] * signedScale / 256;
             int tailH = tail.height * signedScale / 512;
 
@@ -717,32 +716,32 @@ struct NotefieldImpl : public Notefield {
     // ================================================================================================
     // NotefieldImpl :: toggle/check functions.
 
-    void NotefieldImpl::toggleShowWaveform() {
+    void NotefieldImpl::toggleShowWaveform() override {
         myShowWaveform = !myShowWaveform;
         gMenubar->update(Menubar::SHOW_WAVEFORM);
     }
 
-    void NotefieldImpl::toggleShowBeatLines() {
+    void NotefieldImpl::toggleShowBeatLines() override {
         myShowBeatLines = !myShowBeatLines;
         gMenubar->update(Menubar::SHOW_BEATLINES);
     }
 
-    void NotefieldImpl::toggleShowNotes() {
+    void NotefieldImpl::toggleShowNotes() override {
         myShowNotes = !myShowNotes;
         gMenubar->update(Menubar::SHOW_NOTES);
     }
 
-    void NotefieldImpl::toggleShowSongPreview() {
+    void NotefieldImpl::toggleShowSongPreview() override {
         myShowSongPreview = !myShowSongPreview;
     }
 
-    bool hasShowWaveform() { return myShowWaveform; }
+    bool hasShowWaveform() override { return myShowWaveform; }
 
-    bool hasShowBeatLines() { return myShowBeatLines; }
+    bool hasShowBeatLines() override { return myShowBeatLines; }
 
-    bool hasShowNotes() { return myShowNotes; }
+    bool hasShowNotes() override { return myShowNotes; }
 
-    bool hasShowSongPreview() { return myShowSongPreview; }
+    bool hasShowSongPreview() override { return myShowSongPreview; }
 
 };  // NotefieldImpl
 

--- a/src/Editor/NotefieldPreview.cpp
+++ b/src/Editor/NotefieldPreview.cpp
@@ -482,7 +482,8 @@ NotefieldPreview* gNotefieldPreview = nullptr;
 
 void NotefieldPreview::create(XmrNode& settings) {
     gNotefieldPreview = new NotefieldPreviewImpl;
-    static_cast<NotefieldPreviewImpl*>(gNotefieldPreview)->loadSettings(settings);
+    static_cast<NotefieldPreviewImpl*>(gNotefieldPreview)
+        ->loadSettings(settings);
 }
 
 void NotefieldPreview::destroy() {

--- a/src/Editor/NotefieldPreview.cpp
+++ b/src/Editor/NotefieldPreview.cpp
@@ -67,14 +67,17 @@ struct DrawPosHelper {
         return static_cast<int>(dp->baseY + dp->deltaY * row);
     }
     static int RowBasedAlteredAdvance(DrawPosHelper* dp, int row) {
-        return static_cast<int>(dp->baseY + dp->deltaY * gTempo->rowToScroll(row));
+        return static_cast<int>(dp->baseY +
+                                dp->deltaY * gTempo->rowToScroll(row));
     }
     static int RowBasedAlteredGet(const DrawPosHelper* dp, int row,
                                   double time) {
-        return static_cast<int>(dp->baseY + dp->deltaY * gTempo->rowToScroll(row));
+        return static_cast<int>(dp->baseY +
+                                dp->deltaY * gTempo->rowToScroll(row));
     }
     static int TimeBasedAdvance(DrawPosHelper* dp, int row) {
-        return static_cast<int>(dp->baseY + dp->deltaY * dp->tracker.advance(row));
+        return static_cast<int>(dp->baseY +
+                                dp->deltaY * dp->tracker.advance(row));
     }
     static int TimeBasedGet(const DrawPosHelper* dp, int row, double time) {
         return static_cast<int>(dp->baseY + dp->deltaY * time);
@@ -219,10 +222,11 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
         bool zoomedIn = (gView->getZoomLevel() >= 4);
 
         // Determine the first row and last row that should show beat lines.
-        int drawBeginRow = max(0, static_cast<int>(currentRow) - ROWS_PER_BEAT * 4);
-        int drawEndRow =
-            min(static_cast<int>(currentRow) + ROWS_PER_BEAT * 20, gSimfile->getEndRow()) +
-            1;
+        int drawBeginRow =
+            max(0, static_cast<int>(currentRow) - ROWS_PER_BEAT * 4);
+        int drawEndRow = min(static_cast<int>(currentRow) + ROWS_PER_BEAT * 20,
+                             gSimfile->getEndRow()) +
+                         1;
 
         auto& sigs = gTempo->getTimingData().sigs;
         auto it = sigs.begin(), end = sigs.end();
@@ -300,13 +304,14 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
         // Calculate the beat pulse value for the receptors.
         double beat = gTempo->timeToBeat(gView->getCursorTime());
         float beatfrac = static_cast<float>(beat - floor(beat));
-        uint8_t beatpulse =
-            static_cast<uint8_t>(min(max(static_cast<int>((2 - beatfrac * 4) * 255), 0), 255));
+        uint8_t beatpulse = static_cast<uint8_t>(
+            min(max(static_cast<int>((2 - beatfrac * 4) * 255), 0), 255));
 
         // Draw the receptors.
         auto batch = Renderer::batchTC();
         for (int c = 0; c < cols; ++c) {
-            noteskin->recepOff[c].draw(&batch, myColX[c], myY, static_cast<uint8_t>(255));
+            noteskin->recepOff[c].draw(&batch, myColX[c], myY,
+                                       static_cast<uint8_t>(255));
             noteskin->recepOn[c].draw(&batch, myColX[c], myY, beatpulse);
         }
         batch.flush();
@@ -328,7 +333,8 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
             auto note = prevNotes[c];
             if (!note) continue;
             double lum = 1.5 - (time - note->endtime) * 6.0;
-            uint8_t alpha = static_cast<uint8_t>(clamp(static_cast<int>(lum * 255.0), 0, 255));
+            uint8_t alpha = static_cast<uint8_t>(
+                clamp(static_cast<int>(lum * 255.0), 0, 255));
             if (alpha > 0) {
                 noteskin->recepGlow[c].draw(&batch, myColX[c], myY, alpha);
             }
@@ -437,7 +443,7 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
     // ================================================================================================
     // NotefieldPreviewImpl :: toggle/check functions.
 
-    int NotefieldPreviewImpl::getY() override { return myY; }
+    int getY() override { return myY; }
 
     void setMode(DrawMode mode) override {
         myDrawMode = mode;
@@ -446,18 +452,18 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
 
     DrawMode getMode() override { return myDrawMode; }
 
-    void NotefieldPreviewImpl::toggleEnabled() override {
+    void toggleEnabled() override {
         myEnabled = !myEnabled;
         gView->adjustForPreview(myEnabled);
         gMenubar->update(Menubar::PREVIEW_ENABLED);
     }
 
-    void NotefieldPreviewImpl::toggleShowBeatLines() override {
+    void toggleShowBeatLines() override {
         myShowBeatLines = !myShowBeatLines;
         gMenubar->update(Menubar::PREVIEW_SHOW_BEATLINES);
     }
 
-    void NotefieldPreviewImpl::toggleReverseScroll() override {
+    void toggleReverseScroll() override {
         myUseReverseScroll = !myUseReverseScroll;
         gMenubar->update(Menubar::PREVIEW_SHOW_REVERSE_SCROLL);
     }
@@ -476,11 +482,11 @@ NotefieldPreview* gNotefieldPreview = nullptr;
 
 void NotefieldPreview::create(XmrNode& settings) {
     gNotefieldPreview = new NotefieldPreviewImpl;
-    ((NotefieldPreviewImpl*)gNotefieldPreview)->loadSettings(settings);
+    static_cast<NotefieldPreviewImpl*>(gNotefieldPreview)->loadSettings(settings);
 }
 
 void NotefieldPreview::destroy() {
-    delete (NotefieldPreviewImpl*)gNotefieldPreview;
+    delete static_cast<NotefieldPreviewImpl*>(gNotefieldPreview);
     gNotefieldPreview = nullptr;
 }
 

--- a/src/Editor/NotefieldPreview.cpp
+++ b/src/Editor/NotefieldPreview.cpp
@@ -34,7 +34,7 @@ typedef View::Coords Coords;
 struct DrawPosHelper {
     typedef NotefieldPreview::DrawMode DrawMode;
 
-    DrawPosHelper(DrawMode mode, bool reverse = false)
+    explicit DrawPosHelper(DrawMode mode, bool reverse = false)
         : tracker(gTempo->getTimingData()) {
         int dir = reverse ? -1 : 1;
         if (mode == DrawMode::CMOD) {
@@ -61,23 +61,23 @@ struct DrawPosHelper {
         return getFunc(this, row, time);
     }
     static int RowBasedAdvance(DrawPosHelper* dp, int row) {
-        return (int)(dp->baseY + dp->deltaY * row);
+        return static_cast<int>(dp->baseY + dp->deltaY * row);
     }
     static int RowBasedGet(const DrawPosHelper* dp, int row, double time) {
-        return (int)(dp->baseY + dp->deltaY * row);
+        return static_cast<int>(dp->baseY + dp->deltaY * row);
     }
     static int RowBasedAlteredAdvance(DrawPosHelper* dp, int row) {
-        return (int)(dp->baseY + dp->deltaY * gTempo->rowToScroll(row));
+        return static_cast<int>(dp->baseY + dp->deltaY * gTempo->rowToScroll(row));
     }
     static int RowBasedAlteredGet(const DrawPosHelper* dp, int row,
                                   double time) {
-        return (int)(dp->baseY + dp->deltaY * gTempo->rowToScroll(row));
+        return static_cast<int>(dp->baseY + dp->deltaY * gTempo->rowToScroll(row));
     }
     static int TimeBasedAdvance(DrawPosHelper* dp, int row) {
-        return (int)(dp->baseY + dp->deltaY * dp->tracker.advance(row));
+        return static_cast<int>(dp->baseY + dp->deltaY * dp->tracker.advance(row));
     }
     static int TimeBasedGet(const DrawPosHelper* dp, int row, double time) {
-        return (int)(dp->baseY + dp->deltaY * time);
+        return static_cast<int>(dp->baseY + dp->deltaY * time);
     }
 
     typedef int (*AdvanceFunc)(DrawPosHelper*, int);
@@ -111,7 +111,7 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
     // ================================================================================================
     // NotefieldPreviewImpl :: constructor and destructor.
 
-    ~NotefieldPreviewImpl() {}
+    ~NotefieldPreviewImpl() = default;
 
     NotefieldPreviewImpl() {
         myEnabled = false;
@@ -149,7 +149,7 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
         }
     }
 
-    void saveSettings(XmrNode& settings) {
+    void saveSettings(XmrNode& settings) override {
         XmrNode* preview = settings.child("preview");
         if (!preview) preview = settings.addChild("preview");
 
@@ -177,7 +177,7 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
         }
     }
 
-    void draw() {
+    void draw() override {
         if (!myEnabled || gChart->isClosed()) return;
 
         // Update common variables.
@@ -219,9 +219,9 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
         bool zoomedIn = (gView->getZoomLevel() >= 4);
 
         // Determine the first row and last row that should show beat lines.
-        int drawBeginRow = max(0, (int)currentRow - ROWS_PER_BEAT * 4);
+        int drawBeginRow = max(0, static_cast<int>(currentRow) - ROWS_PER_BEAT * 4);
         int drawEndRow =
-            min((int)currentRow + ROWS_PER_BEAT * 20, gSimfile->getEndRow()) +
+            min(static_cast<int>(currentRow) + ROWS_PER_BEAT * 20, gSimfile->getEndRow()) +
             1;
 
         auto& sigs = gTempo->getTimingData().sigs;
@@ -299,14 +299,14 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
 
         // Calculate the beat pulse value for the receptors.
         double beat = gTempo->timeToBeat(gView->getCursorTime());
-        float beatfrac = (float)(beat - floor(beat));
+        float beatfrac = static_cast<float>(beat - floor(beat));
         uint8_t beatpulse =
-            (uint8_t)min(max((int)((2 - beatfrac * 4) * 255), 0), 255);
+            static_cast<uint8_t>(min(max(static_cast<int>((2 - beatfrac * 4) * 255), 0), 255));
 
         // Draw the receptors.
         auto batch = Renderer::batchTC();
         for (int c = 0; c < cols; ++c) {
-            noteskin->recepOff[c].draw(&batch, myColX[c], myY, (uint8_t)255);
+            noteskin->recepOff[c].draw(&batch, myColX[c], myY, static_cast<uint8_t>(255));
             noteskin->recepOn[c].draw(&batch, myColX[c], myY, beatpulse);
         }
         batch.flush();
@@ -328,7 +328,7 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
             auto note = prevNotes[c];
             if (!note) continue;
             double lum = 1.5 - (time - note->endtime) * 6.0;
-            uint8_t alpha = (uint8_t)clamp((int)(lum * 255.0), 0, 255);
+            uint8_t alpha = static_cast<uint8_t>(clamp(static_cast<int>(lum * 255.0), 0, 255));
             if (alpha > 0) {
                 noteskin->recepGlow[c].draw(&batch, myColX[c], myY, alpha);
             }
@@ -437,36 +437,36 @@ struct NotefieldPreviewImpl : public NotefieldPreview {
     // ================================================================================================
     // NotefieldPreviewImpl :: toggle/check functions.
 
-    int NotefieldPreviewImpl::getY() { return myY; }
+    int NotefieldPreviewImpl::getY() override { return myY; }
 
-    void setMode(DrawMode mode) {
+    void setMode(DrawMode mode) override {
         myDrawMode = mode;
         gMenubar->update(Menubar::PREVIEW_VIEW_MODE);
     }
 
-    DrawMode getMode() { return myDrawMode; }
+    DrawMode getMode() override { return myDrawMode; }
 
-    void NotefieldPreviewImpl::toggleEnabled() {
+    void NotefieldPreviewImpl::toggleEnabled() override {
         myEnabled = !myEnabled;
         gView->adjustForPreview(myEnabled);
         gMenubar->update(Menubar::PREVIEW_ENABLED);
     }
 
-    void NotefieldPreviewImpl::toggleShowBeatLines() {
+    void NotefieldPreviewImpl::toggleShowBeatLines() override {
         myShowBeatLines = !myShowBeatLines;
         gMenubar->update(Menubar::PREVIEW_SHOW_BEATLINES);
     }
 
-    void NotefieldPreviewImpl::toggleReverseScroll() {
+    void NotefieldPreviewImpl::toggleReverseScroll() override {
         myUseReverseScroll = !myUseReverseScroll;
         gMenubar->update(Menubar::PREVIEW_SHOW_REVERSE_SCROLL);
     }
 
-    bool hasEnabled() { return myEnabled; }
+    bool hasEnabled() override { return myEnabled; }
 
-    bool hasReverseScroll() { return myUseReverseScroll; }
+    bool hasReverseScroll() override { return myUseReverseScroll; }
 
-    bool hasShowBeatLines() { return myShowBeatLines; }
+    bool hasShowBeatLines() override { return myShowBeatLines; }
 };
 
 // ================================================================================================

--- a/src/Editor/RatingEstimator.cpp
+++ b/src/Editor/RatingEstimator.cpp
@@ -54,7 +54,7 @@ static Vector<double> CalcDensities() {
             if (s > *curStamp + timeWindow) {
                 int numArrows = &s - curStamp;
                 double dt = s - *curStamp;
-                densities.push_back((double)numArrows / dt);
+                densities.push_back(static_cast<double>(numArrows) / dt);
                 curStamp = &s;
             }
         }
@@ -63,14 +63,14 @@ static Vector<double> CalcDensities() {
 
     // Estimation parameters.
     int sliceSize[HM_NUM_SLICES] = {2, 4, 7, 13, 22, 38, 65, 90, 150, 240};
-    int totalSize = (int)densities.size();
-    for (int i = 0; i < HM_NUM_SLICES; ++i) {
-        if (totalSize >= sliceSize[i]) {
+    int totalSize = densities.size();
+    for (int i : sliceSize) {
+        if (totalSize >= i) {
             double n = 0;
-            for (int j = totalSize - sliceSize[i]; j != totalSize; ++j) {
+            for (int j = totalSize - i; j != totalSize; ++j) {
                 n += densities[j];
             }
-            out.push_back(n / sliceSize[i]);
+            out.push_back(n / i);
         } else {
             out.push_back(0.0);
         }
@@ -80,7 +80,7 @@ static Vector<double> CalcDensities() {
 }
 
 inline int getDensityBin(double density) {
-    int bin = (int)density;
+    int bin = static_cast<int>(density);
     return std::min(std::max(0, bin), HM_VALS_PER_SLICE - 2);
 }
 
@@ -92,7 +92,7 @@ double RatingEstimator::estimateRating() {
         double density = densities[i], rating;
         if (density > 0.0) {
             int bin = getDensityBin(density);
-            double frac = std::min(std::max(0.0, density - (double)bin), 1.0);
+            double frac = std::min(std::max(0.0, density - static_cast<double>(bin)), 1.0);
             const double* sliceWeights = myWeights + i * HM_VALS_PER_SLICE;
             double diffA = sliceWeights[bin];
             double diffB = sliceWeights[bin + 1];

--- a/src/Editor/RatingEstimator.cpp
+++ b/src/Editor/RatingEstimator.cpp
@@ -92,7 +92,8 @@ double RatingEstimator::estimateRating() {
         double density = densities[i], rating;
         if (density > 0.0) {
             int bin = getDensityBin(density);
-            double frac = std::min(std::max(0.0, density - static_cast<double>(bin)), 1.0);
+            double frac = std::min(
+                std::max(0.0, density - static_cast<double>(bin)), 1.0);
             const double* sliceWeights = myWeights + i * HM_VALS_PER_SLICE;
             double diffA = sliceWeights[bin];
             double diffB = sliceWeights[bin + 1];

--- a/src/Editor/Selection.cpp
+++ b/src/Editor/Selection.cpp
@@ -128,8 +128,8 @@ struct SelectionImpl : public Selection {
             if (gView->isTimeBased()) {
                 gTempoBoxes->selectTime(mod, t, b, l, r);
             } else {
-                gTempoBoxes->selectRows(mod, static_cast<int>(t + 0.5), static_cast<int>(b + 0.5), l,
-                                        r);
+                gTempoBoxes->selectRows(mod, static_cast<int>(t + 0.5),
+                                        static_cast<int>(b + 0.5), l, r);
             }
         }
     }
@@ -146,7 +146,8 @@ struct SelectionImpl : public Selection {
             mindist *= mindist;
 
             for (auto& note : *gNotes) {
-                double tor = timeBased ? note.time : static_cast<double>(note.row);
+                double tor =
+                    timeBased ? note.time : static_cast<double>(note.row);
                 int dx = xl - gView->columnToX(note.col);
                 int dy = static_cast<int>(clickY - gView->offsetToY(tor));
                 if (abs(dy) < mindist) {
@@ -318,7 +319,8 @@ struct SelectionImpl : public Selection {
         return numSelected;
     }
 
-    int selectNotes(SelectModifier mod, const Vector<RowCol>& indices) override {
+    int selectNotes(SelectModifier mod,
+                    const Vector<RowCol>& indices) override {
         int numSelected = gNotes->select(mod, indices);
         showSelectionResult(mod, numSelected);
         return numSelected;
@@ -386,7 +388,7 @@ Selection* gSelection = nullptr;
 void Selection::create() { gSelection = new SelectionImpl; }
 
 void Selection::destroy() {
-    delete (SelectionImpl*)gSelection;
+    delete static_cast<SelectionImpl*>(gSelection);
     gSelection = nullptr;
 }
 

--- a/src/Editor/Selection.cpp
+++ b/src/Editor/Selection.cpp
@@ -34,7 +34,7 @@ struct SelectionImpl : public Selection {
     // ================================================================================================
     // SelectionImpl :: constructor and destructor.
 
-    ~SelectionImpl() {}
+    ~SelectionImpl() = default;
 
     SelectionImpl() {
         myDragSelectionX = 0;
@@ -128,7 +128,7 @@ struct SelectionImpl : public Selection {
             if (gView->isTimeBased()) {
                 gTempoBoxes->selectTime(mod, t, b, l, r);
             } else {
-                gTempoBoxes->selectRows(mod, (int)(t + 0.5), (int)(b + 0.5), l,
+                gTempoBoxes->selectRows(mod, static_cast<int>(t + 0.5), static_cast<int>(b + 0.5), l,
                                         r);
             }
         }
@@ -146,9 +146,9 @@ struct SelectionImpl : public Selection {
             mindist *= mindist;
 
             for (auto& note : *gNotes) {
-                double tor = timeBased ? note.time : (double)note.row;
+                double tor = timeBased ? note.time : static_cast<double>(note.row);
                 int dx = xl - gView->columnToX(note.col);
-                int dy = (int)(clickY - gView->offsetToY(tor));
+                int dy = static_cast<int>(clickY - gView->offsetToY(tor));
                 if (abs(dy) < mindist) {
                     int sqrdist = dx * dx + dy * dy;
                     if (sqrdist < mindist) {
@@ -180,15 +180,15 @@ struct SelectionImpl : public Selection {
                 begin.row = gTempo->timeToRow(torT);
                 end.row = gTempo->timeToRow(torB);
             } else {
-                begin.row = (int)torT;
-                end.row = (int)torB + 1;
+                begin.row = static_cast<int>(torT);
+                end.row = static_cast<int>(torB) + 1;
             }
             return selectNotes(mod, begin, end) > 0;
         }
         return false;
     }
 
-    void setType(Type type) {
+    void setType(Type type) override {
         myType = type;
 
         // Region selection.
@@ -222,9 +222,9 @@ struct SelectionImpl : public Selection {
         gEditor->reportChanges(VCM_SELECTION_CHANGED);
     }
 
-    Type getType() const { return myType; }
+    Type getType() const override { return myType; }
 
-    void drawRegionSelection() {
+    void drawRegionSelection() override {
         // Draw area selection box.
         if (myIsSelectingRegion || myRegion.beginRow != myRegion.endRow) {
             uint32_t outline = RGBAtoColor32(153, 255, 153, 153);
@@ -242,7 +242,7 @@ struct SelectionImpl : public Selection {
         }
     }
 
-    void drawSelectionBox() {
+    void drawSelectionBox() override {
         // Draw dragging selection box (for note/tempo selection).
         if (myIsDraggingSelection) {
             vec2i mpos = gSystem->getMousePos();
@@ -293,11 +293,11 @@ struct SelectionImpl : public Selection {
         }
     }
 
-    void selectAllNotes() {
+    void selectAllNotes() override {
         showSelectionResult(SELECT_SET, gNotes->selectAll());
     }
 
-    int selectNotes(NotesMan::Filter filter) {
+    int selectNotes(NotesMan::Filter filter) override {
         const char* names[NotesMan::NUM_FILTERS] = {
             "step", "jump note", "mine", "hold", "roll", "warped note"};
         int numSelected = gNotes->select(SELECT_SET, filter);
@@ -305,26 +305,26 @@ struct SelectionImpl : public Selection {
         return numSelected;
     }
 
-    int selectNotes(RowType rowType) {
+    int selectNotes(RowType rowType) override {
         int numSelected = gNotes->selectQuant(rowType);
         showSelectionResult(SELECT_SET, numSelected);
         return numSelected;
     }
 
-    int selectNotes(SelectModifier mod, RowCol begin, RowCol end) {
+    int selectNotes(SelectModifier mod, RowCol begin, RowCol end) override {
         int numSelected =
             gNotes->selectRows(mod, begin.col, end.col, begin.row, end.row);
         showSelectionResult(mod, numSelected);
         return numSelected;
     }
 
-    int selectNotes(SelectModifier mod, const Vector<RowCol>& indices) {
+    int selectNotes(SelectModifier mod, const Vector<RowCol>& indices) override {
         int numSelected = gNotes->select(mod, indices);
         showSelectionResult(mod, numSelected);
         return numSelected;
     }
 
-    int getSelectedNotes(NoteList& out) {
+    int getSelectedNotes(NoteList& out) override {
         if (myRegion.beginRow == myRegion.endRow) {
             for (auto& note : *gNotes) {
                 if (note.isSelected) out.append(CompressNote(note));
@@ -342,7 +342,7 @@ struct SelectionImpl : public Selection {
     // ================================================================================================
     // Region selection.
 
-    void selectRegion() {
+    void selectRegion() override {
         if (!myIsSelectingRegion) {
             gTempoBoxes->deselectAll();
             gNotes->deselectAll();
@@ -356,7 +356,7 @@ struct SelectionImpl : public Selection {
         }
     }
 
-    void selectRegion(int row, int endrow) {
+    void selectRegion(int row, int endrow) override {
         if (row != endrow) {
             if (row > endrow) swapValues(row, endrow);
             myRegion = {row, endrow};
@@ -374,7 +374,7 @@ struct SelectionImpl : public Selection {
         }
     }
 
-    SelectionRegion getSelectedRegion() { return myRegion; }
+    SelectionRegion getSelectedRegion() override { return myRegion; }
 
 };  // SelectionImpl
 

--- a/src/Editor/Shortcuts.cpp
+++ b/src/Editor/Shortcuts.cpp
@@ -431,7 +431,7 @@ struct ShortcutsImpl : public Shortcuts {
     // ================================================================================================
     // ShortcutsImpl :: API functions.
 
-    std::string getNotation(Action::Type action, bool fullList = false) override {
+    std::string getNotation(Action::Type action, bool fullList) override {
         std::string out;
         for (auto& shortcut : shortcutMappings_) {
             if (shortcut.action->code == action) {
@@ -498,7 +498,7 @@ Shortcuts* gShortcuts = nullptr;
 void Shortcuts::create() { gShortcuts = new ShortcutsImpl; }
 
 void Shortcuts::destroy() {
-    delete (ShortcutsImpl*)gShortcuts;
+    delete static_cast<ShortcutsImpl*>(gShortcuts);
     gShortcuts = nullptr;
 }
 

--- a/src/Editor/Shortcuts.cpp
+++ b/src/Editor/Shortcuts.cpp
@@ -426,12 +426,12 @@ struct ShortcutsImpl : public Shortcuts {
         }
     }
 
-    ~ShortcutsImpl() {}
+    ~ShortcutsImpl() = default;
 
     // ================================================================================================
     // ShortcutsImpl :: API functions.
 
-    std::string getNotation(Action::Type action, bool fullList = false) {
+    std::string getNotation(Action::Type action, bool fullList = false) override {
         std::string out;
         for (auto& shortcut : shortcutMappings_) {
             if (shortcut.action->code == action) {
@@ -465,22 +465,22 @@ struct ShortcutsImpl : public Shortcuts {
         return out;
     }
 
-    Action::Type getAction(int keyflags, Code key) {
+    Action::Type getAction(int keyflags, Code key) override {
         for (auto& shortcut : shortcutMappings_) {
             if (shortcut.key && shortcut.key->code == key) {
                 if (shortcut.keyflags == keyflags) {
-                    return (Action::Type)shortcut.action->code;
+                    return shortcut.action->code;
                 }
             }
         }
         return Action::NONE;
     }
 
-    Action::Type getAction(int keyflags, bool scrollUp) {
+    Action::Type getAction(int keyflags, bool scrollUp) override {
         for (auto& shortcut : shortcutMappings_) {
             if (shortcut.key == nullptr && shortcut.scrollUp == scrollUp) {
                 if (shortcut.keyflags == keyflags) {
-                    return (Action::Type)shortcut.action->code;
+                    return shortcut.action->code;
                 }
             }
         }

--- a/src/Editor/Sound.cpp
+++ b/src/Editor/Sound.cpp
@@ -158,8 +158,9 @@ bool Sound::Thread::readBlock() {
         myCurrentFrame += framesRead;
 
         if (mySound->myIsAllocated) {
-            myProgress = static_cast<uint8_t>(static_cast<uint64_t>(100) * myCurrentFrame /
-                                   mySound->myNumFrames);
+            myProgress =
+                static_cast<uint8_t>(static_cast<uint64_t>(100) *
+                                     myCurrentFrame / mySound->myNumFrames);
         }
     }
 

--- a/src/Editor/Sound.cpp
+++ b/src/Editor/Sound.cpp
@@ -68,10 +68,10 @@ static const int BUFFER_SIZE = 1024;
 
 class Sound::Thread : public BackgroundThread {
    public:
-    ~Thread();
+    ~Thread() override;
     Thread(Sound* sound, SoundSource* source);
 
-    void exec();
+    void exec() override;
     bool readBlock();
     void cleanup();
     uint8_t progress() { return myProgress; }
@@ -99,7 +99,7 @@ Sound::Thread::Thread(Sound* sound, SoundSource* source) {
     mySource = source;
 
     int bytesPerFrame = source->getNumChannels() * source->getBytesPerSample();
-    myBuffer = (short*)malloc(BUFFER_SIZE * bytesPerFrame);
+    myBuffer = static_cast<short*>(malloc(BUFFER_SIZE * bytesPerFrame));
 
     myCurrentFrame = 0;
     myReservedFrames = 0;
@@ -158,7 +158,7 @@ bool Sound::Thread::readBlock() {
         myCurrentFrame += framesRead;
 
         if (mySound->myIsAllocated) {
-            myProgress = (uint8_t)((uint64_t)100 * myCurrentFrame /
+            myProgress = static_cast<uint8_t>(static_cast<uint64_t>(100) * myCurrentFrame /
                                    mySound->myNumFrames);
         }
     }

--- a/src/Editor/Statusbar.cpp
+++ b/src/Editor/Statusbar.cpp
@@ -42,7 +42,7 @@ struct StatusbarImpl : public Statusbar {
     // ================================================================================================
     // StatusbarImpl :: constructor / destructor.
 
-    ~StatusbarImpl() {}
+    ~StatusbarImpl() = default;
 
     StatusbarImpl() {
         myShowChart = true;
@@ -76,7 +76,7 @@ struct StatusbarImpl : public Statusbar {
         }
     }
 
-    void saveSettings(XmrNode& settings) {
+    void saveSettings(XmrNode& settings) override {
         XmrNode* statusbar = settings.addChild("statusbar");
 
         statusbar->addAttrib("showChart", myShowChart);
@@ -94,7 +94,7 @@ struct StatusbarImpl : public Statusbar {
     // ================================================================================================
     // StatusbarImpl :: member functions.
 
-    void draw() {
+    void draw() override {
         Vector<std::string> info;
 
         TextStyle textStyle;
@@ -177,75 +177,75 @@ struct StatusbarImpl : public Statusbar {
     // ================================================================================================
     // StatusbarImpl :: toggle/check functions.
 
-    void StatusbarImpl::toggleChart() {
+    void StatusbarImpl::toggleChart() override {
         myShowChart = !myShowChart;
         gMenubar->update(Menubar::STATUSBAR_CHART);
     }
 
-    void StatusbarImpl::toggleSnap() {
+    void StatusbarImpl::toggleSnap() override {
         myShowSnap = !myShowSnap;
         gMenubar->update(Menubar::STATUSBAR_SNAP);
     }
 
-    void StatusbarImpl::toggleBpm() {
+    void StatusbarImpl::toggleBpm() override {
         myShowBpm = !myShowBpm;
         gMenubar->update(Menubar::STATUSBAR_BPM);
     }
 
-    void StatusbarImpl::toggleRow() {
+    void StatusbarImpl::toggleRow() override {
         myShowRow = !myShowRow;
         gMenubar->update(Menubar::STATUSBAR_ROW);
     }
 
-    void StatusbarImpl::toggleBeat() {
+    void StatusbarImpl::toggleBeat() override {
         myShowBeat = !myShowBeat;
         gMenubar->update(Menubar::STATUSBAR_BEAT);
     }
 
-    void StatusbarImpl::toggleMeasure() {
+    void StatusbarImpl::toggleMeasure() override {
         myShowMeasure = !myShowMeasure;
         gMenubar->update(Menubar::STATUSBAR_MEASURE);
     }
 
-    void StatusbarImpl::toggleTime() {
+    void StatusbarImpl::toggleTime() override {
         myShowTime = !myShowTime;
         gMenubar->update(Menubar::STATUSBAR_TIME);
     }
 
-    void StatusbarImpl::toggleTimingMode() {
+    void StatusbarImpl::toggleTimingMode() override {
         myShowTimingMode = !myShowTimingMode;
         gMenubar->update(Menubar::STATUSBAR_TIMING_MODE);
     }
 
-    void StatusbarImpl::toggleScroll() {
+    void StatusbarImpl::toggleScroll() override {
         myShowScroll = !myShowScroll;
         gMenubar->update(Menubar::STATUSBAR_SCROLL);
     }
 
-    void StatusbarImpl::toggleSpeed() {
+    void StatusbarImpl::toggleSpeed() override {
         myShowSpeed = !myShowSpeed;
         gMenubar->update(Menubar::STATUSBAR_SPEED);
     }
 
-    bool StatusbarImpl::hasChart() { return myShowChart; }
+    bool StatusbarImpl::hasChart() override { return myShowChart; }
 
-    bool StatusbarImpl::hasSnap() { return myShowSnap; }
+    bool StatusbarImpl::hasSnap() override { return myShowSnap; }
 
-    bool StatusbarImpl::hasBpm() { return myShowBpm; }
+    bool StatusbarImpl::hasBpm() override { return myShowBpm; }
 
-    bool StatusbarImpl::hasRow() { return myShowRow; }
+    bool StatusbarImpl::hasRow() override { return myShowRow; }
 
-    bool StatusbarImpl::hasBeat() { return myShowBeat; }
+    bool StatusbarImpl::hasBeat() override { return myShowBeat; }
 
-    bool StatusbarImpl::hasMeasure() { return myShowMeasure; }
+    bool StatusbarImpl::hasMeasure() override { return myShowMeasure; }
 
-    bool StatusbarImpl::hasTime() { return myShowTime; }
+    bool StatusbarImpl::hasTime() override { return myShowTime; }
 
-    bool StatusbarImpl::hasTimingMode() { return myShowTimingMode; }
+    bool StatusbarImpl::hasTimingMode() override { return myShowTimingMode; }
 
-    bool StatusbarImpl::hasScroll() { return myShowScroll; }
+    bool StatusbarImpl::hasScroll() override { return myShowScroll; }
 
-    bool StatusbarImpl::hasSpeed() { return myShowSpeed; }
+    bool StatusbarImpl::hasSpeed() override { return myShowSpeed; }
 
 };  // StatusbarImpl
 

--- a/src/Editor/Statusbar.cpp
+++ b/src/Editor/Statusbar.cpp
@@ -177,75 +177,75 @@ struct StatusbarImpl : public Statusbar {
     // ================================================================================================
     // StatusbarImpl :: toggle/check functions.
 
-    void StatusbarImpl::toggleChart() override {
+    void toggleChart() override {
         myShowChart = !myShowChart;
         gMenubar->update(Menubar::STATUSBAR_CHART);
     }
 
-    void StatusbarImpl::toggleSnap() override {
+    void toggleSnap() override {
         myShowSnap = !myShowSnap;
         gMenubar->update(Menubar::STATUSBAR_SNAP);
     }
 
-    void StatusbarImpl::toggleBpm() override {
+    void toggleBpm() override {
         myShowBpm = !myShowBpm;
         gMenubar->update(Menubar::STATUSBAR_BPM);
     }
 
-    void StatusbarImpl::toggleRow() override {
+    void toggleRow() override {
         myShowRow = !myShowRow;
         gMenubar->update(Menubar::STATUSBAR_ROW);
     }
 
-    void StatusbarImpl::toggleBeat() override {
+    void toggleBeat() override {
         myShowBeat = !myShowBeat;
         gMenubar->update(Menubar::STATUSBAR_BEAT);
     }
 
-    void StatusbarImpl::toggleMeasure() override {
+    void toggleMeasure() override {
         myShowMeasure = !myShowMeasure;
         gMenubar->update(Menubar::STATUSBAR_MEASURE);
     }
 
-    void StatusbarImpl::toggleTime() override {
+    void toggleTime() override {
         myShowTime = !myShowTime;
         gMenubar->update(Menubar::STATUSBAR_TIME);
     }
 
-    void StatusbarImpl::toggleTimingMode() override {
+    void toggleTimingMode() override {
         myShowTimingMode = !myShowTimingMode;
         gMenubar->update(Menubar::STATUSBAR_TIMING_MODE);
     }
 
-    void StatusbarImpl::toggleScroll() override {
+    void toggleScroll() override {
         myShowScroll = !myShowScroll;
         gMenubar->update(Menubar::STATUSBAR_SCROLL);
     }
 
-    void StatusbarImpl::toggleSpeed() override {
+    void toggleSpeed() override {
         myShowSpeed = !myShowSpeed;
         gMenubar->update(Menubar::STATUSBAR_SPEED);
     }
 
-    bool StatusbarImpl::hasChart() override { return myShowChart; }
+    bool hasChart() override { return myShowChart; }
 
-    bool StatusbarImpl::hasSnap() override { return myShowSnap; }
+    bool hasSnap() override { return myShowSnap; }
 
-    bool StatusbarImpl::hasBpm() override { return myShowBpm; }
+    bool hasBpm() override { return myShowBpm; }
 
-    bool StatusbarImpl::hasRow() override { return myShowRow; }
+    bool hasRow() override { return myShowRow; }
 
-    bool StatusbarImpl::hasBeat() override { return myShowBeat; }
+    bool hasBeat() override { return myShowBeat; }
 
-    bool StatusbarImpl::hasMeasure() override { return myShowMeasure; }
+    bool hasMeasure() override { return myShowMeasure; }
 
-    bool StatusbarImpl::hasTime() override { return myShowTime; }
+    bool hasTime() override { return myShowTime; }
 
-    bool StatusbarImpl::hasTimingMode() override { return myShowTimingMode; }
+    bool hasTimingMode() override { return myShowTimingMode; }
 
-    bool StatusbarImpl::hasScroll() override { return myShowScroll; }
+    bool hasScroll() override { return myShowScroll; }
 
-    bool StatusbarImpl::hasSpeed() override { return myShowSpeed; }
+    bool hasSpeed() override { return myShowSpeed; }
 
 };  // StatusbarImpl
 
@@ -256,11 +256,11 @@ Statusbar* gStatusbar = nullptr;
 
 void Statusbar::create(XmrNode& settings) {
     gStatusbar = new StatusbarImpl();
-    ((StatusbarImpl*)gStatusbar)->loadSettings(settings);
+    static_cast<StatusbarImpl*>(gStatusbar)->loadSettings(settings);
 }
 
 void Statusbar::destroy() {
-    delete (StatusbarImpl*)gStatusbar;
+    delete static_cast<StatusbarImpl*>(gStatusbar);
     gStatusbar = nullptr;
 }
 

--- a/src/Editor/StreamGenerator.cpp
+++ b/src/Editor/StreamGenerator.cpp
@@ -24,8 +24,8 @@ static const float MAX_SPREAD_DIST = 3.1f;
 enum Foot { FOOT_L = 0, FOOT_R = 1 };
 
 static float GetPadDist(vec2i* pad, int colA, int colB) {
-    float dx = (float)(pad[colA].x - pad[colB].x);
-    float dy = (float)(pad[colA].y - pad[colB].y);
+    float dx = static_cast<float>(pad[colA].x - pad[colB].x);
+    float dy = static_cast<float>(pad[colA].y - pad[colB].y);
     return sqrt(dx * dx + dy * dy);
 }
 
@@ -49,7 +49,7 @@ struct FootPlanner {
 };
 
 struct StreamPlanner {
-    StreamPlanner(const StreamGenerator* sg);
+    explicit StreamPlanner(const StreamGenerator* sg);
 
     float random();
     int getNextCol();
@@ -249,7 +249,7 @@ void StreamGenerator::generate(int row, int endRow, SnapType spacing) {
     while (row < endRow) {
         // Generate an arrow for the current row.
         int col = stream.getNextCol();
-        edit.add.append({row, row, (uint32_t)col, 0, NOTE_STEP_OR_HOLD, 192});
+        edit.add.append({row, row, static_cast<uint32_t>(col), 0, NOTE_STEP_OR_HOLD, 192});
 
         // Store the current facing.
         int yl = stream.pad[stream.feet[FOOT_L].curCol].y;

--- a/src/Editor/StreamGenerator.cpp
+++ b/src/Editor/StreamGenerator.cpp
@@ -249,7 +249,8 @@ void StreamGenerator::generate(int row, int endRow, SnapType spacing) {
     while (row < endRow) {
         // Generate an arrow for the current row.
         int col = stream.getNextCol();
-        edit.add.append({row, row, static_cast<uint32_t>(col), 0, NOTE_STEP_OR_HOLD, 192});
+        edit.add.append(
+            {row, row, static_cast<uint32_t>(col), 0, NOTE_STEP_OR_HOLD, 192});
 
         // Store the current facing.
         int yl = stream.pad[stream.feet[FOOT_L].curCol].y;

--- a/src/Editor/TempoBoxes.cpp
+++ b/src/Editor/TempoBoxes.cpp
@@ -83,11 +83,11 @@ struct TempoBoxesImpl : public TempoBoxes {
 
         // Create a box for every segment.
         auto segments = gTempo->getSegments();
-        for (const auto & segment : *segments) {
+        for (const auto& segment : *segments) {
             auto type = segment.type();
             auto meta = Segment::meta[type];
-            for (auto seg = segment.begin(), segEnd = segment.end(); seg != segEnd;
-                 ++seg) {
+            for (auto seg = segment.begin(), segEnd = segment.end();
+                 seg != segEnd; ++seg) {
                 std::string desc = meta->getDescription(seg.ptr);
                 myBoxes.push_back(TempoBox{desc, seg->row, type, 0, 0, 0});
             }
@@ -182,11 +182,11 @@ struct TempoBoxesImpl : public TempoBoxes {
         int numSelected = 0;
         auto boxEnd = myBoxes.end();
         auto segments = gTempo->getSegments();
-        for (const auto & segment : *segments) {
+        for (const auto& segment : *segments) {
             auto type = segment.type();
             auto box = myBoxes.begin();
-            for (auto seg = segment.begin(), segEnd = segment.end(); seg != segEnd;
-                 ++seg) {
+            for (auto seg = segment.begin(), segEnd = segment.end();
+                 seg != segEnd; ++seg) {
                 while (box != boxEnd &&
                        (box->type != type || box->row < seg->row)) {
                     ++box;
@@ -227,7 +227,8 @@ struct TempoBoxesImpl : public TempoBoxes {
         return numSelected;
     }
 
-    int selectRows(SelectModifier mod, int begin, int end, int xl, int xr) override {
+    int selectRows(SelectModifier mod, int begin, int end, int xl,
+                   int xr) override {
         auto coords = gView->getNotefieldCoords();
         const int baseX[2] = {coords.xl, coords.xr};
         return performSelection(mod, [&](const TempoBox* box) {
@@ -275,12 +276,13 @@ struct TempoBoxesImpl : public TempoBoxes {
             vec2i mpos = gSystem->getMousePos();
             for (int i = 0; i < myBoxes.size(); ++i) {
                 auto& box = myBoxes[i];
-                int y = static_cast<int>(oy + dy * (timeBased ? tracker.advance(box.row)
-                                                   : static_cast<double>(box.row)));
+                int y = static_cast<int>(
+                    oy + dy * (timeBased ? tracker.advance(box.row)
+                                         : static_cast<double>(box.row)));
                 int side = Segment::meta[box.type]->side;
                 int x = baseX[side] + box.x;
-                if (IsInside(recti{x, y - 16, static_cast<int>(box.width), 32}, mpos.x,
-                             mpos.y)) {
+                if (IsInside(recti{x, y - 16, static_cast<int>(box.width), 32},
+                             mpos.x, mpos.y)) {
                     myMouseOverBox = i;
                     break;
                 }
@@ -314,8 +316,9 @@ struct TempoBoxesImpl : public TempoBoxes {
         TempoTimeTracker tracker;
         auto batch = Renderer::batchTC();
         for (const TempoBox& box : myBoxes) {
-            int y = static_cast<int>(oy + dy * (timeBased ? tracker.advance(box.row)
-                                               : static_cast<double>(box.row)));
+            int y = static_cast<int>(
+                oy + dy * (timeBased ? tracker.advance(box.row)
+                                     : static_cast<double>(box.row)));
             if (y < viewTop - 16 || y > viewBtm + 16) continue;
 
             int side = Segment::meta[box.type]->side;
@@ -336,8 +339,9 @@ struct TempoBoxesImpl : public TempoBoxes {
         tracker = TempoTimeTracker();
         TextStyle textStyle;
         for (const TempoBox& box : myBoxes) {
-            int y = static_cast<int>(oy + dy * (timeBased ? tracker.advance(box.row)
-                                               : static_cast<double>(box.row)));
+            int y = static_cast<int>(
+                oy + dy * (timeBased ? tracker.advance(box.row)
+                                     : static_cast<double>(box.row)));
             if (y < viewTop - 16 || y > viewBtm + 16) continue;
 
             int side = Segment::meta[box.type]->side;
@@ -399,11 +403,11 @@ TempoBoxes* gTempoBoxes = nullptr;
 
 void TempoBoxes::create(XmrNode& settings) {
     gTempoBoxes = new TempoBoxesImpl;
-    ((TempoBoxesImpl*)gTempoBoxes)->loadSettings(settings);
+    static_cast<TempoBoxesImpl*>(gTempoBoxes)->loadSettings(settings);
 }
 
 void TempoBoxes::destroy() {
-    delete (TempoBoxesImpl*)gTempoBoxes;
+    delete static_cast<TempoBoxesImpl*>(gTempoBoxes);
     gTempoBoxes = nullptr;
 }
 

--- a/src/Editor/TempoBoxes.cpp
+++ b/src/Editor/TempoBoxes.cpp
@@ -43,7 +43,7 @@ struct TempoBoxesImpl : public TempoBoxes {
     // ================================================================================================
     // TempoBoxesImpl :: constructor and destructor.
 
-    ~TempoBoxesImpl() {}
+    ~TempoBoxesImpl() = default;
 
     TempoBoxesImpl() {
         myBoxBar.texture = myBoxHl.texture =
@@ -66,7 +66,7 @@ struct TempoBoxesImpl : public TempoBoxes {
         }
     }
 
-    void saveSettings(XmrNode& settings) {
+    void saveSettings(XmrNode& settings) override {
         XmrNode* view = settings.child("view");
         if (!view) view = settings.addChild("view");
 
@@ -83,11 +83,10 @@ struct TempoBoxesImpl : public TempoBoxes {
 
         // Create a box for every segment.
         auto segments = gTempo->getSegments();
-        for (auto it = segments->begin(), end = segments->end(); it != end;
-             ++it) {
-            auto type = it->type();
+        for (const auto & segment : *segments) {
+            auto type = segment.type();
             auto meta = Segment::meta[type];
-            for (auto seg = it->begin(), segEnd = it->end(); seg != segEnd;
+            for (auto seg = segment.begin(), segEnd = segment.end(); seg != segEnd;
                  ++seg) {
                 std::string desc = meta->getDescription(seg.ptr);
                 myBoxes.push_back(TempoBox{desc, seg->row, type, 0, 0, 0});
@@ -124,7 +123,7 @@ struct TempoBoxesImpl : public TempoBoxes {
         }
     }
 
-    void onChanges(int changes) {
+    void onChanges(int changes) override {
         if (changes & VCM_TEMPO_CHANGED) {
             update();
         }
@@ -133,24 +132,24 @@ struct TempoBoxesImpl : public TempoBoxes {
     // ================================================================================================
     // TempoBoxesImpl :: toggle visuals.
 
-    void toggleShowBoxes() {
+    void toggleShowBoxes() override {
         myShowBoxes = !myShowBoxes;
         gMenubar->update(Menubar::SHOW_TEMPO_BOXES);
     }
 
-    void toggleShowHelp() {
+    void toggleShowHelp() override {
         myShowHelp = !myShowHelp;
         gMenubar->update(Menubar::SHOW_TEMPO_HELP);
     }
 
-    bool hasShowBoxes() { return myShowBoxes; }
+    bool hasShowBoxes() override { return myShowBoxes; }
 
-    bool hasShowHelp() { return myShowHelp; }
+    bool hasShowHelp() override { return myShowHelp; }
 
     // ================================================================================================
     // TempoBoxesImpl :: selection.
 
-    void deselectAll() {
+    void deselectAll() override {
         for (auto& box : myBoxes) {
             box.isSelected = 0;
         }
@@ -159,7 +158,7 @@ struct TempoBoxesImpl : public TempoBoxes {
         }
     }
 
-    int selectAll() {
+    int selectAll() override {
         for (auto& box : myBoxes) {
             box.isSelected = 1;
         }
@@ -169,7 +168,7 @@ struct TempoBoxesImpl : public TempoBoxes {
         return myBoxes.size();
     }
 
-    int selectType(Segment::Type type) {
+    int selectType(Segment::Type type) override {
         for (auto& box : myBoxes) {
             box.isSelected = (box.type == type ? 1 : 0);
         }
@@ -179,15 +178,14 @@ struct TempoBoxesImpl : public TempoBoxes {
         return myBoxes.size();
     }
 
-    int selectSegments(const Tempo* tempo) {
+    int selectSegments(const Tempo* tempo) override {
         int numSelected = 0;
         auto boxEnd = myBoxes.end();
         auto segments = gTempo->getSegments();
-        for (auto list = segments->begin(), listEnd = segments->end();
-             list != listEnd; ++list) {
-            auto type = list->type();
+        for (const auto & segment : *segments) {
+            auto type = segment.type();
             auto box = myBoxes.begin();
-            for (auto seg = list->begin(), segEnd = list->end(); seg != segEnd;
+            for (auto seg = segment.begin(), segEnd = segment.end(); seg != segEnd;
                  ++seg) {
                 while (box != boxEnd &&
                        (box->type != type || box->row < seg->row)) {
@@ -229,7 +227,7 @@ struct TempoBoxesImpl : public TempoBoxes {
         return numSelected;
     }
 
-    int selectRows(SelectModifier mod, int begin, int end, int xl, int xr) {
+    int selectRows(SelectModifier mod, int begin, int end, int xl, int xr) override {
         auto coords = gView->getNotefieldCoords();
         const int baseX[2] = {coords.xl, coords.xr};
         return performSelection(mod, [&](const TempoBox* box) {
@@ -241,7 +239,7 @@ struct TempoBoxesImpl : public TempoBoxes {
     }
 
     int selectTime(SelectModifier mod, double begin, double end, int xl,
-                   int xr) {
+                   int xr) override {
         auto coords = gView->getNotefieldCoords();
         const int baseX[2] = {coords.xl, coords.xr};
         TempoTimeTracker tracker;
@@ -254,7 +252,7 @@ struct TempoBoxesImpl : public TempoBoxes {
         });
     }
 
-    bool noneSelected() const {
+    bool noneSelected() const override {
         for (auto& box : myBoxes) {
             if (box.isSelected) return false;
         }
@@ -264,7 +262,7 @@ struct TempoBoxesImpl : public TempoBoxes {
     // ================================================================================================
     // TempoBoxesImpl :: tick.
 
-    void tick() {
+    void tick() override {
         myMouseOverBox = -1;
         if (!GuiMain::isCapturingMouse()) {
             bool timeBased = gView->isTimeBased();
@@ -277,11 +275,11 @@ struct TempoBoxesImpl : public TempoBoxes {
             vec2i mpos = gSystem->getMousePos();
             for (int i = 0; i < myBoxes.size(); ++i) {
                 auto& box = myBoxes[i];
-                int y = (int)(oy + dy * (timeBased ? tracker.advance(box.row)
-                                                   : (double)box.row));
+                int y = static_cast<int>(oy + dy * (timeBased ? tracker.advance(box.row)
+                                                   : static_cast<double>(box.row)));
                 int side = Segment::meta[box.type]->side;
                 int x = baseX[side] + box.x;
-                if (IsInside(recti{x, y - 16, (int)box.width, 32}, mpos.x,
+                if (IsInside(recti{x, y - 16, static_cast<int>(box.width), 32}, mpos.x,
                              mpos.y)) {
                     myMouseOverBox = i;
                     break;
@@ -293,7 +291,7 @@ struct TempoBoxesImpl : public TempoBoxes {
     // ================================================================================================
     // TempoBoxesImpl :: draw.
 
-    void draw() {
+    void draw() override {
         if (myShowBoxes == false || myBoxes.empty() ||
             gView->getScaleLevel() < 2)
             return;
@@ -316,15 +314,15 @@ struct TempoBoxesImpl : public TempoBoxes {
         TempoTimeTracker tracker;
         auto batch = Renderer::batchTC();
         for (const TempoBox& box : myBoxes) {
-            int y = (int)(oy + dy * (timeBased ? tracker.advance(box.row)
-                                               : (double)box.row));
+            int y = static_cast<int>(oy + dy * (timeBased ? tracker.advance(box.row)
+                                               : static_cast<double>(box.row)));
             if (y < viewTop - 16 || y > viewBtm + 16) continue;
 
             int side = Segment::meta[box.type]->side;
             int x = baseX[side] + box.x;
 
             int flags = side * TileBar::FLIP_H;
-            recti r = {x, y - 16, (int)box.width, 32};
+            recti r = {x, y - 16, static_cast<int>(box.width), 32};
 
             uint32_t color = Segment::meta[box.type]->color;
             myBoxBar.draw(&batch, r, color, flags);
@@ -338,15 +336,15 @@ struct TempoBoxesImpl : public TempoBoxes {
         tracker = TempoTimeTracker();
         TextStyle textStyle;
         for (const TempoBox& box : myBoxes) {
-            int y = (int)(oy + dy * (timeBased ? tracker.advance(box.row)
-                                               : (double)box.row));
+            int y = static_cast<int>(oy + dy * (timeBased ? tracker.advance(box.row)
+                                               : static_cast<double>(box.row)));
             if (y < viewTop - 16 || y > viewBtm + 16) continue;
 
             int side = Segment::meta[box.type]->side;
             int x = baseX[side] + box.x + side * 4 - 2;
 
             Text::arrange(Text::MC, textStyle, box.str.c_str());
-            Text::draw(recti{x, y - 17, (int)box.width, 32});
+            Text::draw(recti{x, y - 17, static_cast<int>(box.width), 32});
         }
 
         // Display detailed info of the mouse over box.
@@ -390,7 +388,7 @@ struct TempoBoxesImpl : public TempoBoxes {
         Text::draw(vec2i{x, y + 10});
     }
 
-    const Vector<TempoBox>& getBoxes() { return myBoxes; }
+    const Vector<TempoBox>& getBoxes() override { return myBoxes; }
 
 };  // TempoBoxesImpl
 

--- a/src/Editor/TextOverlay.cpp
+++ b/src/Editor/TextOverlay.cpp
@@ -400,7 +400,8 @@ struct TextOverlayImpl : public TextOverlay {
 
         x = 4, y = 4;
         for (auto& m : hudEntries_) {
-            int a = clamp(static_cast<int>(m.timeLeft * 512.0f + 256.0f), 0, 255);
+            int a =
+                clamp(static_cast<int>(m.timeLeft * 512.0f + 256.0f), 0, 255);
 
             textStyle.textColor = Color32a(textStyle.textColor, a);
             textStyle.shadowColor = Color32a(textStyle.shadowColor, a);
@@ -496,7 +497,8 @@ struct TextOverlayImpl : public TextOverlay {
             if (gSystem->getEvents().next(mp)) {
                 if (mp->unhandled()) {
                     mp->setHandled();
-                    gSystem->openWebpage(reinterpret_cast<const char*>(supportLink));
+                    gSystem->openWebpage(
+                        reinterpret_cast<const char*>(supportLink));
                 }
             }
         }
@@ -507,7 +509,8 @@ struct TextOverlayImpl : public TextOverlay {
             if (gSystem->getEvents().next(mp)) {
                 if (mp->unhandled()) {
                     mp->setHandled();
-                    gSystem->openWebpage(reinterpret_cast<const char*>(githubLink));
+                    gSystem->openWebpage(
+                        reinterpret_cast<const char*>(githubLink));
                 }
             }
         }

--- a/src/Editor/TextOverlay.cpp
+++ b/src/Editor/TextOverlay.cpp
@@ -68,7 +68,7 @@ struct TextOverlayImpl : public TextOverlay {
     // ================================================================================================
     // TextOverlayImpl :: constructor and destructor.
 
-    ~TextOverlayImpl() {}
+    ~TextOverlayImpl() = default;
 
     TextOverlayImpl() {
         textOverlayMode_ = HUD;
@@ -208,7 +208,7 @@ struct TextOverlayImpl : public TextOverlay {
             min(max(0, textOverlayScrollPos_), textOverlayScrollEnd_);
     }
 
-    void tick() {
+    void tick() override {
         UpdateScrollValues();
         switch (textOverlayMode_) {
             case HUD:
@@ -251,7 +251,7 @@ struct TextOverlayImpl : public TextOverlay {
         }
     }
 
-    void show(Mode mode) {
+    void show(Mode mode) override {
         if (textOverlayMode_ == mode) {
             textOverlayMode_ = HUD;
         } else {
@@ -275,7 +275,7 @@ struct TextOverlayImpl : public TextOverlay {
         UpdateScrollValues();
     }
 
-    bool isOpen() { return textOverlayMode_ != HUD; }
+    bool isOpen() override { return textOverlayMode_ != HUD; }
 
     void DrawTitleText(const char* left, const char* mid, const char* right) {
         vec2i size = gSystem->getWindowSize();
@@ -315,7 +315,7 @@ struct TextOverlayImpl : public TextOverlay {
         }
     }
 
-    void draw() {
+    void draw() override {
         if (textOverlayMode_ != HUD) {
             vec2i size = gSystem->getWindowSize();
             Draw::fill({0, 0, size.x, size.y}, RGBAtoColor32(0, 0, 0, 191));
@@ -339,7 +339,7 @@ struct TextOverlayImpl : public TextOverlay {
         };
     }
 
-    void addMessage(const char* str, MessageType type) {
+    void addMessage(const char* str, MessageType type) override {
         std::string msg = str;
         if (type == NOTE) {
             hudEntries_.push_back({msg, type, 0.5f});
@@ -400,7 +400,7 @@ struct TextOverlayImpl : public TextOverlay {
 
         x = 4, y = 4;
         for (auto& m : hudEntries_) {
-            int a = clamp((int)(m.timeLeft * 512.0f + 256.0f), 0, 255);
+            int a = clamp(static_cast<int>(m.timeLeft * 512.0f + 256.0f), 0, 255);
 
             textStyle.textColor = Color32a(textStyle.textColor, a);
             textStyle.shadowColor = Color32a(textStyle.shadowColor, a);
@@ -496,7 +496,7 @@ struct TextOverlayImpl : public TextOverlay {
             if (gSystem->getEvents().next(mp)) {
                 if (mp->unhandled()) {
                     mp->setHandled();
-                    gSystem->openWebpage((const char*)supportLink);
+                    gSystem->openWebpage(reinterpret_cast<const char*>(supportLink));
                 }
             }
         }
@@ -507,7 +507,7 @@ struct TextOverlayImpl : public TextOverlay {
             if (gSystem->getEvents().next(mp)) {
                 if (mp->unhandled()) {
                     mp->setHandled();
-                    gSystem->openWebpage((const char*)githubLink);
+                    gSystem->openWebpage(reinterpret_cast<const char*>(githubLink));
                 }
             }
         }
@@ -596,7 +596,7 @@ void InfoBoxWithProgress::draw(recti r) {
 }
 
 void InfoBoxWithProgress::setProgress(double rate) {
-    int progress = clamp((int)(rate * 100.0f + 0.5f), 0, 100);
+    int progress = clamp(static_cast<int>(rate * 100.0f + 0.5f), 0, 100);
     right = Str::val(progress) + '%';
 }
 

--- a/src/Editor/View.cpp
+++ b/src/Editor/View.cpp
@@ -56,9 +56,7 @@ struct ViewImpl : public View, public InputHandler {
 
     ~ViewImpl() = default;
 
-    ViewImpl()
-        : 
-          myPixPerRow(16 * BEATS_PER_ROW) {
+    ViewImpl() : myPixPerRow(16 * BEATS_PER_ROW) {
         vec2i windowSize = gSystem->getWindowSize();
         rect_ = {0, 0, windowSize.x, windowSize.y};
     }
@@ -119,7 +117,8 @@ struct ViewImpl : public View, public InputHandler {
             if (myUseTimeBasedView) {
                 setCursorTime(myCursorTime + delta / myPixPerSec);
             } else {
-                setCursorRow(myCursorRow + static_cast<int>(delta / myPixPerRow));
+                setCursorRow(myCursorRow +
+                             static_cast<int>(delta / myPixPerRow));
             }
         }
         evt.handled = true;
@@ -287,8 +286,8 @@ struct ViewImpl : public View, public InputHandler {
 
         // Store the y-position of time zero.
         if (myUseTimeBasedView) {
-            myChartTopY =
-                floor(static_cast<double>(myReceptorY) - myCursorTime * myPixPerSec);
+            myChartTopY = floor(static_cast<double>(myReceptorY) -
+                                myCursorTime * myPixPerSec);
         } else {
             myChartTopY = floor(static_cast<double>(myReceptorY) -
                                 myCursorBeat * ROWS_PER_BEAT * myPixPerRow);
@@ -462,9 +461,11 @@ struct ViewImpl : public View, public InputHandler {
 
     int getRowY(int row) const {
         if (myUseTimeBasedView) {
-            return static_cast<int>(myChartTopY + gTempo->rowToTime(row) * myPixPerSec);
+            return static_cast<int>(myChartTopY +
+                                    gTempo->rowToTime(row) * myPixPerSec);
         } else {
-            return static_cast<int>(myChartTopY + static_cast<double>(row) * myPixPerRow);
+            return static_cast<int>(myChartTopY +
+                                    static_cast<double>(row) * myPixPerRow);
         }
     }
 
@@ -473,7 +474,8 @@ struct ViewImpl : public View, public InputHandler {
             return static_cast<int>(myChartTopY + time * myPixPerSec);
         } else {
             return static_cast<int>(myChartTopY + gTempo->timeToBeat(time) *
-                                           ROWS_PER_BEAT * myPixPerRow);
+                                                      ROWS_PER_BEAT *
+                                                      myPixPerRow);
         }
     }
 
@@ -515,9 +517,11 @@ struct ViewImpl : public View, public InputHandler {
 
     int rowToY(int row) const override {
         if (myUseTimeBasedView) {
-            return static_cast<int>(myChartTopY + gTempo->rowToTime(row) * myPixPerSec);
+            return static_cast<int>(myChartTopY +
+                                    gTempo->rowToTime(row) * myPixPerSec);
         } else {
-            return static_cast<int>(myChartTopY + static_cast<double>(row) * myPixPerRow);
+            return static_cast<int>(myChartTopY +
+                                    static_cast<double>(row) * myPixPerRow);
         }
     }
 
@@ -526,7 +530,8 @@ struct ViewImpl : public View, public InputHandler {
             return static_cast<int>(myChartTopY + time * myPixPerSec);
         } else {
             return static_cast<int>(myChartTopY + gTempo->timeToBeat(time) *
-                                           ROWS_PER_BEAT * myPixPerRow);
+                                                      ROWS_PER_BEAT *
+                                                      myPixPerRow);
         }
     }
 
@@ -543,7 +548,8 @@ struct ViewImpl : public View, public InputHandler {
     }
 
     ChartOffset rowToOffset(int row) const override {
-        return myUseTimeBasedView ? gTempo->rowToTime(row) : static_cast<ChartOffset>(row);
+        return myUseTimeBasedView ? gTempo->rowToTime(row)
+                                  : static_cast<ChartOffset>(row);
     }
 
     ChartOffset timeToOffset(double time) const override {
@@ -552,7 +558,8 @@ struct ViewImpl : public View, public InputHandler {
     }
 
     int offsetToRow(ChartOffset ofs) const override {
-        return myUseTimeBasedView ? gTempo->timeToRow(ofs) : static_cast<int>(ofs + 0.5);
+        return myUseTimeBasedView ? gTempo->timeToRow(ofs)
+                                  : static_cast<int>(ofs + 0.5);
     }
 
     double offsetToTime(ChartOffset ofs) const override {
@@ -573,7 +580,9 @@ struct ViewImpl : public View, public InputHandler {
 
     int getPreviewOffset() const override { return applyZoom(myPreviewOffset); }
 
-    int applyZoom(int v) const override { return (v * static_cast<int>(64 * myScaleLevel)) >> 8; }
+    int applyZoom(int v) const override {
+        return (v * static_cast<int>(64 * myScaleLevel)) >> 8;
+    }
 
     int getNoteScale() const override { return 64 * myScaleLevel; }
 
@@ -676,11 +685,11 @@ View* gView = nullptr;
 
 void View::create(XmrNode& settings) {
     gView = new ViewImpl;
-    ((ViewImpl*)gView)->loadSettings(settings);
+    static_cast<ViewImpl*>(gView)->loadSettings(settings);
 }
 
 void View::destroy() {
-    delete (ViewImpl*)gView;
+    delete static_cast<ViewImpl*>(gView);
     gView = nullptr;
 }
 

--- a/src/Editor/View.cpp
+++ b/src/Editor/View.cpp
@@ -36,44 +36,28 @@ namespace {};  // anonymous namespace
 
 struct ViewImpl : public View, public InputHandler {
     recti rect_;
-    double myChartTopY;
-    double myCursorTime, myCursorBeat;
-    double myPixPerSec, myPixPerRow;
-    int myCursorRow;
+    double myChartTopY = 0.0;
+    double myCursorTime = 0.0, myCursorBeat = 0.0;
+    double myPixPerSec = 32, myPixPerRow;
+    int myCursorRow = 0;
 
-    int myReceptorY, myReceptorX, myPreviewOffset;
-    double myZoomLevel, myScaleLevel;
-    bool myIsDraggingReceptors, myIsDraggingReceptorsPreview;
-    bool myUseTimeBasedView;
-    bool myUseReverseScroll;
-    bool myUseChartPreview;
-    int myCustomSnap;
+    int myReceptorY = 192, myReceptorX = 0, myPreviewOffset = 640;
+    double myZoomLevel = 8, myScaleLevel = 4;
+    bool myIsDraggingReceptors = false, myIsDraggingReceptorsPreview = false;
+    bool myUseTimeBasedView = true;
+    bool myUseReverseScroll = false;
+    bool myUseChartPreview = false;
+    int myCustomSnap = 20;
     int myCustomSnapSteps[193];
-    SnapType mySnapType;
+    SnapType mySnapType = ST_NONE;
 
     // ================================================================================================
     // ViewImpl :: constructor / destructor.
 
-    ~ViewImpl() {}
+    ~ViewImpl() = default;
 
     ViewImpl()
-        : myChartTopY(0.0),
-          myCursorTime(0.0),
-          myCursorBeat(0.0),
-          myCursorRow(0),
-          myReceptorY(192),
-          myReceptorX(0),
-          myPreviewOffset(640),
-          myZoomLevel(8),
-          myScaleLevel(4),
-          mySnapType(ST_NONE),
-          myCustomSnap(20),
-          myUseTimeBasedView(true),
-          myUseReverseScroll(false),
-          myUseChartPreview(false),
-          myIsDraggingReceptors(false),
-          myIsDraggingReceptorsPreview(false),
-          myPixPerSec(32),
+        : 
           myPixPerRow(16 * BEATS_PER_ROW) {
         vec2i windowSize = gSystem->getWindowSize();
         rect_ = {0, 0, windowSize.x, windowSize.y};
@@ -104,19 +88,19 @@ struct ViewImpl : public View, public InputHandler {
         updateCustomSnapSteps();
     }
 
-    void saveSettings(XmrNode& settings) {
+    void saveSettings(XmrNode& settings) override {
         XmrNode* view = settings.child("view");
         if (!view) view = settings.addChild("view");
 
         view->addAttrib("useTimeBasedView", myUseTimeBasedView);
         view->addAttrib("useReverseScroll", myUseReverseScroll);
         view->addAttrib("useChartPreview", myUseChartPreview);
-        view->addAttrib("customSnap", (long)myCustomSnap);
-        view->addAttrib("zoomLevel", (long)myZoomLevel);
-        view->addAttrib("scaleLevel", (long)myScaleLevel);
-        view->addAttrib("receptorX", (long)myReceptorX);
-        view->addAttrib("receptorY", (long)myReceptorY);
-        view->addAttrib("previewOffset", (long)myPreviewOffset);
+        view->addAttrib("customSnap", static_cast<long>(myCustomSnap));
+        view->addAttrib("zoomLevel", static_cast<long>(myZoomLevel));
+        view->addAttrib("scaleLevel", static_cast<long>(myScaleLevel));
+        view->addAttrib("receptorX", static_cast<long>(myReceptorX));
+        view->addAttrib("receptorY", static_cast<long>(myReceptorY));
+        view->addAttrib("previewOffset", static_cast<long>(myPreviewOffset));
     }
 
     // ================================================================================================
@@ -135,7 +119,7 @@ struct ViewImpl : public View, public InputHandler {
             if (myUseTimeBasedView) {
                 setCursorTime(myCursorTime + delta / myPixPerSec);
             } else {
-                setCursorRow(myCursorRow + (int)(delta / myPixPerRow));
+                setCursorRow(myCursorRow + static_cast<int>(delta / myPixPerRow));
             }
         }
         evt.handled = true;
@@ -205,15 +189,15 @@ struct ViewImpl : public View, public InputHandler {
     // ================================================================================================
     // ViewImpl :: member functions.
 
-    double getZoomLevel() const { return myZoomLevel; }
+    double getZoomLevel() const override { return myZoomLevel; }
 
-    double getScaleLevel() const { return myScaleLevel; }
+    double getScaleLevel() const override { return myScaleLevel; }
 
-    int getCustomSnap() const { return myCustomSnap; }
+    int getCustomSnap() const override { return myCustomSnap; }
 
-    SnapType getSnapType() const { return mySnapType; }
+    SnapType getSnapType() const override { return mySnapType; }
 
-    int getSnapQuant() {
+    int getSnapQuant() override {
         if (mySnapType == ST_CUSTOM) {
             return myCustomSnap;
         } else {
@@ -221,37 +205,37 @@ struct ViewImpl : public View, public InputHandler {
         }
     }
 
-    bool isTimeBased() const { return myUseTimeBasedView; }
+    bool isTimeBased() const override { return myUseTimeBasedView; }
 
-    bool hasReverseScroll() const { return myUseReverseScroll; }
+    bool hasReverseScroll() const override { return myUseReverseScroll; }
 
-    bool hasChartPreview() const { return myUseChartPreview; }
+    bool hasChartPreview() const override { return myUseChartPreview; }
 
-    double getPixPerSec() const { return myPixPerSec; }
+    double getPixPerSec() const override { return myPixPerSec; }
 
-    double getPixPerRow() const { return myPixPerRow; }
+    double getPixPerRow() const override { return myPixPerRow; }
 
-    double getPixPerOfs() const {
+    double getPixPerOfs() const override {
         return myUseTimeBasedView ? myPixPerSec : myPixPerRow;
     }
 
-    int getCursorRow() const { return myCursorRow; }
+    int getCursorRow() const override { return myCursorRow; }
 
-    double getCursorTime() const { return myCursorTime; }
+    double getCursorTime() const override { return myCursorTime; }
 
-    double getCursorBeat() const { return myCursorBeat; }
+    double getCursorBeat() const override { return myCursorBeat; }
 
-    double getCursorOffset() const {
+    double getCursorOffset() const override {
         return myUseTimeBasedView ? myCursorTime : myCursorRow;
     }
 
-    void onChanges(int changes) {
+    void onChanges(int changes) override {
         if (changes & VCM_TEMPO_CHANGED) {
             myCursorTime = gTempo->rowToTime(myCursorRow);
         }
     }
 
-    void tick() {
+    void tick() override {
         vec2i windowSize = gSystem->getWindowSize();
         rect_ = {0, 0, windowSize.x, windowSize.y};
 
@@ -265,7 +249,7 @@ struct ViewImpl : public View, public InputHandler {
         // handle preview receptor dragging.
         else if (myIsDraggingReceptorsPreview) {
             auto mx = gSystem->getMousePos().x - CenterX(rect_) - myReceptorX;
-            auto ofs = (mx << 8) / (int)(64 * myScaleLevel);
+            auto ofs = (mx << 8) / static_cast<int>(64 * myScaleLevel);
             myPreviewOffset = ofs;
         }
 
@@ -291,7 +275,7 @@ struct ViewImpl : public View, public InputHandler {
                 double time = gMusic->getPlayTime();
                 myCursorTime = clamp(time, begintime, endtime);
                 myCursorBeat = gTempo->timeToBeat(myCursorTime);
-                myCursorRow = (int)(myCursorBeat * ROWS_PER_BEAT);
+                myCursorRow = static_cast<int>(myCursorBeat * ROWS_PER_BEAT);
             }
         }
 
@@ -304,9 +288,9 @@ struct ViewImpl : public View, public InputHandler {
         // Store the y-position of time zero.
         if (myUseTimeBasedView) {
             myChartTopY =
-                floor((double)myReceptorY - myCursorTime * myPixPerSec);
+                floor(static_cast<double>(myReceptorY) - myCursorTime * myPixPerSec);
         } else {
-            myChartTopY = floor((double)myReceptorY -
+            myChartTopY = floor(static_cast<double>(myReceptorY) -
                                 myCursorBeat * ROWS_PER_BEAT * myPixPerRow);
         }
     }
@@ -327,19 +311,19 @@ struct ViewImpl : public View, public InputHandler {
         }
     }
 
-    void toggleReverseScroll() {
+    void toggleReverseScroll() override {
         myUseReverseScroll = !myUseReverseScroll;
         myReceptorY = rect_.h - myReceptorY;
         updateScrollValues();
         gMenubar->update(Menubar::USE_REVERSE_SCROLL);
     }
 
-    void toggleChartPreview() {
+    void toggleChartPreview() override {
         myUseChartPreview = !myUseChartPreview;
         gMenubar->update(Menubar::USE_CHART_PREVIEW);
     }
 
-    void setTimeBased(bool enabled) {
+    void setTimeBased(bool enabled) override {
         if (myUseTimeBasedView != enabled) {
             myUseTimeBasedView = enabled;
             gMenubar->update(Menubar::VIEW_MODE);
@@ -347,7 +331,7 @@ struct ViewImpl : public View, public InputHandler {
         }
     }
 
-    void setZoomLevel(double level) {
+    void setZoomLevel(double level) override {
         level = min(max(level, -2.0), 16.0);
         if (myZoomLevel != level) {
             myZoomLevel = level;
@@ -356,7 +340,7 @@ struct ViewImpl : public View, public InputHandler {
         }
     }
 
-    void setScaleLevel(double level) {
+    void setScaleLevel(double level) override {
         level = min(max(level, 1.0), 10.0);
         if (myScaleLevel != level) {
             myScaleLevel = level;
@@ -364,16 +348,16 @@ struct ViewImpl : public View, public InputHandler {
         }
     }
 
-    void setSnapType(int type) {
+    void setSnapType(int type) override {
         if (type < 0) type = NUM_SNAP_TYPES - 1;
         if (type > NUM_SNAP_TYPES - 1) type = 0;
         if (mySnapType != type) {
-            mySnapType = (SnapType)type;
+            mySnapType = static_cast<SnapType>(type);
             HudNote("Snap: %s", ToString(mySnapType));
         }
     }
 
-    void setCustomSnap(int size) {
+    void setCustomSnap(int size) override {
         if (size < 4) size = 4;
         if (size > 192) size = 192;
         // If the custom snap is a non-custom value, set the snap to that value
@@ -392,31 +376,31 @@ struct ViewImpl : public View, public InputHandler {
         }
     }
 
-    void setCursorTime(double time) {
+    void setCursorTime(double time) override {
         double begintime = gTempo->rowToTime(0);
         double endtime = gTempo->rowToTime(gSimfile->getEndRow());
         myCursorTime = min(max(begintime, time), endtime);
         myCursorBeat = gTempo->timeToBeat(myCursorTime);
-        myCursorRow = (int)(myCursorBeat * ROWS_PER_BEAT);
+        myCursorRow = static_cast<int>(myCursorBeat * ROWS_PER_BEAT);
         gMusic->seek(myCursorTime);
     }
 
-    void setCursorRow(int row) {
+    void setCursorRow(int row) override {
         myCursorRow = min(max(row, 0), gSimfile->getEndRow());
         myCursorBeat = myCursorRow * BEATS_PER_ROW;
         myCursorTime = gTempo->rowToTime(myCursorRow);
         gMusic->seek(myCursorTime);
     }
 
-    void setCursorOffset(ChartOffset ofs) {
+    void setCursorOffset(ChartOffset ofs) override {
         if (myUseTimeBasedView) {
             setCursorTime(ofs);
         } else {
-            setCursorRow((int)(ofs + 0.5));
+            setCursorRow(static_cast<int>(ofs + 0.5));
         }
     }
 
-    void setCursorToNextInterval(int rows) {
+    void setCursorToNextInterval(int rows) override {
         if (gView->hasReverseScroll()) rows = rows * -1;
 
         int rowsInInterval = abs(rows);
@@ -434,7 +418,7 @@ struct ViewImpl : public View, public InputHandler {
         }
     }
 
-    void setCursorToStream(bool top) {
+    void setCursorToStream(bool top) override {
         if (gView->hasReverseScroll()) top = !top;
 
         auto first = gNotes->begin(), n = first;
@@ -462,7 +446,7 @@ struct ViewImpl : public View, public InputHandler {
         setCursorRow(n->row);
     }
 
-    void setCursorToSelection(bool top) {
+    void setCursorToSelection(bool top) override {
         if (gView->hasReverseScroll()) top = !top;
 
         auto region = gSelection->getSelectedRegion();
@@ -478,22 +462,22 @@ struct ViewImpl : public View, public InputHandler {
 
     int getRowY(int row) const {
         if (myUseTimeBasedView) {
-            return (int)(myChartTopY + gTempo->rowToTime(row) * myPixPerSec);
+            return static_cast<int>(myChartTopY + gTempo->rowToTime(row) * myPixPerSec);
         } else {
-            return (int)(myChartTopY + (double)row * myPixPerRow);
+            return static_cast<int>(myChartTopY + static_cast<double>(row) * myPixPerRow);
         }
     }
 
     int getTimeY(double time) const {
         if (myUseTimeBasedView) {
-            return (int)(myChartTopY + time * myPixPerSec);
+            return static_cast<int>(myChartTopY + time * myPixPerSec);
         } else {
-            return (int)(myChartTopY + gTempo->timeToBeat(time) *
+            return static_cast<int>(myChartTopY + gTempo->timeToBeat(time) *
                                            ROWS_PER_BEAT * myPixPerRow);
         }
     }
 
-    Coords getReceptorCoords() const {
+    Coords getReceptorCoords() const override {
         Coords out;
         auto noteskin = gNoteskin->get();
         out.y = rect_.y + myReceptorY;
@@ -509,7 +493,7 @@ struct ViewImpl : public View, public InputHandler {
         return out;
     }
 
-    Coords getNotefieldCoords() const {
+    Coords getNotefieldCoords() const override {
         Coords out = getReceptorCoords();
         int ofs = gView->applyZoom(32);
         out.xl -= ofs, out.xr += ofs;
@@ -521,7 +505,7 @@ struct ViewImpl : public View, public InputHandler {
         return out;
     }
 
-    int columnToX(int col) const {
+    int columnToX(int col) const override {
         auto noteskin = gNoteskin->get();
         int cx = rect_.x + rect_.w / 2 + myReceptorX;
         if (!noteskin) return cx;
@@ -529,71 +513,71 @@ struct ViewImpl : public View, public InputHandler {
         return cx + applyZoom(x);
     }
 
-    int rowToY(int row) const {
+    int rowToY(int row) const override {
         if (myUseTimeBasedView) {
-            return (int)(myChartTopY + gTempo->rowToTime(row) * myPixPerSec);
+            return static_cast<int>(myChartTopY + gTempo->rowToTime(row) * myPixPerSec);
         } else {
-            return (int)(myChartTopY + (double)row * myPixPerRow);
+            return static_cast<int>(myChartTopY + static_cast<double>(row) * myPixPerRow);
         }
     }
 
-    int timeToY(double time) const {
+    int timeToY(double time) const override {
         if (myUseTimeBasedView) {
-            return (int)(myChartTopY + time * myPixPerSec);
+            return static_cast<int>(myChartTopY + time * myPixPerSec);
         } else {
-            return (int)(myChartTopY + gTempo->timeToBeat(time) *
+            return static_cast<int>(myChartTopY + gTempo->timeToBeat(time) *
                                            ROWS_PER_BEAT * myPixPerRow);
         }
     }
 
-    int offsetToY(ChartOffset ofs) {
+    int offsetToY(ChartOffset ofs) override {
         if (myUseTimeBasedView) {
-            return (int)(myChartTopY + ofs * myPixPerSec);
+            return static_cast<int>(myChartTopY + ofs * myPixPerSec);
         } else {
-            return (int)(myChartTopY + ofs * myPixPerRow);
+            return static_cast<int>(myChartTopY + ofs * myPixPerRow);
         }
     }
 
-    ChartOffset yToOffset(int viewY) const {
-        return ((ChartOffset)viewY - myChartTopY) / getPixPerOfs();
+    ChartOffset yToOffset(int viewY) const override {
+        return (static_cast<ChartOffset>(viewY) - myChartTopY) / getPixPerOfs();
     }
 
-    ChartOffset rowToOffset(int row) const {
-        return myUseTimeBasedView ? gTempo->rowToTime(row) : (ChartOffset)row;
+    ChartOffset rowToOffset(int row) const override {
+        return myUseTimeBasedView ? gTempo->rowToTime(row) : static_cast<ChartOffset>(row);
     }
 
-    ChartOffset timeToOffset(double time) const {
+    ChartOffset timeToOffset(double time) const override {
         return myUseTimeBasedView ? time
                                   : (gTempo->timeToBeat(time) * ROWS_PER_BEAT);
     }
 
-    int offsetToRow(ChartOffset ofs) const {
-        return myUseTimeBasedView ? gTempo->timeToRow(ofs) : (int)(ofs + 0.5);
+    int offsetToRow(ChartOffset ofs) const override {
+        return myUseTimeBasedView ? gTempo->timeToRow(ofs) : static_cast<int>(ofs + 0.5);
     }
 
-    double offsetToTime(ChartOffset ofs) const {
+    double offsetToTime(ChartOffset ofs) const override {
         return myUseTimeBasedView ? ofs
                                   : gTempo->beatToTime(ofs * BEATS_PER_ROW);
     }
 
-    int getWidth() const { return rect_.w; }
+    int getWidth() const override { return rect_.w; }
 
-    int getHeight() const { return rect_.h; }
+    int getHeight() const override { return rect_.h; }
 
-    const recti& getRect() const { return rect_; }
+    const recti& getRect() const override { return rect_; }
 
-    void adjustForPreview(bool enabled) {
+    void adjustForPreview(bool enabled) override {
         myReceptorX +=
             applyZoom(enabled ? -myPreviewOffset : myPreviewOffset) / 2;
     }
 
-    int getPreviewOffset() const { return applyZoom(myPreviewOffset); }
+    int getPreviewOffset() const override { return applyZoom(myPreviewOffset); }
 
-    int applyZoom(int v) const { return (v * (int)(64 * myScaleLevel)) >> 8; }
+    int applyZoom(int v) const override { return (v * static_cast<int>(64 * myScaleLevel)) >> 8; }
 
-    int getNoteScale() const { return 64 * myScaleLevel; }
+    int getNoteScale() const override { return 64 * myScaleLevel; }
 
-    int snapRow(int row, SnapDir dir) {
+    int snapRow(int row, SnapDir dir) override {
         if (dir == SNAP_CLOSEST) {
             if (isAlignedToSnap(row)) {
                 return row;
@@ -650,7 +634,7 @@ struct ViewImpl : public View, public InputHandler {
         }
     }
 
-    bool isAlignedToSnap(int row) {
+    bool isAlignedToSnap(int row) override {
         int snap = sRowSnapTypes[mySnapType];
 
         // Special case, custom snapping.

--- a/src/Editor/Waveform.cpp
+++ b/src/Editor/Waveform.cpp
@@ -155,10 +155,15 @@ struct WaveformImpl : public Waveform {
     void loadSettings(XmrNode& settings) {
         XmrNode* waveform = settings.child("waveform");
         if (waveform) {
-            waveform->get("bgColor", reinterpret_cast<float*>(&waveformColorScheme_.bg), 4);
-            waveform->get("waveColor", reinterpret_cast<float*>(&waveformColorScheme_.wave), 4);
-            waveform->get("filterColor", reinterpret_cast<float*>(&waveformColorScheme_.filter),
+            waveform->get("bgColor",
+                          reinterpret_cast<float*>(&waveformColorScheme_.bg),
                           4);
+            waveform->get("waveColor",
+                          reinterpret_cast<float*>(&waveformColorScheme_.wave),
+                          4);
+            waveform->get(
+                "filterColor",
+                reinterpret_cast<float*>(&waveformColorScheme_.filter), 4);
 
             const char* ll = waveform->get("luminance");
             if (ll) setLuminance(ToLuminance(ll));
@@ -181,7 +186,8 @@ struct WaveformImpl : public Waveform {
 
         waveform->addAttrib("luminance", ToString(waveformLuminance_));
         waveform->addAttrib("waveStyle", ToString(waveformShape_));
-        waveform->addAttrib("antiAliasing", static_cast<long>(waveformAntiAliasingMode_));
+        waveform->addAttrib("antiAliasing",
+                            static_cast<long>(waveformAntiAliasingMode_));
     }
 
     // ================================================================================================
@@ -249,7 +255,9 @@ struct WaveformImpl : public Waveform {
         clearBlocks();
     }
 
-    void setColors(ColorScheme colors) override { waveformColorScheme_ = colors; }
+    void setColors(ColorScheme colors) override {
+        waveformColorScheme_ = colors;
+    }
 
     ColorScheme getColors() override { return waveformColorScheme_; }
 
@@ -382,7 +390,9 @@ struct WaveformImpl : public Waveform {
         int64_t srcFrames =
             filtered ? waveformFilter_->samplesL.size() : music.getNumFrames();
         int64_t samplePos =
-            max(static_cast<int64_t>(0), static_cast<int64_t>(samplesPerBlock * static_cast<double>(blockId)));
+            max(static_cast<int64_t>(0),
+                static_cast<int64_t>(samplesPerBlock *
+                                     static_cast<double>(blockId)));
         double sampleCount =
             min(static_cast<double>(srcFrames) - samplePos, samplesPerBlock);
 
@@ -423,8 +433,12 @@ struct WaveformImpl : public Waveform {
             int minAmp = SHRT_MAX;
             int maxAmp = SHRT_MIN;
             while (ofs < end) {
-                maxAmp = max(maxAmp, static_cast<int>(*(in + static_cast<int>(round(ofs)))));
-                minAmp = min(minAmp, static_cast<int>(*(in + static_cast<int>(round(ofs)))));
+                maxAmp =
+                    max(maxAmp,
+                        static_cast<int>(*(in + static_cast<int>(round(ofs)))));
+                minAmp =
+                    min(minAmp,
+                        static_cast<int>(*(in + static_cast<int>(round(ofs)))));
                 ofs += sampleSkip;
             }
 
@@ -621,11 +635,11 @@ Waveform* gWaveform = nullptr;
 
 void Waveform::create(XmrNode& settings) {
     gWaveform = new WaveformImpl;
-    ((WaveformImpl*)gWaveform)->loadSettings(settings);
+    static_cast<WaveformImpl*>(gWaveform)->loadSettings(settings);
 }
 
 void Waveform::destroy() {
-    delete (WaveformImpl*)gWaveform;
+    delete static_cast<WaveformImpl*>(gWaveform);
     gWaveform = nullptr;
 }
 

--- a/src/Editor/Waveform.cpp
+++ b/src/Editor/Waveform.cpp
@@ -155,9 +155,9 @@ struct WaveformImpl : public Waveform {
     void loadSettings(XmrNode& settings) {
         XmrNode* waveform = settings.child("waveform");
         if (waveform) {
-            waveform->get("bgColor", (float*)&waveformColorScheme_.bg, 4);
-            waveform->get("waveColor", (float*)&waveformColorScheme_.wave, 4);
-            waveform->get("filterColor", (float*)&waveformColorScheme_.filter,
+            waveform->get("bgColor", reinterpret_cast<float*>(&waveformColorScheme_.bg), 4);
+            waveform->get("waveColor", reinterpret_cast<float*>(&waveformColorScheme_.wave), 4);
+            waveform->get("filterColor", reinterpret_cast<float*>(&waveformColorScheme_.filter),
                           4);
 
             const char* ll = waveform->get("luminance");
@@ -171,7 +171,7 @@ struct WaveformImpl : public Waveform {
         }
     }
 
-    void saveSettings(XmrNode& settings) {
+    void saveSettings(XmrNode& settings) override {
         XmrNode* waveform = settings.child("waveform");
         if (!waveform) waveform = settings.addChild("waveform");
 
@@ -181,53 +181,53 @@ struct WaveformImpl : public Waveform {
 
         waveform->addAttrib("luminance", ToString(waveformLuminance_));
         waveform->addAttrib("waveStyle", ToString(waveformShape_));
-        waveform->addAttrib("antiAliasing", (long)waveformAntiAliasingMode_);
+        waveform->addAttrib("antiAliasing", static_cast<long>(waveformAntiAliasingMode_));
     }
 
     // ================================================================================================
     // ViewImpl :: member functions.
 
-    void clearBlocks() {
+    void clearBlocks() override {
         for (auto block : waveformBlocks_) {
             block->id = UNUSED_BLOCK;
         }
     }
 
-    void setOverlayFilter(bool enabled) {
+    void setOverlayFilter(bool enabled) override {
         waveformOverlayFilter_ = enabled;
 
         clearBlocks();
     }
 
-    bool getOverlayFilter() { return waveformOverlayFilter_; }
+    bool getOverlayFilter() override { return waveformOverlayFilter_; }
 
-    void enableFilter(FilterType type, double strength) {
+    void enableFilter(FilterType type, double strength) override {
         delete waveformFilter_;
         waveformFilter_ = new WaveFilter(type, strength);
 
         clearBlocks();
     }
 
-    void disableFilter() {
+    void disableFilter() override {
         delete waveformFilter_;
         waveformFilter_ = nullptr;
 
         clearBlocks();
     }
 
-    int getWidth() {
+    int getWidth() override {
         return waveformBlockWidth_ * 2 + waveformSpacing_ * 2 + 8;
     }
 
-    void onChanges(int changes) {
+    void onChanges(int changes) override {
         if (changes & VCM_MUSIC_IS_LOADED) {
             if (waveformFilter_) waveformFilter_->update();
         }
     }
 
-    void tick() {}
+    void tick() override {}
 
-    void setPreset(Preset preset) {
+    void setPreset(Preset preset) override {
         switch (preset) {
             case PRESET_VORTEX:
                 waveformColorScheme_.bg = {0.0f, 0.0f, 0.0f, 1};
@@ -249,30 +249,30 @@ struct WaveformImpl : public Waveform {
         clearBlocks();
     }
 
-    void setColors(ColorScheme colors) { waveformColorScheme_ = colors; }
+    void setColors(ColorScheme colors) override { waveformColorScheme_ = colors; }
 
-    ColorScheme getColors() { return waveformColorScheme_; }
+    ColorScheme getColors() override { return waveformColorScheme_; }
 
-    void setLuminance(Luminance lum) {
+    void setLuminance(Luminance lum) override {
         waveformLuminance_ = lum;
         clearBlocks();
     }
 
-    Luminance getLuminance() { return waveformLuminance_; }
+    Luminance getLuminance() override { return waveformLuminance_; }
 
-    void setWaveShape(WaveShape style) {
+    void setWaveShape(WaveShape style) override {
         waveformShape_ = style;
         clearBlocks();
     }
 
-    WaveShape getWaveShape() { return waveformShape_; }
+    WaveShape getWaveShape() override { return waveformShape_; }
 
-    void setAntiAliasing(int level) {
+    void setAntiAliasing(int level) override {
         waveformAntiAliasingMode_ = level;
         clearBlocks();
     }
 
-    int getAntiAliasing() { return waveformAntiAliasingMode_; }
+    int getAntiAliasing() override { return waveformAntiAliasingMode_; }
 
     // ================================================================================================
     // Waveform :: luminance functions.
@@ -375,16 +375,16 @@ struct WaveformImpl : public Waveform {
                      bool filtered) {
         auto& music = gMusic->getSamples();
 
-        double samplesPerSec = (double)music.getFrequency();
+        double samplesPerSec = static_cast<double>(music.getFrequency());
         double samplesPerPixel = samplesPerSec / fabs(gView->getPixPerSec());
-        double samplesPerBlock = (double)TEX_H * samplesPerPixel;
+        double samplesPerBlock = static_cast<double>(TEX_H) * samplesPerPixel;
 
         int64_t srcFrames =
             filtered ? waveformFilter_->samplesL.size() : music.getNumFrames();
         int64_t samplePos =
-            max((int64_t)0, (int64_t)(samplesPerBlock * (double)blockId));
+            max(static_cast<int64_t>(0), static_cast<int64_t>(samplesPerBlock * static_cast<double>(blockId)));
         double sampleCount =
-            min((double)srcFrames - samplePos, samplesPerBlock);
+            min(static_cast<double>(srcFrames) - samplePos, samplesPerBlock);
 
         if (samplePos >= srcFrames || sampleCount <= 0) {
             // A crash could occur if we try to access out-of-bounds memory.
@@ -417,14 +417,14 @@ struct WaveformImpl : public Waveform {
         double ofs = 0;
         for (int y = 0; y < h; ++y) {
             // Determine the last sample of the line.
-            double end = min(sampleCount, (double)(y + 1) * advance);
+            double end = min(sampleCount, static_cast<double>(y + 1) * advance);
 
             // Find the minimum/maximum amplitude within the line.
             int minAmp = SHRT_MAX;
             int maxAmp = SHRT_MIN;
             while (ofs < end) {
-                maxAmp = max(maxAmp, (int)*(in + (int)round(ofs)));
-                minAmp = min(minAmp, (int)*(in + (int)round(ofs)));
+                maxAmp = max(maxAmp, static_cast<int>(*(in + static_cast<int>(round(ofs)))));
+                minAmp = min(minAmp, static_cast<int>(*(in + static_cast<int>(round(ofs)))));
                 ofs += sampleSkip;
             }
 
@@ -541,7 +541,7 @@ struct WaveformImpl : public Waveform {
         if (waveformBlockWidth_ != width) clearBlocks();
     }
 
-    void drawBackground() {
+    void drawBackground() override {
         updateBlockW();
 
         int w = waveformBlockWidth_ * 2 + waveformSpacing_ * 2 + 8;
@@ -551,7 +551,7 @@ struct WaveformImpl : public Waveform {
         Draw::fill({cx - w / 2, 0, w, h}, ToColor32(waveformColorScheme_.bg));
     }
 
-    void drawPeaks() {
+    void drawPeaks() override {
         updateBlockW();
 
         bool reversed = gView->hasReverseScroll();
@@ -580,7 +580,7 @@ struct WaveformImpl : public Waveform {
         int xl = cx - pw - border;
         int xr = cx + pw + border;
 
-        areaf uvs = {0, 0, waveformBlockWidth_ / (float)TEX_W, 1};
+        areaf uvs = {0, 0, waveformBlockWidth_ / static_cast<float>(TEX_W), 1};
         if (reversed) swapValues(uvs.t, uvs.b);
 
         int id = max(0, visibilityStartY / TEX_H);

--- a/src/Managers/ChartMan.cpp
+++ b/src/Managers/ChartMan.cpp
@@ -241,7 +241,8 @@ struct ChartManImpl : public ChartMan {
         MergeItems(items);
     }
 
-    Vector<BreakdownItem> getStreamBreakdown(int* totalMeasures) const override {
+    Vector<BreakdownItem> getStreamBreakdown(
+        int* totalMeasures) const override {
         int dummy;
         if (!totalMeasures) totalMeasures = &dummy;
 

--- a/src/Managers/ChartMan.cpp
+++ b/src/Managers/ChartMan.cpp
@@ -29,7 +29,7 @@ struct ChartManImpl : public ChartMan {
     // ================================================================================================
     // ChartManImpl :: constructor and destructor.
 
-    ~ChartManImpl() {}
+    ~ChartManImpl() = default;
 
     ChartManImpl() {
         myChart = nullptr;
@@ -42,7 +42,7 @@ struct ChartManImpl : public ChartMan {
     // ================================================================================================
     // ChartManImpl :: update functions.
 
-    void update(Chart* chart) { myChart = chart; }
+    void update(Chart* chart) override { myChart = chart; }
 
     // ================================================================================================
     // ChartManImpl :: step artist editing.
@@ -125,7 +125,7 @@ struct ChartManImpl : public ChartMan {
         int before = in.read<int>();
         int after = in.read<int>();
         if (in.success()) {
-            Difficulty newDiff = (Difficulty)(undo ? before : after);
+            Difficulty newDiff = static_cast<Difficulty>(undo ? before : after);
 
             msg = bound.chart->description();
             msg = msg + " :: ";
@@ -144,19 +144,19 @@ struct ChartManImpl : public ChartMan {
     // ================================================================================================
     // ChartManImpl :: set functions.
 
-    void setDifficulty(Difficulty difficulty) {
+    void setDifficulty(Difficulty difficulty) override {
         if (myChart && myChart->difficulty != difficulty) {
             myQueueDifficulty(difficulty);
         }
     }
 
-    void setStepArtist(std::string artist) {
+    void setStepArtist(std::string artist) override {
         if (myChart && myChart->artist != artist) {
             myQueueStepArtist(artist);
         }
     }
 
-    void setMeter(int meter) {
+    void setMeter(int meter) override {
         if (myChart && myChart->meter != meter) {
             myQueueMeter(meter);
         }
@@ -165,25 +165,25 @@ struct ChartManImpl : public ChartMan {
     // ================================================================================================
     // ChartManImpl :: get functions.
 
-    bool isOpen() const { return (myChart != nullptr); }
+    bool isOpen() const override { return (myChart != nullptr); }
 
-    bool isClosed() const { return (myChart == nullptr); }
+    bool isClosed() const override { return (myChart == nullptr); }
 
-    std::string getStepArtist() const {
+    std::string getStepArtist() const override {
         return myChart ? myChart->artist : std::string();
     }
 
-    Difficulty getDifficulty() const {
+    Difficulty getDifficulty() const override {
         return myChart ? myChart->difficulty : DIFF_BEGINNER;
     }
 
-    int getMeter() const { return myChart ? myChart->meter : 1; }
+    int getMeter() const override { return myChart ? myChart->meter : 1; }
 
-    std::string getDescription() const {
+    std::string getDescription() const override {
         return myChart ? myChart->description() : std::string();
     }
 
-    const Chart* get() const { return myChart; }
+    const Chart* get() const override { return myChart; }
 
     // ================================================================================================
     // ChartManImpl :: stream breakdown.
@@ -241,7 +241,7 @@ struct ChartManImpl : public ChartMan {
         MergeItems(items);
     }
 
-    Vector<BreakdownItem> getStreamBreakdown(int* totalMeasures) const {
+    Vector<BreakdownItem> getStreamBreakdown(int* totalMeasures) const override {
         int dummy;
         if (!totalMeasures) totalMeasures = &dummy;
 
@@ -312,7 +312,7 @@ struct ChartManImpl : public ChartMan {
     // ================================================================================================
     // ChartManImpl :: meter estimation.
 
-    double getEstimatedMeter() const {
+    double getEstimatedMeter() const override {
         RatingEstimator hm("assets/rating estimate data.txt");
         return hm.estimateRating();
     }

--- a/src/Managers/MetadataMan.cpp
+++ b/src/Managers/MetadataMan.cpp
@@ -27,7 +27,7 @@ struct MetadataManImpl : public MetadataMan {
     // ================================================================================================
     // MetadataManImpl :: constructor and destructor.
 
-    ~MetadataManImpl() {}
+    ~MetadataManImpl() = default;
 
     MetadataManImpl() {
         mySimfile = nullptr;
@@ -135,7 +135,7 @@ struct MetadataManImpl : public MetadataMan {
         }
     }
 
-    void setMusicPreview(double start, double length) {
+    void setMusicPreview(double start, double length) override {
         if (length <= 0.0) start = length = 0.0;
 
         if (mySimfile && (mySimfile->previewStart != start ||
@@ -144,51 +144,51 @@ struct MetadataManImpl : public MetadataMan {
         }
     }
 
-    void setTitle(const std::string& s) {
+    void setTitle(const std::string& s) override {
         mySetString(&mySimfile->title, s, "title");
     }
 
-    void setTitleTranslit(const std::string& s) {
+    void setTitleTranslit(const std::string& s) override {
         mySetString(&mySimfile->titleTr, s, "transliterated title");
     }
 
-    void setSubtitle(const std::string& s) {
+    void setSubtitle(const std::string& s) override {
         mySetString(&mySimfile->subtitle, s, "subtitle");
     }
 
-    void setSubtitleTranslit(const std::string& s) {
+    void setSubtitleTranslit(const std::string& s) override {
         mySetString(&mySimfile->subtitleTr, s, "transliterated subtitle");
     }
 
-    void setArtist(const std::string& s) {
+    void setArtist(const std::string& s) override {
         mySetString(&mySimfile->artist, s, "artist");
     }
 
-    void setArtistTranslit(const std::string& s) {
+    void setArtistTranslit(const std::string& s) override {
         mySetString(&mySimfile->artistTr, s, "transliterated artist");
     }
 
-    void setGenre(const std::string& s) {
+    void setGenre(const std::string& s) override {
         mySetString(&mySimfile->genre, s, "genre");
     }
 
-    void setCredit(const std::string& s) {
+    void setCredit(const std::string& s) override {
         mySetString(&mySimfile->credit, s, "credit");
     }
 
-    void setMusicPath(const std::string& s) {
+    void setMusicPath(const std::string& s) override {
         mySetString(&mySimfile->music, s, "music");
     }
 
-    void setBannerPath(const std::string& s) {
+    void setBannerPath(const std::string& s) override {
         mySetString(&mySimfile->banner, s, "banner");
     }
 
-    void setBackgroundPath(const std::string& s) {
+    void setBackgroundPath(const std::string& s) override {
         mySetString(&mySimfile->background, s, "background");
     }
 
-    void setCdTitlePath(const std::string& s) {
+    void setCdTitlePath(const std::string& s) override {
         mySetString(&mySimfile->cdTitle, s, "CD title");
     }
 
@@ -235,7 +235,7 @@ struct MetadataManImpl : public MetadataMan {
         return {};
     }
 
-    std::string findMusicFile() {
+    std::string findMusicFile() override {
         std::string out;
         int priority = 0;
         auto audioFiles =
@@ -257,18 +257,18 @@ struct MetadataManImpl : public MetadataMan {
         return out;
     }
 
-    std::string findBannerFile() { return findImageFile("bn", "banner"); }
+    std::string findBannerFile() override { return findImageFile("bn", "banner"); }
 
-    std::string findBackgroundFile() {
+    std::string findBackgroundFile() override {
         return findImageFile("bg", "background");
     }
 
-    std::string findCdTitleFile() { return findImageFile("cd", "title"); }
+    std::string findCdTitleFile() override { return findImageFile("cd", "title"); }
 
     // ================================================================================================
     // MetadataManImpl :: other member functions.
 
-    void update(Simfile* simfile) { mySimfile = simfile; }
+    void update(Simfile* simfile) override { mySimfile = simfile; }
 
 };  // MetadataManImpl
 

--- a/src/Managers/MetadataMan.cpp
+++ b/src/Managers/MetadataMan.cpp
@@ -257,13 +257,17 @@ struct MetadataManImpl : public MetadataMan {
         return out;
     }
 
-    std::string findBannerFile() override { return findImageFile("bn", "banner"); }
+    std::string findBannerFile() override {
+        return findImageFile("bn", "banner");
+    }
 
     std::string findBackgroundFile() override {
         return findImageFile("bg", "background");
     }
 
-    std::string findCdTitleFile() override { return findImageFile("cd", "title"); }
+    std::string findCdTitleFile() override {
+        return findImageFile("cd", "title");
+    }
 
     // ================================================================================================
     // MetadataManImpl :: other member functions.

--- a/src/Managers/NoteMan.cpp
+++ b/src/Managers/NoteMan.cpp
@@ -33,9 +33,9 @@ struct NotesManImpl : public NotesMan {
 
     Vector<ExpandedNote> myNotes;
 
-    int myNumSteps, myNumJumps;
-    int myNumHolds, myNumRolls;
-    int myNumMines, myNumWarps;
+    int myNumSteps = 0, myNumJumps = 0;
+    int myNumHolds = 0, myNumRolls = 0;
+    int myNumMines = 0, myNumWarps = 0;
 
     Simfile* mySimfile;
     Chart* myChart;
@@ -48,15 +48,11 @@ struct NotesManImpl : public NotesMan {
     // ================================================================================================
     // NotesManImpl :: constructor and destructor.
 
-    ~NotesManImpl() {}
+    ~NotesManImpl() = default;
 
     NotesManImpl()
-        : myNumSteps(0),
-          myNumJumps(0),
-          myNumHolds(0),
-          myNumRolls(0),
-          myNumMines(0),
-          myNumWarps(0) {
+        
+          {
         myChart = nullptr;
 
         myApplyAddNoteId = gHistory->addCallback(ApplyAddNote);
@@ -176,7 +172,7 @@ struct NotesManImpl : public NotesMan {
         }
     }
 
-    void update(Simfile* simfile, Chart* chart) {
+    void update(Simfile* simfile, Chart* chart) override {
         mySimfile = simfile;
         myChart = chart;
 
@@ -190,7 +186,7 @@ struct NotesManImpl : public NotesMan {
         gEditor->reportChanges(VCM_NOTES_CHANGED);
     }
 
-    void updateTempo() {
+    void updateTempo() override {
         myUpdateNoteTimes();
         myUpdateWarpedNotes();
         myUpdateFakedNotes();
@@ -510,7 +506,7 @@ struct NotesManImpl : public NotesMan {
         return numSelected;
     }
 
-    void deselectAll() {
+    void deselectAll() override {
         for (auto& note : myNotes) {
             note.isSelected = 0;
         }
@@ -519,7 +515,7 @@ struct NotesManImpl : public NotesMan {
         }
     }
 
-    int selectAll() {
+    int selectAll() override {
         for (auto& note : myNotes) {
             note.isSelected = 1;
         }
@@ -529,7 +525,7 @@ struct NotesManImpl : public NotesMan {
         return myNotes.size();
     }
 
-    int selectQuant(int rowType) {
+    int selectQuant(int rowType) override {
         int numSelected = 0;
         for (auto& note : myNotes) {
             note.isSelected = (ToRowType(note.row) == rowType);
@@ -542,7 +538,7 @@ struct NotesManImpl : public NotesMan {
     }
 
     int selectRows(SelectModifier mod, int firstCol, int lastCol, int firstRow,
-                   int lastRow) {
+                   int lastRow) override {
         return performSelection(mod, [&](const ExpandedNote* note) {
             return (note->col >= firstCol && note->col < lastCol &&
                     note->row >= firstRow && note->row < lastRow);
@@ -550,7 +546,7 @@ struct NotesManImpl : public NotesMan {
     }
 
     int selectTime(SelectModifier mod, int firstCol, int lastCol,
-                   double firstTime, double lastTime) {
+                   double firstTime, double lastTime) override {
         gSelection->setType(Selection::NOTES);
         return performSelection(mod, [&](const ExpandedNote* note) {
             return (note->col >= firstCol && note->col < lastCol &&
@@ -558,7 +554,7 @@ struct NotesManImpl : public NotesMan {
         });
     }
 
-    int select(SelectModifier mod, const Vector<RowCol>& indices) {
+    int select(SelectModifier mod, const Vector<RowCol>& indices) override {
         auto it = indices.begin(), end = indices.end();
         return performSelection(mod, [&](const ExpandedNote* note) {
             while (it != end && LessThanRowCol(*it, *note)) ++it;
@@ -567,7 +563,7 @@ struct NotesManImpl : public NotesMan {
         });
     }
 
-    int select(SelectModifier mod, const Note* notes, int numNotes) {
+    int select(SelectModifier mod, const Note* notes, int numNotes) override {
         auto it = notes, end = notes + numNotes;
         return performSelection(mod, [&](const ExpandedNote* note) {
             while (it != end && LessThanRowCol(*it, *note)) ++it;
@@ -576,7 +572,7 @@ struct NotesManImpl : public NotesMan {
         });
     }
 
-    int select(SelectModifier mod, Filter filter) {
+    int select(SelectModifier mod, Filter filter) override {
         auto first = myNotes.begin();
         auto last = myNotes.end() - 1;
         switch (filter) {
@@ -623,7 +619,7 @@ struct NotesManImpl : public NotesMan {
         return 0;
     }
 
-    bool noneSelected() const {
+    bool noneSelected() const override {
         for (auto& note : myNotes) {
             if (note.isSelected) return false;
         }
@@ -634,7 +630,7 @@ struct NotesManImpl : public NotesMan {
     // NotesManImpl :: editing functions.
 
     void modify(const NoteEdit& edit, bool clearRegion,
-                const EditDescription* desc) {
+                const EditDescription* desc) override {
         NoteEditResult result;
         myChart->notes.prepareEdit(edit, result, clearRegion);
 
@@ -650,7 +646,7 @@ struct NotesManImpl : public NotesMan {
         }
     }
 
-    void removeSelectedNotes() {
+    void removeSelectedNotes() override {
         NoteEdit edit;
         Vector<RowCol> indices;
         forAllSelectedNotes([&](const ExpandedNote& note) {
@@ -659,14 +655,14 @@ struct NotesManImpl : public NotesMan {
         modify(edit, false, nullptr);
     }
 
-    void insertRows(int startRow, int numRows, bool curChartOnly) {
+    void insertRows(int startRow, int numRows, bool curChartOnly) override {
         myQueueInsertRows(startRow, numRows, curChartOnly);
     }
 
     // ================================================================================================
     // NotesManImpl :: clipboard functions.
 
-    void copyToClipboard(bool timeBased) {
+    void copyToClipboard(bool timeBased) override {
         // Get the note selection.
         NoteList notes;
         int numNotes = gSelection->getSelectedNotes(notes);
@@ -686,7 +682,7 @@ struct NotesManImpl : public NotesMan {
         }
     }
 
-    void pasteFromClipboard(bool insert) {
+    void pasteFromClipboard(bool insert) override {
         Vector<uint8_t> buffer = GetClipboardData(clipboardTag);
         ReadStream stream(buffer.data(), buffer.size());
 
@@ -722,23 +718,23 @@ struct NotesManImpl : public NotesMan {
     // ================================================================================================
     // NotesManImpl :: get functions
 
-    int getNumSteps() const { return myNumSteps; }
+    int getNumSteps() const override { return myNumSteps; }
 
-    int getNumJumps() const { return myNumJumps; }
+    int getNumJumps() const override { return myNumJumps; }
 
-    int getNumMines() const { return myNumMines; }
+    int getNumMines() const override { return myNumMines; }
 
-    int getNumHolds() const { return myNumHolds; }
+    int getNumHolds() const override { return myNumHolds; }
 
-    int getNumRolls() const { return myNumRolls; }
+    int getNumRolls() const override { return myNumRolls; }
 
-    int getNumWarps() const { return myNumWarps; }
+    int getNumWarps() const override { return myNumWarps; }
 
-    const ExpandedNote* begin() const { return myNotes.begin(); }
+    const ExpandedNote* begin() const override { return myNotes.begin(); }
 
-    const ExpandedNote* end() const { return myNotes.end(); }
+    const ExpandedNote* end() const override { return myNotes.end(); }
 
-    const ExpandedNote* getNoteAt(int row, int col) const {
+    const ExpandedNote* getNoteAt(int row, int col) const override {
         RowCol key = {row, col};
         auto it = std::lower_bound(myNotes.begin(), myNotes.end(), key,
                                    [](const ExpandedNote& a, const RowCol& b) {
@@ -748,7 +744,7 @@ struct NotesManImpl : public NotesMan {
                                                                      : nullptr;
     }
 
-    const ExpandedNote* getNoteIntersecting(int row, int col) const {
+    const ExpandedNote* getNoteIntersecting(int row, int col) const override {
         auto it = myNotes.begin(), end = myNotes.end();
         for (; it != end && it->endrow < row; ++it);
         for (; it != end && it->row <= row; ++it) {
@@ -757,7 +753,7 @@ struct NotesManImpl : public NotesMan {
         return nullptr;
     }
 
-    Vector<const ExpandedNote*> getNotesBeforeTime(double time) const {
+    Vector<const ExpandedNote*> getNotesBeforeTime(double time) const override {
         Vector<const ExpandedNote*> out(gStyle->getNumCols(), nullptr);
         auto cols = out.begin();
         for (auto& n : myNotes) {
@@ -768,7 +764,7 @@ struct NotesManImpl : public NotesMan {
         return out;
     }
 
-    bool empty() const { return myNotes.empty(); }
+    bool empty() const override { return myNotes.empty(); }
 
 };  // NotesManImpl
 

--- a/src/Managers/NoteMan.cpp
+++ b/src/Managers/NoteMan.cpp
@@ -50,11 +50,9 @@ struct NotesManImpl : public NotesMan {
 
     ~NotesManImpl() = default;
 
-    NotesManImpl()
-        
-          {
+    NotesManImpl() {
         myChart = nullptr;
-
+        mySimfile = nullptr;
         myApplyAddNoteId = gHistory->addCallback(ApplyAddNote);
         myApplyRemNoteId = gHistory->addCallback(ApplyRemoveNote);
         myApplyChangeNotesId = gHistory->addCallback(ApplyChangeNotes);
@@ -398,7 +396,7 @@ struct NotesManImpl : public NotesMan {
                     myItemizeInsertRows(stream, chart, startRow, numRows);
                 }
             }
-            stream.write((Chart*)nullptr);
+            stream.write(static_cast<Chart*>(nullptr));
 
             gHistory->addEntry(myApplyInsertRowsId, stream.data(),
                                stream.size());

--- a/src/Managers/NoteskinMan.cpp
+++ b/src/Managers/NoteskinMan.cpp
@@ -30,8 +30,8 @@ struct NoteskinImpl : public Noteskin {
 };
 
 struct SpriteTransform {
-    SpriteTransform() : x(0), y(0), w(0), h(0), rot(0), mir(0) {}
-    int x, y, w, h, rot, mir;
+    SpriteTransform()  = default;
+    int x = 0, y = 0, w = 0, h = 0, rot = 0, mir = 0;
 };
 
 static bool LoadTexture(const std::string& path, const std::string& dir,
@@ -151,12 +151,12 @@ static void SetUVS(const Texture& tex, SpriteTransform& t, BatchSprite& spr) {
         float tmp[8] = {0, 0, 1, 0, 0, 1, 1, 1};
         memcpy(spr.uvs, tmp, sizeof(float) * 8);
     } else {
-        double du = 1.0f / (double)tex.size().x;
-        double dv = 1.0f / (double)tex.size().y;
-        double ul = du * (double)t.x, ur = ul + du * (double)spr.width;
-        double vt = dv * (double)t.y, vb = vt + dv * (double)spr.height;
+        double du = 1.0f / static_cast<double>(tex.size().x);
+        double dv = 1.0f / static_cast<double>(tex.size().y);
+        double ul = du * static_cast<double>(t.x), ur = ul + du * static_cast<double>(spr.width);
+        double vt = dv * static_cast<double>(t.y), vb = vt + dv * static_cast<double>(spr.height);
         double uvs[8] = {ul, vt, ur, vt, ul, vb, ur, vb};
-        for (int i = 0; i < 8; ++i) spr.uvs[i] = (float)uvs[i];
+        for (int i = 0; i < 8; ++i) spr.uvs[i] = static_cast<float>(uvs[i]);
 
         // handle rotation.
         float* p = spr.uvs;
@@ -442,7 +442,7 @@ struct NoteskinManImpl : public NoteskinMan {
         }
     }
 
-    void saveSettings(XmrNode& settings) {
+    void saveSettings(XmrNode& settings) override {
         XmrNode* view = settings.child("view");
         if (!view) view = settings.addChild("view");
 
@@ -461,7 +461,7 @@ struct NoteskinManImpl : public NoteskinMan {
         return type.supportedStyles.find(style) != type.supportedStyles.size();
     }
 
-    void update(Chart* chart) {
+    void update(Chart* chart) override {
         const Style* style = chart ? chart->style : nullptr;
         if (myActiveStyle == style) return;
         myActiveStyle = style;
@@ -505,11 +505,11 @@ struct NoteskinManImpl : public NoteskinMan {
         }
     }
 
-    int getNumTypes() const { return myTypes.size(); }
+    int getNumTypes() const override { return myTypes.size(); }
 
-    const std::string& getName(int type) const { return myTypes[type].name; }
+    const std::string& getName(int type) const override { return myTypes[type].name; }
 
-    bool isSupported(int type) const {
+    bool isSupported(int type) const override {
         return Supports(myTypes[type], gStyle->get());
     }
 
@@ -518,7 +518,7 @@ struct NoteskinManImpl : public NoteskinMan {
         myPriorities.insert(0, type, 1);
     }
 
-    void setType(int type) {
+    void setType(int type) override {
         type = clamp(type, 0, myTypes.size());
         if (myActiveSkin && myActiveSkin->type != type) {
             LoadNoteskin(myActiveSkin, myTypes[type]);
@@ -528,9 +528,9 @@ struct NoteskinManImpl : public NoteskinMan {
         }
     }
 
-    int getType() const { return myActiveSkin ? myActiveSkin->type : 0; }
+    int getType() const override { return myActiveSkin ? myActiveSkin->type : 0; }
 
-    const Noteskin* get() const { return myActiveSkin; }
+    const Noteskin* get() const override { return myActiveSkin; }
 
 };  // NoteskinImpl.
 

--- a/src/Managers/NoteskinMan.cpp
+++ b/src/Managers/NoteskinMan.cpp
@@ -30,7 +30,7 @@ struct NoteskinImpl : public Noteskin {
 };
 
 struct SpriteTransform {
-    SpriteTransform()  = default;
+    SpriteTransform() = default;
     int x = 0, y = 0, w = 0, h = 0, rot = 0, mir = 0;
 };
 
@@ -153,8 +153,10 @@ static void SetUVS(const Texture& tex, SpriteTransform& t, BatchSprite& spr) {
     } else {
         double du = 1.0f / static_cast<double>(tex.size().x);
         double dv = 1.0f / static_cast<double>(tex.size().y);
-        double ul = du * static_cast<double>(t.x), ur = ul + du * static_cast<double>(spr.width);
-        double vt = dv * static_cast<double>(t.y), vb = vt + dv * static_cast<double>(spr.height);
+        double ul = du * static_cast<double>(t.x),
+               ur = ul + du * static_cast<double>(spr.width);
+        double vt = dv * static_cast<double>(t.y),
+               vb = vt + dv * static_cast<double>(spr.height);
         double uvs[8] = {ul, vt, ur, vt, ul, vb, ur, vb};
         for (int i = 0; i < 8; ++i) spr.uvs[i] = static_cast<float>(uvs[i]);
 
@@ -507,7 +509,9 @@ struct NoteskinManImpl : public NoteskinMan {
 
     int getNumTypes() const override { return myTypes.size(); }
 
-    const std::string& getName(int type) const override { return myTypes[type].name; }
+    const std::string& getName(int type) const override {
+        return myTypes[type].name;
+    }
 
     bool isSupported(int type) const override {
         return Supports(myTypes[type], gStyle->get());
@@ -528,7 +532,9 @@ struct NoteskinManImpl : public NoteskinMan {
         }
     }
 
-    int getType() const override { return myActiveSkin ? myActiveSkin->type : 0; }
+    int getType() const override {
+        return myActiveSkin ? myActiveSkin->type : 0;
+    }
 
     const Noteskin* get() const override { return myActiveSkin; }
 

--- a/src/Managers/SimfileMan.cpp
+++ b/src/Managers/SimfileMan.cpp
@@ -51,8 +51,8 @@ struct SimfileManImpl : public SimfileMan {
     // SimfileManImpl :: constructor and destructor.
 
     SimfileManImpl()
-        
-          {
+
+    {
         myApplyAddChartId =
             gHistory->addCallback(ApplyAddChart, ReleaseAddChart);
         myApplyRemoveChartId =
@@ -71,7 +71,7 @@ struct SimfileManImpl : public SimfileMan {
 
         // Row of the last segment.
         auto segments = mySimfile->tempo->segments;
-        for (auto & segment : *segments) {
+        for (auto& segment : *segments) {
             for (auto seg = segment.begin(), end = segment.end(); seg != end;
                  ++seg) {
                 endRow = max(endRow, seg->row);

--- a/src/Managers/SimfileMan.cpp
+++ b/src/Managers/SimfileMan.cpp
@@ -37,12 +37,12 @@ namespace Vortex {
 // SimfileManImpl :: member data.
 
 struct SimfileManImpl : public SimfileMan {
-    Chart* myChart;
-    Simfile* mySimfile;
+    Chart* myChart = nullptr;
+    Simfile* mySimfile = nullptr;
 
-    int myEndRow;
-    int myChartIndex;
-    bool myBackupOnSave;
+    int myEndRow = 0;
+    int myChartIndex = -1;
+    bool myBackupOnSave = false;
 
     History::EditId myApplyAddChartId;
     History::EditId myApplyRemoveChartId;
@@ -51,11 +51,8 @@ struct SimfileManImpl : public SimfileMan {
     // SimfileManImpl :: constructor and destructor.
 
     SimfileManImpl()
-        : myChart(nullptr),
-          mySimfile(nullptr),
-          myEndRow(0),
-          myChartIndex(-1),
-          myBackupOnSave(false) {
+        
+          {
         myApplyAddChartId =
             gHistory->addCallback(ApplyAddChart, ReleaseAddChart);
         myApplyRemoveChartId =
@@ -74,9 +71,8 @@ struct SimfileManImpl : public SimfileMan {
 
         // Row of the last segment.
         auto segments = mySimfile->tempo->segments;
-        for (auto list = segments->begin(), listEnd = segments->end();
-             list != listEnd; ++list) {
-            for (auto seg = list->begin(), end = list->end(); seg != end;
+        for (auto & segment : *segments) {
+            for (auto seg = segment.begin(), end = segment.end(); seg != end;
                  ++seg) {
                 endRow = max(endRow, seg->row);
             }
@@ -133,7 +129,7 @@ struct SimfileManImpl : public SimfileMan {
                                VCM_CHART_PROPERTIES_CHANGED);
     }
 
-    void onChanges(int changes) {
+    void onChanges(int changes) override {
         if (changes &
             (VCM_NOTES_CHANGED | VCM_TEMPO_CHANGED | VCM_MUSIC_IS_LOADED)) {
             myUpdateEndRow();
@@ -143,7 +139,7 @@ struct SimfileManImpl : public SimfileMan {
     // ================================================================================================
     // SimfileManImpl :: open and close functions.
 
-    bool load(const std::string& path) {
+    bool load(const std::string& path) override {
         close();
 
         bool loadedFromAudio = false;
@@ -209,7 +205,7 @@ struct SimfileManImpl : public SimfileMan {
     }
 
     bool save(const std::string& dir, const std::string& name,
-              SimFormat format) {
+              SimFormat format) override {
         if (!mySimfile) return false;
 
         // Update the song directory and filename.
@@ -225,7 +221,7 @@ struct SimfileManImpl : public SimfileMan {
         return result;
     }
 
-    void close() {
+    void close() override {
         if (!mySimfile) return;
 
         delete mySimfile;
@@ -266,7 +262,7 @@ struct SimfileManImpl : public SimfileMan {
     }
 
     void addChart(const Style* style, std::string artist, Difficulty difficulty,
-                  int meter) {
+                  int meter) override {
         Chart* chart = new Chart;
 
         chart->style = style;
@@ -301,11 +297,11 @@ struct SimfileManImpl : public SimfileMan {
         return msg;
     }
 
-    void removeChart(const Chart* chart) {
+    void removeChart(const Chart* chart) override {
         if (!chart) return;
 
         if (mySimfile) {
-            int pos = mySimfile->charts.find((Chart*)chart);
+            int pos = mySimfile->charts.find(const_cast<Chart*>(chart));
             if (pos == mySimfile->charts.size()) {
                 HudError(
                     "Trying to remove a chart that is not in the chart list.");
@@ -454,7 +450,7 @@ struct SimfileManImpl : public SimfileMan {
         return "Removed chart: " + chart->description();
     }
 
-    void sortCharts() {
+    void sortCharts() override {
         std::stable_sort(mySimfile->charts.begin(), mySimfile->charts.end(),
                          [](const Chart* a, const Chart* b) {
                              if (a->style != b->style) {
@@ -470,7 +466,7 @@ struct SimfileManImpl : public SimfileMan {
     // ================================================================================================
     // SimfileManImpl :: open chart.
 
-    void openChart(int index) {
+    void openChart(int index) override {
         if (mySimfile && myChartIndex != index && index >= -1 &&
             index < mySimfile->charts.size()) {
             myChartIndex = index;
@@ -485,7 +481,7 @@ struct SimfileManImpl : public SimfileMan {
         }
     }
 
-    void openChart(const Chart* chart) {
+    void openChart(const Chart* chart) override {
         if (mySimfile) {
             for (int i = 0; i < mySimfile->charts.size(); ++i) {
                 if (mySimfile->charts[i] == chart) {
@@ -497,38 +493,38 @@ struct SimfileManImpl : public SimfileMan {
         HudWarning("Trying to open a chart that is not in the chart list.");
     }
 
-    void nextChart() { openChart(myChartIndex + 1); }
+    void nextChart() override { openChart(myChartIndex + 1); }
 
-    void previousChart() { openChart(myChartIndex - 1); }
+    void previousChart() override { openChart(myChartIndex - 1); }
 
     // ================================================================================================
     // SimfileManImpl :: get functions.
 
-    std::string getDir() const {
+    std::string getDir() const override {
         return mySimfile ? mySimfile->dir : std::string();
     }
 
-    std::string getFile() const {
+    std::string getFile() const override {
         return mySimfile ? mySimfile->file : std::string();
     }
 
-    int getNumCharts() const {
+    int getNumCharts() const override {
         return mySimfile ? mySimfile->charts.size() : 0;
     }
 
     int getActiveChart() const { return myChartIndex; }
 
-    const Chart* getChart(int index) const {
+    const Chart* getChart(int index) const override {
         return mySimfile->charts.begin()[index];
     }
 
-    int getEndRow() const { return myEndRow; }
+    int getEndRow() const override { return myEndRow; }
 
-    bool isOpen() const { return mySimfile != nullptr; }
+    bool isOpen() const override { return mySimfile != nullptr; }
 
-    bool isClosed() const { return mySimfile == nullptr; }
+    bool isClosed() const override { return mySimfile == nullptr; }
 
-    const Simfile* get() const { return mySimfile; }
+    const Simfile* get() const override { return mySimfile; }
 
 };  // SimfileManImpl
 

--- a/src/Managers/StyleMan.cpp
+++ b/src/Managers/StyleMan.cpp
@@ -279,7 +279,7 @@ struct StyleManImpl : public StyleMan {
     }
 
     const Style* findStyle(const std::string& styleId) override {
-        for (auto & myStyle : myStyles) {
+        for (auto& myStyle : myStyles) {
             if (myStyle->id == styleId) {
                 return myStyle;
             }

--- a/src/Managers/StyleMan.cpp
+++ b/src/Managers/StyleMan.cpp
@@ -278,21 +278,20 @@ struct StyleManImpl : public StyleMan {
         return style;
     }
 
-    const Style* findStyle(const std::string& styleId) {
-        for (int i = 0; i < myStyles.size(); ++i) {
-            if (myStyles[i]->id == styleId) {
-                return myStyles[i];
+    const Style* findStyle(const std::string& styleId) override {
+        for (auto & myStyle : myStyles) {
+            if (myStyle->id == styleId) {
+                return myStyle;
             }
         }
         return nullptr;
     }
 
     const Style* findStyle(const std::string& chartName, int numCols,
-                           int numPlayers) {
+                           int numPlayers) override {
         // First, check if an existing style matches the requested column and
         // player count.
-        for (int i = 0; i < myStyles.size(); ++i) {
-            auto style = myStyles[i];
+        for (auto style : myStyles) {
             if (style->numCols == numCols && style->numPlayers == numPlayers) {
                 return style;
             }
@@ -306,13 +305,12 @@ struct StyleManImpl : public StyleMan {
     }
 
     const Style* findStyle(const std::string& chartName, int numCols,
-                           int numPlayers, const std::string& id) {
+                           int numPlayers, const std::string& id) override {
         /// Use lookup by column and player count if the id string is empty.
         if (id.empty()) {
             // First, check if an existing style matches the requested column
             // and player count.
-            for (int i = 0; i < myStyles.size(); ++i) {
-                auto style = myStyles[i];
+            for (auto style : myStyles) {
                 if (style->numCols == numCols &&
                     style->numPlayers == numPlayers) {
                     HudWarning("%s is missing a style, using %s.",
@@ -330,8 +328,7 @@ struct StyleManImpl : public StyleMan {
         }
 
         /// Try to find a match in the list of loaded styles.
-        for (int i = 0; i < myStyles.size(); ++i) {
-            auto style = myStyles[i];
+        for (auto style : myStyles) {
             if (style->id == id) {
                 return style;
             }
@@ -344,23 +341,23 @@ struct StyleManImpl : public StyleMan {
         return createFallbackStyle(id, numCols, numPlayers);
     }
 
-    void update(Chart* chart) {
-        myActiveStyle = (Style*)(chart ? chart->style : nullptr);
+    void update(Chart* chart) override {
+        myActiveStyle = const_cast<Style*>(chart ? chart->style : nullptr);
     }
 
-    int getNumStyles() const { return myNumDefaultStyles; }
+    int getNumStyles() const override { return myNumDefaultStyles; }
 
-    int getNumCols() const {
+    int getNumCols() const override {
         return myActiveStyle ? myActiveStyle->numCols : 0;
     }
 
-    int getNumPlayers() const {
+    int getNumPlayers() const override {
         return myActiveStyle ? myActiveStyle->numPlayers : 0;
     }
 
-    Style* get(int index) const { return myStyles[index]; }
+    Style* get(int index) const override { return myStyles[index]; }
 
-    Style* get() const { return myActiveStyle; }
+    Style* get() const override { return myActiveStyle; }
 
 };  // StyleManImpl.
 

--- a/src/Managers/TempoMan.cpp
+++ b/src/Managers/TempoMan.cpp
@@ -55,8 +55,8 @@ struct TempoManImpl : public TempoMan {
     ~TempoManImpl() = default;
 
     TempoManImpl()
-        
-          {
+
+    {
         myUpdateTimingData();
 
         myApplyOffsetId = gHistory->addCallback(ApplyOffset);
@@ -247,7 +247,7 @@ struct TempoManImpl : public TempoMan {
                 }
                 myWriteInsertRows(stream, mySimfile->tempo, startRow, numRows);
             }
-            stream.write((Tempo*)nullptr);
+            stream.write(static_cast<Tempo*>(nullptr));
 
             gHistory->addEntry(myApplyInsertRowsId, stream.data(),
                                stream.size());
@@ -256,9 +256,8 @@ struct TempoManImpl : public TempoMan {
 
     void myApplyInsertRowsOffset(Tempo* tempo, int startRow, int numRows) {
         auto segs = tempo->segments;
-        for (auto & list : *segs) {
-            for (auto seg = list.begin(), end = list.end(); seg != end;
-                 ++seg) {
+        for (auto& list : *segs) {
+            for (auto seg = list.begin(), end = list.end(); seg != end; ++seg) {
                 if (seg->row >= startRow && seg->row > 0) {
                     seg->row += numRows;
                 }
@@ -467,7 +466,7 @@ struct TempoManImpl : public TempoMan {
 
         // Copy all the selected segments.
         auto boxes = gTempoBoxes->getBoxes();
-        for (auto & segment : *myTempo->segments) {
+        for (auto& segment : *myTempo->segments) {
             auto type = segment.type();
             auto seg = segment.begin(), end = segment.end();
             auto box = boxes.begin(), boxEnd = boxes.end();
@@ -486,16 +485,15 @@ struct TempoManImpl : public TempoMan {
 
         // Find out what the first row is.
         int row = INT_MAX;
-        for (auto & list : clipboard) {
+        for (auto& list : clipboard) {
             if (list.size()) {
                 row = min(row, list.begin()->row);
             }
         }
 
         // Offset all segments to row zero.
-        for (auto & list : clipboard) {
-            for (auto seg = list.begin(), end = list.end(); seg != end;
-                 ++seg) {
+        for (auto& list : clipboard) {
+            for (auto seg = list.begin(), end = list.end(); seg != end; ++seg) {
                 seg->row -= row;
             }
         }
@@ -523,9 +521,8 @@ struct TempoManImpl : public TempoMan {
 
         // Offset all segments to the cursor row.
         int row = gView->getCursorRow();
-        for (auto & list : clipboard.add) {
-            for (auto seg = list.begin(), end = list.end(); seg != end;
-                 ++seg) {
+        for (auto& list : clipboard.add) {
+            for (auto seg = list.begin(), end = list.end(); seg != end; ++seg) {
                 seg->row += row;
             }
         }
@@ -620,13 +617,17 @@ struct TempoManImpl : public TempoMan {
     // ================================================================================================
     // TempoManImpl :: timing functions.
 
-    int timeToRow(double time) const override { return myTimingData.timeToRow(time); }
+    int timeToRow(double time) const override {
+        return myTimingData.timeToRow(time);
+    }
 
     double timeToBeat(double time) const override {
         return myTimingData.timeToBeat(time);
     }
 
-    double rowToTime(int row) const override { return myTimingData.rowToTime(row); }
+    double rowToTime(int row) const override {
+        return myTimingData.rowToTime(row);
+    }
 
     double beatToTime(double beat) const override {
         return myTimingData.beatToTime(beat);
@@ -645,7 +646,9 @@ struct TempoManImpl : public TempoMan {
         return SIM_DEFAULT_BPM;
     }
 
-    double rowToScroll(int row) const override { return myTimingData.rowToScroll(row); }
+    double rowToScroll(int row) const override {
+        return myTimingData.rowToScroll(row);
+    }
 
     double beatToScroll(double beat) const override {
         return myTimingData.beatToScroll(beat);

--- a/src/Managers/TempoMan.cpp
+++ b/src/Managers/TempoMan.cpp
@@ -32,16 +32,16 @@ namespace Vortex {
 const char* TempoMan::clipboardTag = "tempo";
 
 struct TempoManImpl : public TempoMan {
-    Tempo* myTempo;
+    Tempo* myTempo = nullptr;
 
     Chart* myChart;
-    Simfile* mySimfile;
+    Simfile* mySimfile = nullptr;
     TimingData myTimingData;
     double myInitialBpm;
 
     int myTweakRow;
-    Tempo* myTweakTempo;
-    TweakMode myTweakMode;
+    Tempo* myTweakTempo = nullptr;
+    TweakMode myTweakMode = TWEAK_NONE;
     double myTweakValue;
 
     History::EditId myApplyOffsetId;
@@ -52,13 +52,11 @@ struct TempoManImpl : public TempoMan {
     // ================================================================================================
     // TempoManImpl :: constructor and destructor.
 
-    ~TempoManImpl() {}
+    ~TempoManImpl() = default;
 
     TempoManImpl()
-        : myTempo(nullptr),
-          mySimfile(nullptr),
-          myTweakTempo(nullptr),
-          myTweakMode(TWEAK_NONE) {
+        
+          {
         myUpdateTimingData();
 
         myApplyOffsetId = gHistory->addCallback(ApplyOffset);
@@ -84,7 +82,7 @@ struct TempoManImpl : public TempoMan {
         gEditor->reportChanges(VCM_TEMPO_CHANGED);
     }
 
-    void update(Simfile* sim, Chart* chart) {
+    void update(Simfile* sim, Chart* chart) override {
         myChart = chart;
         mySimfile = sim;
 
@@ -258,9 +256,8 @@ struct TempoManImpl : public TempoMan {
 
     void myApplyInsertRowsOffset(Tempo* tempo, int startRow, int numRows) {
         auto segs = tempo->segments;
-        for (auto list = segs->begin(), listEnd = segs->end(); list != listEnd;
-             ++list) {
-            for (auto seg = list->begin(), end = list->end(); seg != end;
+        for (auto & list : *segs) {
+            for (auto seg = list.begin(), end = list.end(); seg != end;
                  ++seg) {
                 if (seg->row >= startRow && seg->row > 0) {
                     seg->row += numRows;
@@ -412,14 +409,14 @@ struct TempoManImpl : public TempoMan {
         return round(clamp(val, min, max) * 1000000.0) / 1000000.0;
     }
 
-    void modify(const SegmentEdit& edit) { modify(edit, true); }
+    void modify(const SegmentEdit& edit) override { modify(edit, true); }
 
-    void modify(const SegmentEdit& edit, bool clearRegion) {
+    void modify(const SegmentEdit& edit, bool clearRegion) override {
         stopTweaking(false);
         myQueueSegments(edit, clearRegion);
     }
 
-    void removeSelectedSegments() {
+    void removeSelectedSegments() override {
         SegmentEdit edit;
         for (auto& box : gTempoBoxes->getBoxes()) {
             if (box.isSelected) {
@@ -431,11 +428,11 @@ struct TempoManImpl : public TempoMan {
         modify(edit);
     }
 
-    void insertRows(int startRow, int numRows, bool curChartOnly) {
+    void insertRows(int startRow, int numRows, bool curChartOnly) override {
         myQueueInsertRows(startRow, numRows, curChartOnly);
     }
 
-    void setOffset(double val) {
+    void setOffset(double val) override {
         val = ClampAndRound(val, VC_MIN_OFFSET, VC_MAX_OFFSET);
         if (myTempo && myTempo->offset != val) {
             stopTweaking(false);
@@ -443,19 +440,19 @@ struct TempoManImpl : public TempoMan {
         }
     }
 
-    void setDefaultBpm() {
+    void setDefaultBpm() override {
         if (myTempo && myTempo->displayBpmType != BPM_ACTUAL) {
             myQueueDisplayBpm({BPM_ACTUAL, myTempo->displayBpmRange});
         }
     }
 
-    void setRandomBpm() {
+    void setRandomBpm() override {
         if (myTempo && myTempo->displayBpmType != BPM_RANDOM) {
             myQueueDisplayBpm({BPM_RANDOM, myTempo->displayBpmRange});
         }
     }
 
-    void setCustomBpm(BpmRange range) {
+    void setCustomBpm(BpmRange range) override {
         if (myTempo && (myTempo->displayBpmType != BPM_CUSTOM ||
                         Differs(myTempo->displayBpmRange, range))) {
             myQueueDisplayBpm({BPM_CUSTOM, range});
@@ -465,16 +462,14 @@ struct TempoManImpl : public TempoMan {
     // ================================================================================================
     // TempoManImpl :: clipboard functions.
 
-    void copyToClipboard() {
+    void copyToClipboard() override {
         SegmentGroup clipboard;
 
         // Copy all the selected segments.
         auto boxes = gTempoBoxes->getBoxes();
-        for (auto list = myTempo->segments->begin(),
-                  listEnd = myTempo->segments->end();
-             list != listEnd; ++list) {
-            auto type = list->type();
-            auto seg = list->begin(), end = list->end();
+        for (auto & segment : *myTempo->segments) {
+            auto type = segment.type();
+            auto seg = segment.begin(), end = segment.end();
             auto box = boxes.begin(), boxEnd = boxes.end();
             while (seg != end && box != boxEnd) {
                 if (box->isSelected == 0 || box->type != type ||
@@ -491,17 +486,15 @@ struct TempoManImpl : public TempoMan {
 
         // Find out what the first row is.
         int row = INT_MAX;
-        for (auto list = clipboard.begin(), listEnd = clipboard.end();
-             list != listEnd; ++list) {
-            if (list->size()) {
-                row = min(row, list->begin()->row);
+        for (auto & list : clipboard) {
+            if (list.size()) {
+                row = min(row, list.begin()->row);
             }
         }
 
         // Offset all segments to row zero.
-        for (auto list = clipboard.begin(), listEnd = clipboard.end();
-             list != listEnd; ++list) {
-            for (auto seg = list->begin(), end = list->end(); seg != end;
+        for (auto & list : clipboard) {
+            for (auto seg = list.begin(), end = list.end(); seg != end;
                  ++seg) {
                 seg->row -= row;
             }
@@ -516,7 +509,7 @@ struct TempoManImpl : public TempoMan {
         }
     }
 
-    void pasteFromClipboard(bool insert) {
+    void pasteFromClipboard(bool insert) override {
         SegmentEdit clipboard;
 
         // Decode the clipboard data.
@@ -530,9 +523,8 @@ struct TempoManImpl : public TempoMan {
 
         // Offset all segments to the cursor row.
         int row = gView->getCursorRow();
-        for (auto list = clipboard.add.begin(), listEnd = clipboard.add.end();
-             list != listEnd; ++list) {
-            for (auto seg = list->begin(), end = list->end(); seg != end;
+        for (auto & list : clipboard.add) {
+            for (auto seg = list.begin(), end = list.end(); seg != end;
                  ++seg) {
                 seg->row += row;
             }
@@ -545,7 +537,7 @@ struct TempoManImpl : public TempoMan {
     // ================================================================================================
     // TempoManImpl :: tweak functions.
 
-    void startTweakingOffset() {
+    void startTweakingOffset() override {
         if (myTweakMode == TWEAK_OFFSET || !myTempo) return;
 
         stopTweaking(false);
@@ -556,7 +548,7 @@ struct TempoManImpl : public TempoMan {
         myTweakValue = myTempo->offset;
     }
 
-    void startTweakingBpm(int row) {
+    void startTweakingBpm(int row) override {
         row = max(0, row);
 
         if ((myTweakMode == TWEAK_BPM && myTweakRow == row) || !myTempo) return;
@@ -569,7 +561,7 @@ struct TempoManImpl : public TempoMan {
         myTweakValue = getBpm(row);
     }
 
-    void startTweakingStop(int row) {
+    void startTweakingStop(int row) override {
         if ((myTweakMode == TWEAK_STOP && myTweakRow == row) || !myTempo)
             return;
 
@@ -581,7 +573,7 @@ struct TempoManImpl : public TempoMan {
         myTweakValue = myTempo->segments->getRow<Stop>(myTweakRow).seconds;
     }
 
-    void setTweakValue(double value) {
+    void setTweakValue(double value) override {
         myTweakValue = value;
         if (myTweakMode == TWEAK_OFFSET) {
             myTweakTempo->offset = value;
@@ -595,7 +587,7 @@ struct TempoManImpl : public TempoMan {
         gEditor->reportChanges(VCM_TEMPO_CHANGED);
     }
 
-    void stopTweaking(bool apply) {
+    void stopTweaking(bool apply) override {
         if (myTweakMode == TWEAK_NONE) return;
 
         TweakMode mode = myTweakMode;
@@ -628,23 +620,23 @@ struct TempoManImpl : public TempoMan {
     // ================================================================================================
     // TempoManImpl :: timing functions.
 
-    int timeToRow(double time) const { return myTimingData.timeToRow(time); }
+    int timeToRow(double time) const override { return myTimingData.timeToRow(time); }
 
-    double timeToBeat(double time) const {
+    double timeToBeat(double time) const override {
         return myTimingData.timeToBeat(time);
     }
 
-    double rowToTime(int row) const { return myTimingData.rowToTime(row); }
+    double rowToTime(int row) const override { return myTimingData.rowToTime(row); }
 
-    double beatToTime(double beat) const {
+    double beatToTime(double beat) const override {
         return myTimingData.beatToTime(beat);
     }
 
-    double beatToMeasure(double beat) const {
+    double beatToMeasure(double beat) const override {
         return myTimingData.beatToMeasure(beat);
     }
 
-    double getBpm(int row) const {
+    double getBpm(int row) const override {
         if (myTweakTempo) {
             return myTweakTempo->segments->getRecent<BpmChange>(row).bpm;
         } else if (myTempo) {
@@ -653,26 +645,26 @@ struct TempoManImpl : public TempoMan {
         return SIM_DEFAULT_BPM;
     }
 
-    double rowToScroll(int row) const { return myTimingData.rowToScroll(row); }
+    double rowToScroll(int row) const override { return myTimingData.rowToScroll(row); }
 
-    double beatToScroll(double beat) const {
+    double beatToScroll(double beat) const override {
         return myTimingData.beatToScroll(beat);
     }
 
-    double positionToSpeed(double beat, double time) const {
+    double positionToSpeed(double beat, double time) const override {
         return myTimingData.positionToSpeed(beat, time);
     }
 
     // ================================================================================================
     // TempoManImpl :: get functions.
 
-    TweakMode getTweakMode() const { return myTweakMode; }
+    TweakMode getTweakMode() const override { return myTweakMode; }
 
-    double getTweakValue() const { return myTweakValue; }
+    double getTweakValue() const override { return myTweakValue; }
 
-    int getTweakRow() const { return myTweakRow; }
+    int getTweakRow() const override { return myTweakRow; }
 
-    double getOffset() const {
+    double getOffset() const override {
         if (myTweakTempo) {
             return myTweakTempo->offset;
         } else if (myTempo) {
@@ -681,7 +673,7 @@ struct TempoManImpl : public TempoMan {
         return 0.0;
     }
 
-    TimingMode getTimingMode() const {
+    TimingMode getTimingMode() const override {
         bool splitTiming = false;
         for (auto chart : mySimfile->charts) {
             if (chart->hasTempo()) {
@@ -696,15 +688,15 @@ struct TempoManImpl : public TempoMan {
         return TIMING_UNIFIED;
     }
 
-    DisplayBpm getDisplayBpmType() const {
+    DisplayBpm getDisplayBpmType() const override {
         return myTempo ? myTempo->displayBpmType : BPM_ACTUAL;
     }
 
-    BpmRange getDisplayBpmRange() const {
+    BpmRange getDisplayBpmRange() const override {
         return myTempo ? myTempo->displayBpmRange : BpmRange{0.0, 0.0};
     }
 
-    BpmRange getBpmRange() const {
+    BpmRange getBpmRange() const override {
         double low = DBL_MAX, high = 0;
         if (myTempo) {
             auto it = myTempo->segments->begin<BpmChange>();
@@ -719,9 +711,9 @@ struct TempoManImpl : public TempoMan {
         return (high >= low) ? BpmRange{low, high} : BpmRange{0, 0};
     }
 
-    const TimingData& getTimingData() const { return myTimingData; }
+    const TimingData& getTimingData() const override { return myTimingData; }
 
-    const SegmentGroup* getSegments() const {
+    const SegmentGroup* getSegments() const override {
         if (myTweakTempo) {
             return myTweakTempo->segments;
         } else if (myTempo) {
@@ -733,7 +725,7 @@ struct TempoManImpl : public TempoMan {
     // ================================================================================================
     // TempoManImpl :: visual sync
 
-    void injectBoundingBpmChange(const int target_row) {
+    void injectBoundingBpmChange(const int target_row) override {
         if (target_row <= 0) {
             return;
         }
@@ -752,7 +744,7 @@ struct TempoManImpl : public TempoMan {
     }
 
     void destructiveShiftRowToTime(const int target_row,
-                                   const double target_time) {
+                                   const double target_time) override {
         if (target_row <= 0) {
             this->setOffset(-target_time);
             return;
@@ -772,7 +764,7 @@ struct TempoManImpl : public TempoMan {
     }
 
     void nonDestructiveShiftRowToTime(const int target_row,
-                                      const double target_time) {
+                                      const double target_time) override {
         if (target_row <= 0) {
             this->setOffset(-target_time);
             return;

--- a/src/Simfile/Chart.cpp
+++ b/src/Simfile/Chart.cpp
@@ -12,7 +12,7 @@ Chart::Chart()
     : style(nullptr), difficulty(DIFF_BEGINNER), meter(1), tempo(nullptr) {}
 
 Chart::~Chart() {
-    style = 0;
+    style = nullptr;
     difficulty = DIFF_BEGINNER;
     meter = 1;
     delete tempo;

--- a/src/Simfile/LoadDwi.cpp
+++ b/src/Simfile/LoadDwi.cpp
@@ -197,7 +197,8 @@ static char* ReadNoteRow(char* p, NoteList& out, int row, const int* map,
                 hold->type = NOTE_STEP_OR_HOLD;
                 holds[col] = 0;
             } else {
-                out.append({row, row, static_cast<uint32_t>(col), 0, NOTE_STEP_OR_HOLD,
+                out.append({row, row, static_cast<uint32_t>(col), 0,
+                            NOTE_STEP_OR_HOLD,
                             static_cast<uint32_t>(quantization)});
                 if (cols[col] & HOLD_BIT) {
                     holds[col] = out.size();

--- a/src/Simfile/LoadDwi.cpp
+++ b/src/Simfile/LoadDwi.cpp
@@ -197,8 +197,8 @@ static char* ReadNoteRow(char* p, NoteList& out, int row, const int* map,
                 hold->type = NOTE_STEP_OR_HOLD;
                 holds[col] = 0;
             } else {
-                out.append({row, row, (uint32_t)col, 0, NOTE_STEP_OR_HOLD,
-                            (uint32_t)quantization});
+                out.append({row, row, static_cast<uint32_t>(col), 0, NOTE_STEP_OR_HOLD,
+                            static_cast<uint32_t>(quantization)});
                 if (cols[col] & HOLD_BIT) {
                     holds[col] = out.size();
                 }

--- a/src/Simfile/LoadOsu.cpp
+++ b/src/Simfile/LoadOsu.cpp
@@ -324,8 +324,8 @@ static void AssignDifficulties(Simfile* sim,
             }
         }
         int numMatches = 0;
-        for (auto& matche : matches) {
-            if (matche) ++numMatches;
+        for (auto& match : matches) {
+            if (match) ++numMatches;
         }
         if (numMatches > bestNumMatches) {
             bestNumMatches = numMatches;

--- a/src/Simfile/LoadOsu.cpp
+++ b/src/Simfile/LoadOsu.cpp
@@ -314,7 +314,7 @@ static void AssignDifficulties(Simfile* sim,
     int bestNumMatches = 0;
 
     // Find the set of difficulties that has the most matches with the charts.
-    for (auto & difficultyString : difficultyStrings) {
+    for (auto& difficultyString : difficultyStrings) {
         Chart* matches[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
         for (int i = 0; i < charts.size(); ++i) {
             for (int j = 0; j < 5; ++j) {
@@ -324,7 +324,7 @@ static void AssignDifficulties(Simfile* sim,
             }
         }
         int numMatches = 0;
-        for (auto & matche : matches) {
+        for (auto& matche : matches) {
             if (matche) ++numMatches;
         }
         if (numMatches > bestNumMatches) {
@@ -431,11 +431,11 @@ static void ConvertNotes(Simfile* sim, OsuFile& osu, Chart& chart) {
         int row = tracker.advance(hitObject.time);
         if (hitObject.endtime > hitObject.time) {
             int endrow = timing.timeToRow(hitObject.endtime);
-            chart.notes.append(
-                {row, endrow, static_cast<uint32_t>(col), 0, NOTE_STEP_OR_HOLD, 192});
+            chart.notes.append({row, endrow, static_cast<uint32_t>(col), 0,
+                                NOTE_STEP_OR_HOLD, 192});
         } else {
-            chart.notes.append(
-                {row, row, static_cast<uint32_t>(col), 0, NOTE_STEP_OR_HOLD, 192});
+            chart.notes.append({row, row, static_cast<uint32_t>(col), 0,
+                                NOTE_STEP_OR_HOLD, 192});
         }
     }
 }

--- a/src/Simfile/LoadOsu.cpp
+++ b/src/Simfile/LoadOsu.cpp
@@ -132,7 +132,7 @@ static int NoteVal(const char*& p) {
     if (end) p = end;
     while (*p && *p != ',') ++p;
     if (*p == ',') ++p;
-    return (int)out;
+    return static_cast<int>(out);
 }
 
 static double NoteValf(const char*& p) {
@@ -141,7 +141,7 @@ static double NoteValf(const char*& p) {
     if (end) p = end;
     while (*p && *p != ',') ++p;
     if (*p == ',') ++p;
-    return (int)out;
+    return static_cast<int>(out);
 }
 
 static void SkipNoteVal(const char*& p) {
@@ -310,22 +310,22 @@ static void AssignDifficulties(Simfile* sim,
     if (sim->charts.empty()) return;
 
     auto& charts = sim->charts;
-    Chart* bestMatches[5] = {0, 0, 0, 0, 0};
+    Chart* bestMatches[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
     int bestNumMatches = 0;
 
     // Find the set of difficulties that has the most matches with the charts.
-    for (int set = 0; set < 6; ++set) {
-        Chart* matches[5] = {0, 0, 0, 0, 0};
+    for (auto & difficultyString : difficultyStrings) {
+        Chart* matches[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
         for (int i = 0; i < charts.size(); ++i) {
             for (int j = 0; j < 5; ++j) {
-                if (versions[i] == difficultyStrings[set][j]) {
+                if (versions[i] == difficultyString[j]) {
                     matches[j] = charts[i];
                 }
             }
         }
         int numMatches = 0;
-        for (int i = 0; i < 5; ++i) {
-            if (matches[i]) ++numMatches;
+        for (auto & matche : matches) {
+            if (matche) ++numMatches;
         }
         if (numMatches > bestNumMatches) {
             bestNumMatches = numMatches;
@@ -342,7 +342,7 @@ static void AssignDifficulties(Simfile* sim,
         }
         for (int i = 0; i < 5; ++i) {
             if (bestMatches[i]) {
-                bestMatches[i]->difficulty = (Difficulty)i;
+                bestMatches[i]->difficulty = static_cast<Difficulty>(i);
             }
         }
     } else  // No matches, sort by number of notes and assign upwards.
@@ -353,7 +353,7 @@ static void AssignDifficulties(Simfile* sim,
                   });
         int offset = max(0, min(charts[0]->meter / 2, 5 - charts.size()));
         for (int i = 0; i < charts.size(); ++i) {
-            charts[i]->difficulty = (Difficulty)(offset + i);
+            charts[i]->difficulty = static_cast<Difficulty>(offset + i);
         }
     }
 }
@@ -392,7 +392,7 @@ static void ConvertTimingPoints(Simfile* sim, OsuFile& osu) {
         double curRow = prevRow + deltaRows;
 
         // Round the row.
-        int row = (int)(curRow + 0.5);
+        int row = static_cast<int>(curRow + 0.5);
         tempo->segments->append(BpmChange(row, it->second.bpm));
 
         // Advance to the next BPM change
@@ -432,10 +432,10 @@ static void ConvertNotes(Simfile* sim, OsuFile& osu, Chart& chart) {
         if (hitObject.endtime > hitObject.time) {
             int endrow = timing.timeToRow(hitObject.endtime);
             chart.notes.append(
-                {row, endrow, (uint32_t)col, 0, NOTE_STEP_OR_HOLD, 192});
+                {row, endrow, static_cast<uint32_t>(col), 0, NOTE_STEP_OR_HOLD, 192});
         } else {
             chart.notes.append(
-                {row, row, (uint32_t)col, 0, NOTE_STEP_OR_HOLD, 192});
+                {row, row, static_cast<uint32_t>(col), 0, NOTE_STEP_OR_HOLD, 192});
         }
     }
 }

--- a/src/Simfile/LoadSm.cpp
+++ b/src/Simfile/LoadSm.cpp
@@ -301,11 +301,11 @@ static void ReadNoteRow(ReadNoteData& data, int row, char* p,
         if (*p == '0') {
             // Do nothing.
         } else if (*p == '1') {
-            data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player,
-                                NOTE_STEP_OR_HOLD, (uint32_t)quantization});
+            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
+                                NOTE_STEP_OR_HOLD, static_cast<uint32_t>(quantization)});
         } else if (*p == '2' || *p == '4') {
-            data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player,
-                                NOTE_STEP_OR_HOLD, (uint32_t)quantization});
+            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
+                                NOTE_STEP_OR_HOLD, static_cast<uint32_t>(quantization)});
             data.holdType[col] = (*p == '2') ? NOTE_STEP_OR_HOLD : NOTE_ROLL;
             data.holdPos[col] = data.notes->size();
             data.quants[col] = quantization;
@@ -332,14 +332,14 @@ static void ReadNoteRow(ReadNoteData& data, int row, char* p,
                 data.quants[col] = 0;
             }
         } else if (*p == 'M') {
-            data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player,
-                                NOTE_MINE, (uint32_t)quantization});
+            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
+                                NOTE_MINE, static_cast<uint32_t>(quantization)});
         } else if (*p == 'L') {
-            data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player,
-                                NOTE_LIFT, (uint32_t)quantization});
+            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
+                                NOTE_LIFT, static_cast<uint32_t>(quantization)});
         } else if (*p == 'F') {
-            data.notes->append({row, row, (uint32_t)col, (uint32_t)data.player,
-                                NOTE_FAKE, (uint32_t)quantization});
+            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
+                                NOTE_FAKE, static_cast<uint32_t>(quantization)});
         }
     }
 }
@@ -418,7 +418,7 @@ static void ParseNotes(ParseData& data, Chart* chart, const std::string& style,
                 for (int i = 4; i < ROWS_PER_NOTE_SECTION; i++) {
                     bool valid = true;
                     line = measureText;
-                    float mod = (float)ROWS_PER_NOTE_SECTION / i;
+                    float mod = static_cast<float>(ROWS_PER_NOTE_SECTION) / i;
                     for (int j = 0; valid && j < ROWS_PER_NOTE_SECTION;
                          ++j, line += numCols) {
                         float rem = round(fmod(j, mod));
@@ -447,8 +447,8 @@ static void ParseNotes(ParseData& data, Chart* chart, const std::string& style,
 
                 // Handle abnormal numbers of lines loading
                 if (ROWS_PER_NOTE_SECTION % numLines != 0) {
-                    ofs = ((int)round(192.0f / numLines * (i + 1)) -
-                           (int)round(192.0f / numLines * i));
+                    ofs = (static_cast<int>(round(192.0f / numLines * (i + 1))) -
+                           static_cast<int>(round(192.0f / numLines * i)));
                 }
                 line += numCols;
                 row += ofs;

--- a/src/Simfile/LoadSm.cpp
+++ b/src/Simfile/LoadSm.cpp
@@ -301,11 +301,15 @@ static void ReadNoteRow(ReadNoteData& data, int row, char* p,
         if (*p == '0') {
             // Do nothing.
         } else if (*p == '1') {
-            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
-                                NOTE_STEP_OR_HOLD, static_cast<uint32_t>(quantization)});
+            data.notes->append({row, row, static_cast<uint32_t>(col),
+                                static_cast<uint32_t>(data.player),
+                                NOTE_STEP_OR_HOLD,
+                                static_cast<uint32_t>(quantization)});
         } else if (*p == '2' || *p == '4') {
-            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
-                                NOTE_STEP_OR_HOLD, static_cast<uint32_t>(quantization)});
+            data.notes->append({row, row, static_cast<uint32_t>(col),
+                                static_cast<uint32_t>(data.player),
+                                NOTE_STEP_OR_HOLD,
+                                static_cast<uint32_t>(quantization)});
             data.holdType[col] = (*p == '2') ? NOTE_STEP_OR_HOLD : NOTE_ROLL;
             data.holdPos[col] = data.notes->size();
             data.quants[col] = quantization;
@@ -332,14 +336,17 @@ static void ReadNoteRow(ReadNoteData& data, int row, char* p,
                 data.quants[col] = 0;
             }
         } else if (*p == 'M') {
-            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
-                                NOTE_MINE, static_cast<uint32_t>(quantization)});
+            data.notes->append({row, row, static_cast<uint32_t>(col),
+                                static_cast<uint32_t>(data.player), NOTE_MINE,
+                                static_cast<uint32_t>(quantization)});
         } else if (*p == 'L') {
-            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
-                                NOTE_LIFT, static_cast<uint32_t>(quantization)});
+            data.notes->append({row, row, static_cast<uint32_t>(col),
+                                static_cast<uint32_t>(data.player), NOTE_LIFT,
+                                static_cast<uint32_t>(quantization)});
         } else if (*p == 'F') {
-            data.notes->append({row, row, static_cast<uint32_t>(col), static_cast<uint32_t>(data.player),
-                                NOTE_FAKE, static_cast<uint32_t>(quantization)});
+            data.notes->append({row, row, static_cast<uint32_t>(col),
+                                static_cast<uint32_t>(data.player), NOTE_FAKE,
+                                static_cast<uint32_t>(quantization)});
         }
     }
 }
@@ -447,8 +454,9 @@ static void ParseNotes(ParseData& data, Chart* chart, const std::string& style,
 
                 // Handle abnormal numbers of lines loading
                 if (ROWS_PER_NOTE_SECTION % numLines != 0) {
-                    ofs = (static_cast<int>(round(192.0f / numLines * (i + 1))) -
-                           static_cast<int>(round(192.0f / numLines * i)));
+                    ofs =
+                        (static_cast<int>(round(192.0f / numLines * (i + 1))) -
+                         static_cast<int>(round(192.0f / numLines * i)));
                 }
                 line += numCols;
                 row += ofs;

--- a/src/Simfile/NoteList.cpp
+++ b/src/Simfile/NoteList.cpp
@@ -454,12 +454,14 @@ static void ApplyQuantOffset(Note& out, int offsetRows) {
     // (int) round(192.0f / out.quant * (above) then make this the new measure
     // offset
     if (192 % out.quant > 0 && startingOffset != endingOffset) {
-        out.row = out.row - endingOffset +
-                  static_cast<int>(round(192.0f / out.quant *
-                             round(endingOffset / 192.0f * out.quant)));
+        out.row =
+            out.row - endingOffset +
+            static_cast<int>(round(192.0f / out.quant *
+                                   round(endingOffset / 192.0f * out.quant)));
         out.endrow = out.endrow - endingRowOffset +
-                     static_cast<int>(round(192.0f / out.quant *
-                                round(endingRowOffset / 192.0f * out.quant)));
+                     static_cast<int>(
+                         round(192.0f / out.quant *
+                               round(endingRowOffset / 192.0f * out.quant)));
     }
 }
 

--- a/src/Simfile/NoteList.cpp
+++ b/src/Simfile/NoteList.cpp
@@ -20,7 +20,7 @@ namespace Vortex {
 namespace {
 
 inline int64_t NotePos(const Note* n) {
-    return ((int64_t)n->row << 8) | n->col;
+    return (static_cast<int64_t>(n->row) << 8) | n->col;
 }
 
 template <typename T, typename R>
@@ -169,7 +169,7 @@ void NoteList::cleanup() {
         write += offset;
     }
 
-    myNum = (int)(write - myNotes);
+    myNum = static_cast<int>(write - myNotes);
 }
 
 void NoteList::sanitize(const Chart* chart) {
@@ -204,10 +204,10 @@ void NoteList::sanitize(const Chart* chart) {
 
     // Make sure all notes are valid, sorted, and do not overlap.
     for (auto& note : *this) {
-        if (note.col >= (uint32_t)numCols) {
+        if (note.col >= static_cast<uint32_t>(numCols)) {
             ++numInvalidCols;
             note.row = -1;
-        } else if (note.player >= (uint32_t)numPlayers) {
+        } else if (note.player >= static_cast<uint32_t>(numPlayers)) {
             ++numInvalidPlayers;
             note.row = -1;
         } else if (note.row <= endrows[note.col]) {
@@ -222,7 +222,7 @@ void NoteList::sanitize(const Chart* chart) {
         } else {
             col = note.col;
             row = note.row;
-            endrows[note.col] = (int)note.endrow;
+            endrows[note.col] = note.endrow;
         }
     }
 
@@ -455,11 +455,11 @@ static void ApplyQuantOffset(Note& out, int offsetRows) {
     // offset
     if (192 % out.quant > 0 && startingOffset != endingOffset) {
         out.row = out.row - endingOffset +
-                  (int)round(192.0f / out.quant *
-                             round(endingOffset / 192.0f * out.quant));
+                  static_cast<int>(round(192.0f / out.quant *
+                             round(endingOffset / 192.0f * out.quant)));
         out.endrow = out.endrow - endingRowOffset +
-                     (int)round(192.0f / out.quant *
-                                round(endingRowOffset / 192.0f * out.quant));
+                     static_cast<int>(round(192.0f / out.quant *
+                                round(endingRowOffset / 192.0f * out.quant)));
     }
 }
 
@@ -555,7 +555,7 @@ void NoteList::myReserve(int num) {
     int numBytes = num * sizeof(Note);
     if (myCap < numBytes) {
         myCap = max(numBytes, myCap << 1);
-        myNotes = (Note*)realloc(myNotes, myCap);
+        myNotes = static_cast<Note*>(realloc(myNotes, myCap));
     }
 }
 

--- a/src/Simfile/Parsing.cpp
+++ b/src/Simfile/Parsing.cpp
@@ -159,7 +159,7 @@ bool ParseVal(const char* str, int& outInt) {
 bool ParseBeat(const char* str, int& outRow) {
     double beat;
     if (!ParseVal(str, beat)) return false;
-    outRow = (int)(beat * 48 + 0.5);
+    outRow = static_cast<int>(beat * 48 + 0.5);
     return true;
 }
 

--- a/src/Simfile/SaveOsu.cpp
+++ b/src/Simfile/SaveOsu.cpp
@@ -28,7 +28,9 @@ namespace {
 // ===================================================================================
 // Exporting utilities.
 
-static int ToMilliseconds(double time) { return static_cast<int>(time * 1000.0 + 0.5); }
+static int ToMilliseconds(double time) {
+    return static_cast<int>(time * 1000.0 + 0.5);
+}
 
 static void WriteBlock(std::ofstream& out, const char* name) {
     out << "\n[" << name << "]\n";
@@ -66,9 +68,9 @@ static int FindNextRow(const Vector<T>& list, int row) {
 }
 
 static int FindNextNoteRow(const NoteList& list, int row) {
-    const Note* it = std::lower_bound(
-        list.begin(), list.end(), row,
-        [](const Note& a, int row) { return a.row < row; });
+    const Note* it =
+        std::lower_bound(list.begin(), list.end(), row,
+                         [](const Note& a, int row) { return a.row < row; });
     while (it != list.end() && it->type != NOTE_STEP_OR_HOLD) ++it;
     return (it != list.end()) ? it->row : INT_MAX;
 }

--- a/src/Simfile/SaveOsu.cpp
+++ b/src/Simfile/SaveOsu.cpp
@@ -28,7 +28,7 @@ namespace {
 // ===================================================================================
 // Exporting utilities.
 
-static int ToMilliseconds(double time) { return (int)(time * 1000.0 + 0.5); }
+static int ToMilliseconds(double time) { return static_cast<int>(time * 1000.0 + 0.5); }
 
 static void WriteBlock(std::ofstream& out, const char* name) {
     out << "\n[" << name << "]\n";
@@ -68,7 +68,7 @@ static int FindNextRow(const Vector<T>& list, int row) {
 static int FindNextNoteRow(const NoteList& list, int row) {
     const Note* it = std::lower_bound(
         list.begin(), list.end(), row,
-        [](const Note& a, int row) { return (int)a.row < row; });
+        [](const Note& a, int row) { return a.row < row; });
     while (it != list.end() && it->type != NOTE_STEP_OR_HOLD) ++it;
     return (it != list.end()) ? it->row : INT_MAX;
 }

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -30,7 +30,7 @@ static const int NUM_MEASURE_SUBDIV = 10;
 static const int ROWS_PER_NOTE_SECTION = 192;
 static const int MIN_SECTIONS_PER_MEASURE = 4;
 
-static double ToBeat(int row) { return (double)row / ROWS_PER_BEAT; }
+static double ToBeat(int row) { return static_cast<double>(row) / ROWS_PER_BEAT; }
 
 struct ExportData {
     Vector<int> diffs;
@@ -385,9 +385,9 @@ static std::string RadarToString(const Vector<double>& list) {
     if (list.empty()) {
         out = "0,0,0,0,0";
     } else {
-        for (auto it = list.begin(); it != list.end(); ++it) {
+        for (double it : list) {
             if (out.length()) Str::append(out, ',');
-            Str::appendVal(out, *it, 0, 6);
+            Str::appendVal(out, it, 0, 6);
         }
     }
     return out;
@@ -412,7 +412,7 @@ static const char* GetDifficultyString(Difficulty difficulty) {
 static inline bool TestSectionCompression(const char* section, int width,
                                           int quant) {
     std::string zeroline(width, '0');
-    float mod = (float)ROWS_PER_NOTE_SECTION / quant;
+    float mod = static_cast<float>(ROWS_PER_NOTE_SECTION) / quant;
     for (int j = 0; j < ROWS_PER_NOTE_SECTION; ++j) {
         float rem = round(fmod(j, mod));
         // Check all the compressed rows and make sure they are empty
@@ -473,11 +473,11 @@ static void WriteSections(ExportData& data) {
             int endRow = startRow + ROWS_PER_NOTE_SECTION;
 
             // Advance to the first note in the current section.
-            for (; it != end && (int)it->row < startRow; ++it);
+            for (; it != end && it->row < startRow; ++it);
 
             // Write the notes of the current player to the section data.
-            for (; it != end && (int)it->row < endRow; ++it) {
-                if ((int)it->player == pn) {
+            for (; it != end && it->row < endRow; ++it) {
+                if (static_cast<int>(it->player) == pn) {
                     int pos = (it->row - startRow) * numCols + it->col;
                     if (it->row == it->endrow) {
                         section[pos] = GetNoteChar(it->type);
@@ -485,11 +485,11 @@ static void WriteSections(ExportData& data) {
                         section[pos] = GetHoldChar(it->type);
                         auto hold = holds[it->col];
                         if (hold) {
-                            if ((int)hold->endrow >= startRow &&
-                                (int)hold->endrow < endRow) {
+                            if (hold->endrow >= startRow &&
+                                hold->endrow < endRow) {
                                 int pos =
-                                    ((int)hold->endrow - startRow) * numCols +
-                                    (int)hold->col;
+                                    (hold->endrow - startRow) * numCols +
+                                    static_cast<int>(hold->col);
                                 section[pos] = '3';
                                 --remainingHolds;
                             }
@@ -505,8 +505,8 @@ static void WriteSections(ExportData& data) {
                 for (int col = 0; col < numCols; ++col) {
                     auto hold = holds[col];
                     if (hold) {
-                        if ((int)hold->endrow >= startRow &&
-                            (int)hold->endrow < endRow) {
+                        if (hold->endrow >= startRow &&
+                            hold->endrow < endRow) {
                             int pos =
                                 (hold->endrow - startRow) * numCols + hold->col;
                             section[pos] = '3';

--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -30,7 +30,9 @@ static const int NUM_MEASURE_SUBDIV = 10;
 static const int ROWS_PER_NOTE_SECTION = 192;
 static const int MIN_SECTIONS_PER_MEASURE = 4;
 
-static double ToBeat(int row) { return static_cast<double>(row) / ROWS_PER_BEAT; }
+static double ToBeat(int row) {
+    return static_cast<double>(row) / ROWS_PER_BEAT;
+}
 
 struct ExportData {
     Vector<int> diffs;
@@ -487,9 +489,8 @@ static void WriteSections(ExportData& data) {
                         if (hold) {
                             if (hold->endrow >= startRow &&
                                 hold->endrow < endRow) {
-                                int pos =
-                                    (hold->endrow - startRow) * numCols +
-                                    static_cast<int>(hold->col);
+                                int pos = (hold->endrow - startRow) * numCols +
+                                          static_cast<int>(hold->col);
                                 section[pos] = '3';
                                 --remainingHolds;
                             }
@@ -505,8 +506,7 @@ static void WriteSections(ExportData& data) {
                 for (int col = 0; col < numCols; ++col) {
                     auto hold = holds[col];
                     if (hold) {
-                        if (hold->endrow >= startRow &&
-                            hold->endrow < endRow) {
+                        if (hold->endrow >= startRow && hold->endrow < endRow) {
                             int pos =
                                 (hold->endrow - startRow) * numCols + hold->col;
                             section[pos] = '3';

--- a/src/Simfile/SegmentGroup.cpp
+++ b/src/Simfile/SegmentGroup.cpp
@@ -14,7 +14,7 @@ SegmentGroup::SegmentGroup() {
     ForEachType(type) { myLists[type].setType(type); }
 }
 
-SegmentGroup::~SegmentGroup() {}
+SegmentGroup::~SegmentGroup() = default;
 
 void SegmentGroup::clear() {
     ForEachType(type) { myLists[type].clear(); }

--- a/src/Simfile/SegmentList.cpp
+++ b/src/Simfile/SegmentList.cpp
@@ -13,15 +13,15 @@ namespace Vortex {
 namespace {
 
 inline Segment* ofs(void* pos, int offset) {
-    return (Segment*)(((uint8_t*)pos) + offset);
+    return reinterpret_cast<Segment*>((static_cast<uint8_t*>(pos)) + offset);
 }
 
 inline const Segment* ofs(const void* pos, int offset) {
-    return (const Segment*)(((const uint8_t*)pos) + offset);
+    return reinterpret_cast<const Segment*>((static_cast<const uint8_t*>(pos)) + offset);
 }
 
 inline int diff(const Segment* begin, const Segment* end) {
-    return ((const uint8_t*)end) - ((const uint8_t*)begin);
+    return (reinterpret_cast<const uint8_t*>(end)) - (reinterpret_cast<const uint8_t*>(begin));
 }
 
 };  // anonymous namespace.
@@ -96,7 +96,7 @@ void SegmentList::clear() {
         auto meta = Segment::meta[myType];
         for (int i = 0; i < myNum; ++i) {
             uint8_t* seg = mySegs + i * myStride;
-            meta->destruct((Segment*)seg);
+            meta->destruct(reinterpret_cast<Segment*>(seg));
         }
     }
     myNum = 0;
@@ -442,36 +442,36 @@ void SegmentList::prepareEdit(const List& inAdd, const List& inRem,
 // SegmentList :: iterators.
 
 SegmentIter SegmentList::begin() {
-    return {(Segment*)mySegs, (uint32_t)myStride};
+    return {reinterpret_cast<Segment*>(mySegs), static_cast<uint32_t>(myStride)};
 }
 
 SegmentConstIter SegmentList::begin() const {
-    return {(const Segment*)mySegs, (uint32_t)myStride};
+    return {reinterpret_cast<const Segment*>(mySegs), static_cast<uint32_t>(myStride)};
 }
 
 SegmentIter SegmentList::end() {
-    return {(Segment*)(mySegs + myNum * myStride), (uint32_t)myStride};
+    return {reinterpret_cast<Segment*>(mySegs + myNum * myStride), static_cast<uint32_t>(myStride)};
 }
 
 SegmentConstIter SegmentList::end() const {
-    return {(const Segment*)(mySegs + myNum * myStride), (uint32_t)myStride};
+    return {reinterpret_cast<const Segment*>(mySegs + myNum * myStride), static_cast<uint32_t>(myStride)};
 }
 
 SegmentIter SegmentList::rbegin() {
-    return {(Segment*)(mySegs + (myNum - 1) * myStride), (uint32_t)myStride};
+    return {reinterpret_cast<Segment*>(mySegs + (myNum - 1) * myStride), static_cast<uint32_t>(myStride)};
 }
 
 SegmentConstIter SegmentList::rbegin() const {
-    return {(const Segment*)(mySegs + (myNum - 1) * myStride),
-            (uint32_t)myStride};
+    return {reinterpret_cast<const Segment*>(mySegs + (myNum - 1) * myStride),
+            static_cast<uint32_t>(myStride)};
 }
 
 SegmentIter SegmentList::rend() {
-    return {(Segment*)(mySegs - myStride), (uint32_t)myStride};
+    return {reinterpret_cast<Segment*>(mySegs - myStride), static_cast<uint32_t>(myStride)};
 }
 
 SegmentConstIter SegmentList::rend() const {
-    return {(const Segment*)(mySegs - myStride), (uint32_t)myStride};
+    return {reinterpret_cast<const Segment*>(mySegs - myStride), static_cast<uint32_t>(myStride)};
 }
 
 // ================================================================================================
@@ -485,14 +485,14 @@ const Segment* SegmentList::find(int row) const {
     while (count > 1) {
         step = count >> 1;
         mid = it + step * myStride;
-        if (((const Segment*)mid)->row <= row) {
+        if ((reinterpret_cast<const Segment*>(mid))->row <= row) {
             it = mid;
             count -= step;
         } else {
             count = step;
         }
     }
-    auto out = (const Segment*)it;
+    auto out = reinterpret_cast<const Segment*>(it);
 
     return (out->row <= row) ? out : nullptr;
 }
@@ -504,7 +504,7 @@ void SegmentList::myReserve(int num) {
     int numBytes = num * myStride;
     if (myCap < numBytes) {
         myCap = max(numBytes, myCap << 1);
-        mySegs = (uint8_t*)realloc(mySegs, myCap);
+        mySegs = static_cast<uint8_t*>(realloc(mySegs, myCap));
     }
 }
 

--- a/src/Simfile/SegmentList.cpp
+++ b/src/Simfile/SegmentList.cpp
@@ -17,11 +17,13 @@ inline Segment* ofs(void* pos, int offset) {
 }
 
 inline const Segment* ofs(const void* pos, int offset) {
-    return reinterpret_cast<const Segment*>((static_cast<const uint8_t*>(pos)) + offset);
+    return reinterpret_cast<const Segment*>((static_cast<const uint8_t*>(pos)) +
+                                            offset);
 }
 
 inline int diff(const Segment* begin, const Segment* end) {
-    return (reinterpret_cast<const uint8_t*>(end)) - (reinterpret_cast<const uint8_t*>(begin));
+    return (reinterpret_cast<const uint8_t*>(end)) -
+           (reinterpret_cast<const uint8_t*>(begin));
 }
 
 };  // anonymous namespace.
@@ -442,23 +444,28 @@ void SegmentList::prepareEdit(const List& inAdd, const List& inRem,
 // SegmentList :: iterators.
 
 SegmentIter SegmentList::begin() {
-    return {reinterpret_cast<Segment*>(mySegs), static_cast<uint32_t>(myStride)};
+    return {reinterpret_cast<Segment*>(mySegs),
+            static_cast<uint32_t>(myStride)};
 }
 
 SegmentConstIter SegmentList::begin() const {
-    return {reinterpret_cast<const Segment*>(mySegs), static_cast<uint32_t>(myStride)};
+    return {reinterpret_cast<const Segment*>(mySegs),
+            static_cast<uint32_t>(myStride)};
 }
 
 SegmentIter SegmentList::end() {
-    return {reinterpret_cast<Segment*>(mySegs + myNum * myStride), static_cast<uint32_t>(myStride)};
+    return {reinterpret_cast<Segment*>(mySegs + myNum * myStride),
+            static_cast<uint32_t>(myStride)};
 }
 
 SegmentConstIter SegmentList::end() const {
-    return {reinterpret_cast<const Segment*>(mySegs + myNum * myStride), static_cast<uint32_t>(myStride)};
+    return {reinterpret_cast<const Segment*>(mySegs + myNum * myStride),
+            static_cast<uint32_t>(myStride)};
 }
 
 SegmentIter SegmentList::rbegin() {
-    return {reinterpret_cast<Segment*>(mySegs + (myNum - 1) * myStride), static_cast<uint32_t>(myStride)};
+    return {reinterpret_cast<Segment*>(mySegs + (myNum - 1) * myStride),
+            static_cast<uint32_t>(myStride)};
 }
 
 SegmentConstIter SegmentList::rbegin() const {
@@ -467,11 +474,13 @@ SegmentConstIter SegmentList::rbegin() const {
 }
 
 SegmentIter SegmentList::rend() {
-    return {reinterpret_cast<Segment*>(mySegs - myStride), static_cast<uint32_t>(myStride)};
+    return {reinterpret_cast<Segment*>(mySegs - myStride),
+            static_cast<uint32_t>(myStride)};
 }
 
 SegmentConstIter SegmentList::rend() const {
-    return {reinterpret_cast<const Segment*>(mySegs - myStride), static_cast<uint32_t>(myStride)};
+    return {reinterpret_cast<const Segment*>(mySegs - myStride),
+            static_cast<uint32_t>(myStride)};
 }
 
 // ================================================================================================

--- a/src/Simfile/Segments.cpp
+++ b/src/Simfile/Segments.cpp
@@ -515,7 +515,7 @@ static const SegmentMeta FakeMeta = {sizeof(Fake),
 // ================================================================================================
 // Label.
 
-Label::Label() {}
+Label::Label() = default;
 
 Label::Label(int row, std::string str) : Segment(row), str(str) {}
 

--- a/src/Simfile/Segments.cpp
+++ b/src/Simfile/Segments.cpp
@@ -16,42 +16,42 @@ namespace Vortex {
 // Low level segment functions.
 
 template <typename T>
-void Encode(WriteStream& out, const T& seg);
+void Encode(WriteStream& out, const T& seg) {};
 
 template <typename T>
-void Decode(ReadStream& in, T& seg);
+void Decode(ReadStream& in, T& seg) {};
 
 template <typename T>
-bool IsRedundant(const T& seg, const T* prev);
+bool IsRedundant(const T& seg, const T* prev) {};
 
 template <typename T>
-bool IsEquivalent(const T& seg, const T& other);
+bool IsEquivalent(const T& seg, const T& other) {};
 
 template <typename T>
-std::string GetDescription(const T& seg);
+std::string GetDescription(const T& seg) {};
 
 // ================================================================================================
 // Segment wrapper functions.
 
 template <typename T>
 static void WrapNew(Segment* seg) {
-    new ((T*)seg) T();
+    new (static_cast<T*>(seg)) T();
 }
 
 template <typename T>
 static void WrapDel(Segment* seg) {
-    (*(T*)seg).~T();
+    (*static_cast<T*>(seg)).~T();
 }
 
 template <typename T>
 static void WrapCpy(Segment* seg, const Segment* src) {
-    *((T*)seg) = *((const T*)src);
+    *(static_cast<T*>(seg)) = *(static_cast<T*>(const_cast<Segment*>(src)));
 }
 
 template <typename T>
 static void WrapEnc(WriteStream& out, const Segment* seg) {
     out.write(seg->row);
-    Encode<T>(out, *(const T*)seg);
+    Encode<T>(out, *static_cast<const T*>(seg));
 }
 
 template <typename T>
@@ -64,17 +64,19 @@ static void WrapDec(ReadStream& in, SegmentGroup* out) {
 
 template <typename T>
 static bool WrapRed(const Segment* seg, const Segment* prev) {
-    return IsRedundant<T>(*(const T*)seg, (const T*)prev);
+    return IsRedundant<T>(*static_cast<const T*>(seg),
+                          static_cast<const T*>(prev));
 }
 
 template <typename T>
 static bool WrapEqu(const Segment* seg, const Segment* other) {
-    return IsEquivalent<T>(*(const T*)seg, *(const T*)other);
+    return IsEquivalent<T>(*static_cast<const T*>(seg),
+                           *static_cast<const T*>(other));
 }
 
 template <typename T>
 static std::string WrapDsc(const Segment* seg) {
-    return GetDescription<T>(*(const T*)seg);
+    return GetDescription<T>(*static_cast<const T*>(seg));
 }
 
 #define WRAP(x)                                                             \

--- a/src/Simfile/TimingData.cpp
+++ b/src/Simfile/TimingData.cpp
@@ -109,7 +109,8 @@ static WarpResult HandleWarp(Vector<Event>& out, MergedTS* it, MergedTS* end,
 
         // Check if the warp ended before the current segments.
         if (spr > 0 && time > targetTime && warpRows == 0) {
-            int warpEndRow = static_cast<int>(row - round((time - targetTime) / spr));
+            int warpEndRow =
+                static_cast<int>(row - round((time - targetTime) / spr));
             if (warpEndRow <= entry->row) {
                 entry->endTime = time;
                 entry->spr = spr;
@@ -124,16 +125,17 @@ static WarpResult HandleWarp(Vector<Event>& out, MergedTS* it, MergedTS* end,
         do {
             switch (it->type) {
                 case Segment::BPM:
-                    spr = SecPerRow(((const BpmChange*)it->seg)->bpm);
+                    spr = SecPerRow(
+                        reinterpret_cast<const BpmChange*>(it->seg)->bpm);
                     break;
                 case Segment::DELAY:
-                    time += ((const Delay*)it->seg)->seconds;
+                    time += reinterpret_cast<const Delay*>(it->seg)->seconds;
                     break;
                 case Segment::STOP:
-                    time += ((const Stop*)it->seg)->seconds;
+                    time += reinterpret_cast<const Stop*>(it->seg)->seconds;
                     break;
                 case Segment::WARP:
-                    warpRows += ((const Warp*)it->seg)->numRows;
+                    warpRows += reinterpret_cast<const Warp*>(it->seg)->numRows;
                     break;
             }
         } while (++it != end && it->seg->row < row);
@@ -155,7 +157,8 @@ static WarpResult HandleWarp(Vector<Event>& out, MergedTS* it, MergedTS* end,
     // If we reach this point, none of the segments caused the warp to end.
     spr = fabs(spr);
     int row = prevRow + warpRows;
-    if (time < targetTime) row += static_cast<int>(round((targetTime - time) / spr));
+    if (time < targetTime)
+        row += static_cast<int>(round((targetTime - time) / spr));
     out.push_back({row, targetTime, targetTime, targetTime, spr});
     return {row, targetTime, it};
 }
@@ -171,16 +174,17 @@ static void CreateEvents(Vector<Event>& out, double time, MergedTS* it,
         do {
             switch (it->type) {
                 case Segment::BPM:
-                    spr = SecPerRow(((const BpmChange*)it->seg)->bpm);
+                    spr = SecPerRow(
+                        reinterpret_cast<const BpmChange*>(it->seg)->bpm);
                     break;
                 case Segment::DELAY:
-                    delay += ((const Delay*)it->seg)->seconds;
+                    delay += reinterpret_cast<const Delay*>(it->seg)->seconds;
                     break;
                 case Segment::STOP:
-                    stop += ((const Stop*)it->seg)->seconds;
+                    stop += reinterpret_cast<const Stop*>(it->seg)->seconds;
                     break;
                 case Segment::WARP:
-                    warp += ((const Warp*)it->seg)->numRows;
+                    warp +=  reinterpret_cast<const Warp*>(it->seg)->numRows;
                     break;
             }
         } while (++it != end && it->seg->row < row);
@@ -404,7 +408,8 @@ static double BeatToTime(const Event* it, double beat) {
 
 static double BeatToMeasure(const TimeSig* sig, double beat) {
     double row = beat * ROWS_PER_BEAT;
-    return sig->measure + (row - sig->row) / static_cast<double>(sig->rowsPerMeasure);
+    return sig->measure +
+           (row - sig->row) / static_cast<double>(sig->rowsPerMeasure);
 }
 
 static double RowToScroll(const ScrollRow* scroll, int row) {
@@ -426,7 +431,8 @@ static double PositionToSpeed(const ScrollSpeed* speed, double beat,
     if (speed->unit == 1) {
         strength = (time - (speed->rowTime)) / speed->delay;
     } else {
-        strength = (beat - (static_cast<double>(speed->row) / ROWS_PER_BEAT)) / speed->delay;
+        strength = (beat - (static_cast<double>(speed->row) / ROWS_PER_BEAT)) /
+                   speed->delay;
     }
 
     return lerp(speed->start, speed->end, clamp(strength, 0.0, 1.0));
@@ -508,7 +514,8 @@ double TimingData::rowToScroll(int row) const {
 }
 
 double TimingData::beatToScroll(double beat) const {
-    int row = static_cast<int>(floor(beat * ROWS_PER_BEAT));  // floor matches games better?
+    int row = static_cast<int>(
+        floor(beat * ROWS_PER_BEAT));  // floor matches games better?
     return BeatToScroll(MostRecentScrollRow(scrolls, row), beat);
 }
 

--- a/src/Simfile/TimingData.cpp
+++ b/src/Simfile/TimingData.cpp
@@ -184,7 +184,7 @@ static void CreateEvents(Vector<Event>& out, double time, MergedTS* it,
                     stop += reinterpret_cast<const Stop*>(it->seg)->seconds;
                     break;
                 case Segment::WARP:
-                    warp +=  reinterpret_cast<const Warp*>(it->seg)->numRows;
+                    warp += reinterpret_cast<const Warp*>(it->seg)->numRows;
                     break;
             }
         } while (++it != end && it->seg->row < row);

--- a/src/Simfile/TimingData.cpp
+++ b/src/Simfile/TimingData.cpp
@@ -109,7 +109,7 @@ static WarpResult HandleWarp(Vector<Event>& out, MergedTS* it, MergedTS* end,
 
         // Check if the warp ended before the current segments.
         if (spr > 0 && time > targetTime && warpRows == 0) {
-            int warpEndRow = (int)(row - round((time - targetTime) / spr));
+            int warpEndRow = static_cast<int>(row - round((time - targetTime) / spr));
             if (warpEndRow <= entry->row) {
                 entry->endTime = time;
                 entry->spr = spr;
@@ -155,7 +155,7 @@ static WarpResult HandleWarp(Vector<Event>& out, MergedTS* it, MergedTS* end,
     // If we reach this point, none of the segments caused the warp to end.
     spr = fabs(spr);
     int row = prevRow + warpRows;
-    if (time < targetTime) row += (int)round((targetTime - time) / spr);
+    if (time < targetTime) row += static_cast<int>(round((targetTime - time) / spr));
     out.push_back({row, targetTime, targetTime, targetTime, spr});
     return {row, targetTime, it};
 }
@@ -242,7 +242,7 @@ static void CreateScrollRows(Vector<ScrollRow>& out, const Scroll* it,
     double rowScroll = 0, ratio = 1;
     if (it != end) {
         row = it->row;
-        rowScroll = (double)it->row;
+        rowScroll = static_cast<double>(it->row);
         ratio = it->ratio;
         out.push_back({row, rowScroll, ratio});
 
@@ -382,7 +382,7 @@ static double TimeToBeat(const Event* it, double time) {
 static int TimeToRow(const Event* it, double time) {
     int row = it->row;
     if (time > it->endTime && it->spr > 0.0) {
-        row += (int)((time - it->endTime) / it->spr);
+        row += static_cast<int>((time - it->endTime) / it->spr);
     }
     return row;
 }
@@ -404,7 +404,7 @@ static double BeatToTime(const Event* it, double beat) {
 
 static double BeatToMeasure(const TimeSig* sig, double beat) {
     double row = beat * ROWS_PER_BEAT;
-    return sig->measure + (row - sig->row) / (double)sig->rowsPerMeasure;
+    return sig->measure + (row - sig->row) / static_cast<double>(sig->rowsPerMeasure);
 }
 
 static double RowToScroll(const ScrollRow* scroll, int row) {
@@ -424,9 +424,9 @@ static double PositionToSpeed(const ScrollSpeed* speed, double beat,
 
     double strength;
     if (speed->unit == 1) {
-        strength = (time - ((double)speed->rowTime)) / speed->delay;
+        strength = (time - (speed->rowTime)) / speed->delay;
     } else {
-        strength = (beat - ((double)speed->row / ROWS_PER_BEAT)) / speed->delay;
+        strength = (beat - (static_cast<double>(speed->row) / ROWS_PER_BEAT)) / speed->delay;
     }
 
     return lerp(speed->start, speed->end, clamp(strength, 0.0, 1.0));
@@ -494,12 +494,12 @@ double TimingData::rowToTime(int row) const {
 }
 
 double TimingData::beatToTime(double beat) const {
-    int row = (int)ceil(beat * ROWS_PER_BEAT);
+    int row = static_cast<int>(ceil(beat * ROWS_PER_BEAT));
     return BeatToTime(MostRecentEvent(events, row), beat);
 }
 
 double TimingData::beatToMeasure(double beat) const {
-    int row = (int)ceil(beat * ROWS_PER_BEAT);
+    int row = static_cast<int>(ceil(beat * ROWS_PER_BEAT));
     return BeatToMeasure(MostRecentTimeSig(sigs, row), beat);
 }
 
@@ -508,12 +508,12 @@ double TimingData::rowToScroll(int row) const {
 }
 
 double TimingData::beatToScroll(double beat) const {
-    int row = (int)floor(beat * ROWS_PER_BEAT);  // floor matches games better?
+    int row = static_cast<int>(floor(beat * ROWS_PER_BEAT));  // floor matches games better?
     return BeatToScroll(MostRecentScrollRow(scrolls, row), beat);
 }
 
 double TimingData::positionToSpeed(double beat, double time) const {
-    int row = (int)ceil(beat * ROWS_PER_BEAT);
+    int row = static_cast<int>(ceil(beat * ROWS_PER_BEAT));
     return PositionToSpeed(MostRecentScrollSpeed(speeds, row), beat, time);
 }
 

--- a/src/System/Debug.cpp
+++ b/src/System/Debug.cpp
@@ -54,12 +54,12 @@ void openConsole() {
 
     AllocConsole();
 
-    long hOut =
-        _open_osfhandle(reinterpret_cast<intptr_t>(GetStdHandle(STD_OUTPUT_HANDLE)), _O_WTEXT);
-    long hIn =
-        _open_osfhandle(reinterpret_cast<intptr_t>(GetStdHandle(STD_INPUT_HANDLE)), _O_WTEXT);
-    long hErr =
-        _open_osfhandle(reinterpret_cast<intptr_t>(GetStdHandle(STD_ERROR_HANDLE)), _O_WTEXT);
+    long hOut = _open_osfhandle(
+        reinterpret_cast<intptr_t>(GetStdHandle(STD_OUTPUT_HANDLE)), _O_WTEXT);
+    long hIn = _open_osfhandle(
+        reinterpret_cast<intptr_t>(GetStdHandle(STD_INPUT_HANDLE)), _O_WTEXT);
+    long hErr = _open_osfhandle(
+        reinterpret_cast<intptr_t>(GetStdHandle(STD_ERROR_HANDLE)), _O_WTEXT);
 
     *stdout = *_fdopen(hOut, "w");
     *stdin = *_fdopen(hIn, "r");

--- a/src/System/Debug.cpp
+++ b/src/System/Debug.cpp
@@ -41,7 +41,7 @@ void openLogFile() {
     if (sHasLogFile) return;
 
     FILE* fp = nullptr;
-    if (_wfopen_s(&fp, sLogPath, L"w") == 0) {
+    if (_wfopen_s(&fp, sLogPath, L"w") == 0 && fp) {
         fwrite("\xEF\xBB\xBF", 1, 3, fp);  // UTF-8 BOM.
         fclose(fp);
     }
@@ -55,11 +55,11 @@ void openConsole() {
     AllocConsole();
 
     long hOut =
-        _open_osfhandle((intptr_t)GetStdHandle(STD_OUTPUT_HANDLE), _O_WTEXT);
+        _open_osfhandle(reinterpret_cast<intptr_t>(GetStdHandle(STD_OUTPUT_HANDLE)), _O_WTEXT);
     long hIn =
-        _open_osfhandle((intptr_t)GetStdHandle(STD_INPUT_HANDLE), _O_WTEXT);
+        _open_osfhandle(reinterpret_cast<intptr_t>(GetStdHandle(STD_INPUT_HANDLE)), _O_WTEXT);
     long hErr =
-        _open_osfhandle((intptr_t)GetStdHandle(STD_ERROR_HANDLE), _O_WTEXT);
+        _open_osfhandle(reinterpret_cast<intptr_t>(GetStdHandle(STD_ERROR_HANDLE)), _O_WTEXT);
 
     *stdout = *_fdopen(hOut, "w");
     *stdin = *_fdopen(hIn, "r");
@@ -80,7 +80,7 @@ static bool sLogBlankLine = false;
 
 static void WriteToLogAndConsole(const char* msg) {
     FILE* fp = nullptr;
-    if (sHasLogFile && _wfopen_s(&fp, sLogPath, L"a") == 0) {
+    if (sHasLogFile && _wfopen_s(&fp, sLogPath, L"a") == 0 && fp) {
         fwrite(msg, 1, strlen(msg), fp);
         fclose(fp);
     }
@@ -168,7 +168,7 @@ static const char* sDashLine = "-----------------------------------";
 
 static LRESULT CALLBACK CBTProc(INT nCode, WPARAM wParam, LPARAM lParam) {
     if (nCode == HCBT_ACTIVATE) {
-        HWND hWndChild = (HWND)wParam;
+        HWND hWndChild = reinterpret_cast<HWND>(wParam);
 
         UINT result;
         if (GetDlgItem(hWndChild, IDYES))
@@ -221,13 +221,14 @@ bool assrt(const char* exp, const char* file, int line, const char* func,
         Debug::WriteToLogAndConsole(buffer);
         Debug::WriteToLogAndConsole(sDashLine);
 
-        int answer =
-            ShowMessageBox(nullptr, buffer, "ASSERT", MB_ICONERROR | MB_YESNOCANCEL);
+        int answer = ShowMessageBox(nullptr, buffer, "ASSERT",
+                                    MB_ICONERROR | MB_YESNOCANCEL);
         if (answer == IDYES) {
             return true;
         } else if (answer == IDCANCEL) {
             if (!AddIgnore(id)) {
-                MessageBoxA(nullptr, "Maximum number of ignorable asserts reached.",
+                MessageBoxA(nullptr,
+                            "Maximum number of ignorable asserts reached.",
                             "ERROR", MB_ICONERROR | MB_OK);
             }
         }

--- a/src/System/Debug.cpp
+++ b/src/System/Debug.cpp
@@ -87,7 +87,7 @@ static void WriteToLogAndConsole(const char* msg) {
     if (sHasConsole) {
         WideString wmsg = Widen(msg);
         WriteConsoleW(GetStdHandle(STD_OUTPUT_HANDLE), wmsg.str(),
-                      wmsg.length(), nullptr, 0);
+                      wmsg.length(), nullptr, nullptr);
     }
 }
 
@@ -187,7 +187,7 @@ static LRESULT CALLBACK CBTProc(INT nCode, WPARAM wParam, LPARAM lParam) {
 
 static int ShowMessageBox(HWND hWnd, LPCSTR lpcText, LPCSTR lpcCaption,
                           UINT uType) {
-    sHook = SetWindowsHookEx(WH_CBT, &CBTProc, 0, GetCurrentThreadId());
+    sHook = SetWindowsHookEx(WH_CBT, &CBTProc, nullptr, GetCurrentThreadId());
     return MessageBox(hWnd, lpcText, lpcCaption, uType);
 }
 
@@ -222,12 +222,12 @@ bool assrt(const char* exp, const char* file, int line, const char* func,
         Debug::WriteToLogAndConsole(sDashLine);
 
         int answer =
-            ShowMessageBox(0, buffer, "ASSERT", MB_ICONERROR | MB_YESNOCANCEL);
+            ShowMessageBox(nullptr, buffer, "ASSERT", MB_ICONERROR | MB_YESNOCANCEL);
         if (answer == IDYES) {
             return true;
         } else if (answer == IDCANCEL) {
             if (!AddIgnore(id)) {
-                MessageBoxA(0, "Maximum number of ignorable asserts reached.",
+                MessageBoxA(nullptr, "Maximum number of ignorable asserts reached.",
                             "ERROR", MB_ICONERROR | MB_OK);
             }
         }

--- a/src/System/File.cpp
+++ b/src/System/File.cpp
@@ -190,7 +190,7 @@ static const char* GetExtension(const char* p) {
 
 Path::Path() = default;
 
-Path::Path(const Path& other)  = default;
+Path::Path(const Path& other) = default;
 
 Path::Path(const std::string& path) : str(Concatenate(std::string(), path)) {}
 

--- a/src/System/File.cpp
+++ b/src/System/File.cpp
@@ -117,9 +117,9 @@ static void AddItems(Vector<PathItem>& out, const std::string& path) {
                 if (out.size() && !out.back().dotdot())
                     out.pop_back();
                 else
-                    out.push_back({a, (size_t)(b - a)});
+                    out.push_back({a, static_cast<size_t>(b - a)});
             } else if (size > 1 || (size == 1 && a[0] != '.')) {
-                out.push_back({a, (size_t)(b - a)});
+                out.push_back({a, static_cast<size_t>(b - a)});
             }
             a = *b ? (b + 1) : b;
         }
@@ -188,9 +188,9 @@ static const char* GetExtension(const char* p) {
 // ================================================================================================
 // Path.
 
-Path::Path() {}
+Path::Path() = default;
 
-Path::Path(const Path& other) : str(other.str) {}
+Path::Path(const Path& other)  = default;
 
 Path::Path(const std::string& path) : str(Concatenate(std::string(), path)) {}
 

--- a/src/System/Mixer.cpp
+++ b/src/System/Mixer.cpp
@@ -66,7 +66,7 @@ struct MixerImpl : public Mixer {
         _aligned_free(myBlockMemory);
     }
 
-    MixerImpl(){
+    MixerImpl() {
         memset(myHeaders, 0, sizeof(myHeaders));
         mySource = nullptr;
         myBlockMemory = static_cast<BYTE*>(

--- a/src/System/Mixer.cpp
+++ b/src/System/Mixer.cpp
@@ -171,7 +171,7 @@ struct MixerImpl : public Mixer {
         return true;
     }
 
-    void pause() {
+    void pause() override {
         if (myIsOpened && !myIsPaused) {
             SetEvent(myPauseThread);
             WaitForSingleObject(myThreadPaused, INFINITE);

--- a/src/System/Mixer.cpp
+++ b/src/System/Mixer.cpp
@@ -67,10 +67,10 @@ struct MixerImpl : public Mixer {
     }
 
     MixerImpl()
-        
-          {
-        myBlockMemory =
-            static_cast<BYTE*>(_aligned_malloc(WAVEOUT_BLOCK_SIZE * WAVEOUT_BLOCKS, 16));
+
+    {
+        myBlockMemory = static_cast<BYTE*>(
+            _aligned_malloc(WAVEOUT_BLOCK_SIZE * WAVEOUT_BLOCKS, 16));
         for (WAVEHDR& header : myHeaders) {
             memset(&header, 0, sizeof(WAVEHDR));
         }
@@ -125,7 +125,8 @@ struct MixerImpl : public Mixer {
         wfex.cbSize = 0;
 
         MMRESULT res = waveOutOpen(&myWaveout, WAVE_MAPPER, &wfex,
-                                   (DWORD_PTR)(&MixerCallback), (DWORD_PTR)this,
+                                   reinterpret_cast<DWORD_PTR>(&MixerCallback), 
+                                   reinterpret_cast<DWORD_PTR>(this),
                                    CALLBACK_FUNCTION);
 
         if (res != MMSYSERR_NOERROR) {
@@ -159,8 +160,9 @@ struct MixerImpl : public Mixer {
         myIsOpened = true;
 
         // Start the MixerDevice update thread.
-        myThread = CreateThread(nullptr, 0, static_cast<LPTHREAD_START_ROUTINE>(MixerThread),
-                                this, 0, nullptr);
+        myThread = CreateThread(
+            nullptr, 0, static_cast<LPTHREAD_START_ROUTINE>(MixerThread), this,
+            0, nullptr);
 
         return true;
     }
@@ -191,8 +193,10 @@ struct MixerImpl : public Mixer {
     }
 
     void mixThread() {
-        const HANDLE events[] = {static_cast<HANDLE>(myKillThread), static_cast<HANDLE>(myResumeThread),
-            static_cast<HANDLE>(myPauseThread), static_cast<HANDLE>(myWriteBlock)};
+        const HANDLE events[] = {static_cast<HANDLE>(myKillThread),
+                                 static_cast<HANDLE>(myResumeThread),
+                                 static_cast<HANDLE>(myPauseThread),
+                                 static_cast<HANDLE>(myWriteBlock)};
         while (true) {
             // Wait for a thread event.
             DWORD id = WaitForMultipleObjects(4, events, FALSE, INFINITE);
@@ -230,7 +234,7 @@ struct MixerImpl : public Mixer {
 static void CALLBACK MixerCallback(HWAVEOUT hwo, UINT msg, DWORD_PTR mixer,
                                    DWORD_PTR, DWORD_PTR) {
     if (msg == WOM_DONE) {
-        ((MixerImpl*)mixer)->blockDone();
+        reinterpret_cast<MixerImpl*>(mixer)->blockDone();
     }
 }
 

--- a/src/System/Mixer.cpp
+++ b/src/System/Mixer.cpp
@@ -21,7 +21,7 @@ static DWORD WINAPI MixerThread(LPVOID param);
 struct ThreadEvent {
     ThreadEvent() { handle = CreateEvent(nullptr, FALSE, FALSE, nullptr); }
     ~ThreadEvent() { CloseHandle(handle); }
-    operator HANDLE() { return handle; }
+    explicit operator HANDLE() { return handle; }
     HANDLE handle;
 };
 
@@ -36,13 +36,13 @@ struct MixerImpl : public Mixer {
         WO_WRITE_BLOCK = WAIT_OBJECT_0 + 3,
     };
 
-    int myFrequency;
-    int myFreeBlockIndex;
+    int myFrequency = 0;
+    int myFreeBlockIndex = 0;
 
-    BYTE* myBlockMemory;
+    BYTE* myBlockMemory = nullptr;
     WAVEHDR myHeaders[WAVEOUT_BLOCKS];
-    HWAVEOUT myWaveout;
-    HANDLE myThread;
+    HWAVEOUT myWaveout = nullptr;
+    HANDLE myThread = nullptr;
 
     ThreadEvent myKillThread;
     ThreadEvent myPauseThread;
@@ -50,45 +50,39 @@ struct MixerImpl : public Mixer {
     ThreadEvent myThreadPaused;
     ThreadEvent myWriteBlock;
 
-    volatile LONG myFreeBlocks;
+    volatile LONG myFreeBlocks = 0;
 
-    bool myIsOpened;
-    bool myIsPaused;
+    bool myIsOpened = false;
+    bool myIsPaused = true;
 
     MixSource* mySource;
 
     // ================================================================================================
     // MixerImpl :: constructor and destructor.
 
-    ~MixerImpl() {
+    ~MixerImpl() override {
         close();
 
         _aligned_free(myBlockMemory);
     }
 
     MixerImpl()
-        : myFrequency(0),
-          myFreeBlockIndex(0),
-          myBlockMemory(nullptr),
-          myWaveout(0),
-          myThread(0),
-          myFreeBlocks(0),
-          myIsOpened(false),
-          myIsPaused(true) {
+        
+          {
         myBlockMemory =
-            (BYTE*)_aligned_malloc(WAVEOUT_BLOCK_SIZE * WAVEOUT_BLOCKS, 16);
+            static_cast<BYTE*>(_aligned_malloc(WAVEOUT_BLOCK_SIZE * WAVEOUT_BLOCKS, 16));
         for (WAVEHDR& header : myHeaders) {
             memset(&header, 0, sizeof(WAVEHDR));
         }
     }
 
-    void close() {
+    void close() override {
         if (myThread) {
-            SetEvent(myKillThread);
+            SetEvent(static_cast<HANDLE>(myKillThread));
             LONG err = WaitForSingleObject(myThread, INFINITE);
             if (err) HudError("failed to close audio thread: %i", err);
             CloseHandle(myThread);
-            myThread = 0;
+            myThread = nullptr;
         }
         if (myWaveout) {
             LONG err = waveOutReset(myWaveout);
@@ -108,7 +102,7 @@ struct MixerImpl : public Mixer {
 
             err = waveOutClose(myWaveout);
             if (err) HudError("failed to close wave out: %i\n", err);
-            myWaveout = 0;
+            myWaveout = nullptr;
         }
 
         myFreeBlockIndex = 0;
@@ -117,7 +111,7 @@ struct MixerImpl : public Mixer {
         myIsPaused = true;
     }
 
-    bool open(MixSource* source, int samplerate) {
+    bool open(MixSource* source, int samplerate) override {
         if (myIsOpened) close();
 
         // Try to open the waveout device.
@@ -165,7 +159,7 @@ struct MixerImpl : public Mixer {
         myIsOpened = true;
 
         // Start the MixerDevice update thread.
-        myThread = CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)MixerThread,
+        myThread = CreateThread(nullptr, 0, static_cast<LPTHREAD_START_ROUTINE>(MixerThread),
                                 this, 0, nullptr);
 
         return true;
@@ -173,39 +167,39 @@ struct MixerImpl : public Mixer {
 
     void pause() override {
         if (myIsOpened && !myIsPaused) {
-            SetEvent(myPauseThread);
-            WaitForSingleObject(myThreadPaused, INFINITE);
+            SetEvent(static_cast<HANDLE>(myPauseThread));
+            WaitForSingleObject(static_cast<HANDLE>(myThreadPaused), INFINITE);
             waveOutReset(myWaveout);
             myIsPaused = true;
         }
     }
 
-    void resume() {
+    void resume() override {
         if (myIsOpened && myIsPaused) {
             myFreeBlockIndex = 0;
             myFreeBlocks = WAVEOUT_BLOCKS;
-            SetEvent(myResumeThread);
+            SetEvent(static_cast<HANDLE>(myResumeThread));
             waveOutRestart(myWaveout);
-            SetEvent(myWriteBlock);
+            SetEvent(static_cast<HANDLE>(myWriteBlock));
             myIsPaused = false;
         }
     }
 
     void blockDone() {
         InterlockedIncrement(&myFreeBlocks);
-        SetEvent(myWriteBlock);
+        SetEvent(static_cast<HANDLE>(myWriteBlock));
     }
 
     void mixThread() {
-        const HANDLE events[] = {myKillThread, myResumeThread, myPauseThread,
-                                 myWriteBlock};
+        const HANDLE events[] = {static_cast<HANDLE>(myKillThread), static_cast<HANDLE>(myResumeThread),
+            static_cast<HANDLE>(myPauseThread), static_cast<HANDLE>(myWriteBlock)};
         while (true) {
             // Wait for a thread event.
             DWORD id = WaitForMultipleObjects(4, events, FALSE, INFINITE);
             if (id == WO_KILL_THREAD) {
                 return;
             } else if (id == WO_PAUSE_THREAD) {
-                SetEvent(myThreadPaused);
+                SetEvent(static_cast<HANDLE>(myThreadPaused));
                 id = WaitForMultipleObjects(2, events, FALSE, INFINITE);
                 if (id == WO_KILL_THREAD) return;
             } else if (id == WO_WRITE_BLOCK) {
@@ -220,7 +214,7 @@ struct MixerImpl : public Mixer {
                     myFreeBlockIndex = (myFreeBlockIndex + 1) % WAVEOUT_BLOCKS;
 
                     // Send the filled block to wave out.
-                    mySource->writeFrames((short*)samples,
+                    mySource->writeFrames(reinterpret_cast<short*>(samples),
                                           WAVEOUT_BLOCK_FRAMES);
                     waveOutWrite(myWaveout, header, sizeof(WAVEHDR));
                 }
@@ -241,7 +235,7 @@ static void CALLBACK MixerCallback(HWAVEOUT hwo, UINT msg, DWORD_PTR mixer,
 }
 
 static DWORD WINAPI MixerThread(LPVOID mixer) {
-    ((MixerImpl*)mixer)->mixThread();
+    (static_cast<MixerImpl*>(mixer))->mixThread();
     return 0;
 }
 
@@ -250,6 +244,6 @@ static DWORD WINAPI MixerThread(LPVOID mixer) {
 
 Mixer* Mixer::create() { return new MixerImpl; }
 
-Mixer::~Mixer() {}
+Mixer::~Mixer() = default;
 
 };  // namespace Vortex

--- a/src/System/Mixer.cpp
+++ b/src/System/Mixer.cpp
@@ -124,10 +124,10 @@ struct MixerImpl : public Mixer {
         wfex.wBitsPerSample = sizeof(short) * 8;
         wfex.cbSize = 0;
 
-        MMRESULT res = waveOutOpen(&myWaveout, WAVE_MAPPER, &wfex,
-                                   reinterpret_cast<DWORD_PTR>(&MixerCallback), 
-                                   reinterpret_cast<DWORD_PTR>(this),
-                                   CALLBACK_FUNCTION);
+        MMRESULT res =
+            waveOutOpen(&myWaveout, WAVE_MAPPER, &wfex,
+                        reinterpret_cast<DWORD_PTR>(&MixerCallback),
+                        reinterpret_cast<DWORD_PTR>(this), CALLBACK_FUNCTION);
 
         if (res != MMSYSERR_NOERROR) {
             HudError("failed to open wave out: %i", res);

--- a/src/System/Mixer.cpp
+++ b/src/System/Mixer.cpp
@@ -66,9 +66,9 @@ struct MixerImpl : public Mixer {
         _aligned_free(myBlockMemory);
     }
 
-    MixerImpl()
-
-    {
+    MixerImpl(){
+        memset(myHeaders, 0, sizeof(myHeaders));
+        mySource = nullptr;
         myBlockMemory = static_cast<BYTE*>(
             _aligned_malloc(WAVEOUT_BLOCK_SIZE * WAVEOUT_BLOCKS, 16));
         for (WAVEHDR& header : myHeaders) {

--- a/src/System/System.cpp
+++ b/src/System/System.cpp
@@ -832,10 +832,11 @@ struct SystemImpl : public System {
         bool handled = false;
         if (msg == WM_CREATE) {
             void* app = reinterpret_cast<LPCREATESTRUCT>(lp)->lpCreateParams;
-            SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(app));
+            SetWindowLongPtrW(hwnd, GWLP_USERDATA,
+                              reinterpret_cast<LONG_PTR>(app));
         } else {
-            SystemImpl* app =
-                reinterpret_cast<SystemImpl*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+            SystemImpl* app = reinterpret_cast<SystemImpl*>(
+                GetWindowLongPtrW(hwnd, GWLP_USERDATA));
             if (app) handled = app->handleMsg(msg, wp, lp, res);
         }
         return handled ? res : DefWindowProcW(hwnd, msg, wp, lp);

--- a/src/System/System.cpp
+++ b/src/System/System.cpp
@@ -169,34 +169,40 @@ static bool LogCheckpoint(bool result, const char* description) {
 
 typedef System::MenuItem MItem;
 
-MItem* MItem::create() { return reinterpret_cast<MenuItem*>(CreatePopupMenu()); }
+MItem* MItem::create() {
+    return reinterpret_cast<MenuItem*>(CreatePopupMenu());
+}
 
 void MItem::addSeperator() {
     AppendMenuW(reinterpret_cast<HMENU>(this), MF_SEPARATOR, 0, nullptr);
 }
 void MItem::addItem(int item, const std::string& text) {
-    AppendMenuW(reinterpret_cast<HMENU>(this), MF_STRING, item, Widen(text).str());
+    AppendMenuW(reinterpret_cast<HMENU>(this), MF_STRING, item,
+                Widen(text).str());
 }
 
 void MItem::addSubmenu(MItem* submenu, const std::string& text, bool grayed) {
     int flags = MF_STRING | MF_POPUP | (grayed * MF_GRAYED);
-    AppendMenuW(reinterpret_cast<HMENU>(this), MF_STRING | MF_POPUP, (UINT_PTR)submenu,
-                Widen(text).str());
+    AppendMenuW(reinterpret_cast<HMENU>(this), MF_STRING | MF_POPUP,
+                reinterpret_cast<UINT_PTR>(submenu), Widen(text).str());
 }
 
 void MItem::replaceSubmenu(int pos, MItem* submenu, const std::string& text,
                            bool grayed) {
     int flags = MF_BYPOSITION | MF_STRING | MF_POPUP | (grayed * MF_GRAYED);
     DeleteMenu(reinterpret_cast<HMENU>(this), pos, MF_BYPOSITION);
-    InsertMenuW(reinterpret_cast<HMENU>(this), pos, flags, (UINT_PTR)submenu, Widen(text).str());
+    InsertMenuW(reinterpret_cast<HMENU>(this), pos, flags,
+                reinterpret_cast<UINT_PTR>(submenu), Widen(text).str());
 }
 
 void MItem::setChecked(int item, bool state) {
-    CheckMenuItem(reinterpret_cast<HMENU>(this), item, state ? MF_CHECKED : MF_UNCHECKED);
+    CheckMenuItem(reinterpret_cast<HMENU>(this), item,
+                  state ? MF_CHECKED : MF_UNCHECKED);
 }
 
 void MItem::setEnabled(int item, bool state) {
-    EnableMenuItem(reinterpret_cast<HMENU>(this), item, state ? MF_ENABLED : MF_GRAYED);
+    EnableMenuItem(reinterpret_cast<HMENU>(this), item,
+                   state ? MF_ENABLED : MF_GRAYED);
 }
 
 namespace {
@@ -241,11 +247,10 @@ struct SystemImpl : public System {
 
     SystemImpl()
         : myInstance(GetModuleHandle(nullptr)),
-          
+
           myMousePos({0, 0}),
           mySize({0, 0}),
-          myTitle("ArrowVortex")
-          {
+          myTitle("ArrowVortex") {
         myApplicationStartTime = Debug::getElapsedTime();
 
         // Register the window class.
@@ -273,7 +278,8 @@ struct SystemImpl : public System {
         for (int i = 0; i < 15; ++i)
             myKeyMap[VK_F1 + i] = static_cast<Key::Code>(Key::F1 + i);
         for (int i = 0; i < 9; ++i)
-            myKeyMap[VK_NUMPAD0 + i] = static_cast<Key::Code>(Key::NUMPAD_0 + i);
+            myKeyMap[VK_NUMPAD0 + i] =
+                static_cast<Key::Code>(Key::NUMPAD_0 + i);
 
         // Create a window handle.
         myStyle = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_OVERLAPPEDWINDOW;
@@ -304,10 +310,12 @@ struct SystemImpl : public System {
         pfd.cDepthBits = 24;
         pfd.cStencilBits = 8;
 
-        // Set the pixel format.
+        // Set the pixel format
+#pragma warning(suppress : 6387)
         int cpf = ChoosePixelFormat(myHDC, &pfd);
         if (LogCheckpoint(cpf != 0, "choosing pixel format")) return;
 
+#pragma warning(suppress : 6387)
         BOOL spf = SetPixelFormat(myHDC, cpf, &pfd);
         if (LogCheckpoint(spf != 0, "setting pixel format")) return;
 
@@ -331,8 +339,8 @@ struct SystemImpl : public System {
 
         // Enable vsync for now, we will disable it later if the settings
         // require it.
-        wglSwapInterval =
-            reinterpret_cast<PFNWGLSWAPINTERVALFARPROC>(wglGetProcAddress("wglSwapIntervalEXT"));
+        wglSwapInterval = reinterpret_cast<PFNWGLSWAPINTERVALFARPROC>(
+            wglGetProcAddress("wglSwapIntervalEXT"));
         Debug::log("swap interval support :: %s\n",
                    wglSwapInterval ? "OK" : "MISSING");
         if (wglSwapInterval) {
@@ -462,7 +470,7 @@ struct SystemImpl : public System {
 
             // End of frame
             auto curTime = Debug::getElapsedTime();
-            deltaTime = duration<double>(static_cast<float>min(
+            deltaTime = duration<double>(static_cast<float> min(
                 max(0, duration<double>(curTime - prevTime).count()), 0.25));
             prevTime = curTime;
 
@@ -638,7 +646,7 @@ struct SystemImpl : public System {
             }
             case WM_GETMINMAXINFO: {
                 vec2i minSize = {256, 256}, maxSize = {0, 0};
-                MINMAXINFO* mm = (MINMAXINFO*)lp;
+                MINMAXINFO* mm = reinterpret_cast<MINMAXINFO*>(lp);
                 if (minSize.x > 0 && minSize.y > 0) {
                     RECT r = {0, 0, minSize.x, minSize.y};
                     AdjustWindowRectEx(&r, myStyle, FALSE, myExStyle);
@@ -699,8 +707,10 @@ struct SystemImpl : public System {
             }
             case WM_RBUTTONDOWN:
                 ++mc;
+                break;
             case WM_MBUTTONDOWN:
                 ++mc;
+                break;
             case WM_LBUTTONDOWN:
                 ++mc;
                 {
@@ -715,8 +725,10 @@ struct SystemImpl : public System {
                 }
             case WM_RBUTTONDBLCLK:
                 ++mc;
+                break;
             case WM_MBUTTONDBLCLK:
                 ++mc;
+                break;
             case WM_LBUTTONDBLCLK:
                 ++mc;
                 {
@@ -731,8 +743,10 @@ struct SystemImpl : public System {
                 }
             case WM_RBUTTONUP:
                 ++mc;
+                break;
             case WM_MBUTTONUP:
                 ++mc;
+                break;
             case WM_LBUTTONUP:
                 ++mc;
                 {
@@ -760,24 +774,26 @@ struct SystemImpl : public System {
             case WM_DROPFILES: {
                 if (myIsInsideMessageLoop) {
                     POINT pos;
-                    DragQueryPoint((HDROP)wp, &pos);
+                    DragQueryPoint(reinterpret_cast<HDROP>(wp), &pos);
 
                     // Get the number of files dropped.
-                    UINT numFiles =
-                        DragQueryFileW((HDROP)wp, 0xFFFFFFFF, nullptr, 0);
+                    UINT numFiles = DragQueryFileW(reinterpret_cast<HDROP>(wp),
+                                                   0xFFFFFFFF, nullptr, 0);
                     std::vector<std::string> files(numFiles);
 
                     for (UINT i = 0; i < numFiles; ++i) {
                         // Get the length of the file path and retrieve it.
                         // Giving 0 for the stringbuffer returns path size
                         // without nullbyte.
-                        UINT pathLen = DragQueryFileW((HDROP)wp, i, nullptr, 0);
+                        UINT pathLen = DragQueryFileW(
+                            reinterpret_cast<HDROP>(wp), i, nullptr, 0);
                         WideString wstr(pathLen, 0);
-                        DragQueryFileW((HDROP)wp, i, wstr.begin(), pathLen + 1);
+                        DragQueryFileW(reinterpret_cast<HDROP>(wp), i,
+                                       wstr.begin(), pathLen + 1);
                         files[i] = Narrow(wstr);
                     }
 
-                    DragFinish((HDROP)wp);
+                    DragFinish(reinterpret_cast<HDROP>(wp));
 
                     // Pass the file drop event to the input handler.
                     std::vector<const char*> filePtrs;
@@ -815,11 +831,11 @@ struct SystemImpl : public System {
         LRESULT res = 0;
         bool handled = false;
         if (msg == WM_CREATE) {
-            void* app = ((LPCREATESTRUCT)lp)->lpCreateParams;
-            SetWindowLongPtrW(hwnd, GWLP_USERDATA, (LONG_PTR)app);
+            void* app = reinterpret_cast<LPCREATESTRUCT>(lp)->lpCreateParams;
+            SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(app));
         } else {
             SystemImpl* app =
-                (SystemImpl*)GetWindowLongPtrW(hwnd, GWLP_USERDATA);
+                reinterpret_cast<SystemImpl*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
             if (app) handled = app->handleMsg(msg, wp, lp, res);
         }
         return handled ? res : DefWindowProcW(hwnd, msg, wp, lp);
@@ -832,8 +848,8 @@ struct SystemImpl : public System {
                           Buttons b, Icon i) override {
         WideString wtitle = Widen(title), wtext = Widen(text);
         int flags = sDlgType[b] | sDlgIcon[i], result = R_OK;
-        switch (MessageBoxW(static_cast<HWND>(gSystem->getHWND()), wtext.str(), wtitle.str(),
-                            flags)) {
+        switch (MessageBoxW(static_cast<HWND>(gSystem->getHWND()), wtext.str(),
+                            wtitle.str(), flags)) {
             case IDOK:
                 return R_OK;
             case IDYES:
@@ -900,8 +916,9 @@ struct SystemImpl : public System {
         int flags = CREATE_NO_WINDOW;
         PROCESS_INFORMATION processInfo;
         ZeroMemory(&processInfo, sizeof(processInfo));
-        if (CreateProcessW(nullptr, wbuffer.data(), nullptr, nullptr, TRUE, flags, nullptr,
-                           nullptr, &startupInfo, &processInfo)) {
+        if (CreateProcessW(nullptr, wbuffer.data(), nullptr, nullptr, TRUE,
+                           flags, nullptr, nullptr, &startupInfo,
+                           &processInfo)) {
             if (pipe) {
                 DWORD bytesWritten;
                 int bytesRead = pipe->read();
@@ -922,7 +939,8 @@ struct SystemImpl : public System {
     }
 
     void openWebpage(const std::string& link) override {
-        ShellExecuteW(nullptr, nullptr, Widen(link).str(), nullptr, nullptr, SW_SHOW);
+        ShellExecuteW(nullptr, nullptr, Widen(link).str(), nullptr, nullptr,
+                      SW_SHOW);
     }
 
     void setWorkingDir(const std::string& path) override {
@@ -950,7 +968,9 @@ struct SystemImpl : public System {
 
     Cursor::Icon getCursor() const override { return myCursor; }
 
-    bool isKeyDown(Key::Code key) const override { return myKeyState.test(key); }
+    bool isKeyDown(Key::Code key) const override {
+        return myKeyState.test(key);
+    }
 
     bool isMouseDown(Mouse::Code button) const override {
         return myMouseState.test(button);
@@ -1029,8 +1049,8 @@ int APIENTRY WinMain(HINSTANCE, HINSTANCE, char*, int) {
     Debug::openConsole();
 #endif
     gSystem = new SystemImpl;
-    ((SystemImpl*)gSystem)->messageLoop();
-    delete (SystemImpl*)gSystem;
+    static_cast<SystemImpl*>(gSystem)->messageLoop();
+    delete static_cast<SystemImpl*>(gSystem);
     ApplicationEnd();
 
 #ifdef CRTDBG_MAP_ALLOC

--- a/src/System/System.cpp
+++ b/src/System/System.cpp
@@ -126,7 +126,7 @@ static std::string ShowFileDialog(std::string title, std::string path,
     // Prepare the open/save file dialog.
     OPENFILENAMEW ofns = {sizeof(OPENFILENAMEW)};
     ofns.lpstrFilter = wfilter.str();
-    ofns.hwndOwner = (HWND)gSystem->getHWND();
+    ofns.hwndOwner = static_cast<HWND>(gSystem->getHWND());
     ofns.lpstrFile = outPath;
     ofns.nMaxFile = MAX_PATH;
     ofns.lpstrTitle = wtitle.str();
@@ -152,9 +152,9 @@ static bool LogCheckpoint(bool result, const char* description) {
         char lpMsgBuf[100];
         DWORD code = GetLastError();
         FormatMessageA(
-            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
             code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), lpMsgBuf, 60,
-            NULL);
+            nullptr);
         Debug::blockBegin(Debug::ERROR, description);
         Debug::log("windows error code %i: %s", code, lpMsgBuf);
         Debug::blockEnd();
@@ -169,34 +169,34 @@ static bool LogCheckpoint(bool result, const char* description) {
 
 typedef System::MenuItem MItem;
 
-MItem* MItem::create() { return (MenuItem*)CreatePopupMenu(); }
+MItem* MItem::create() { return reinterpret_cast<MenuItem*>(CreatePopupMenu()); }
 
 void MItem::addSeperator() {
-    AppendMenuW((HMENU)this, MF_SEPARATOR, 0, nullptr);
+    AppendMenuW(reinterpret_cast<HMENU>(this), MF_SEPARATOR, 0, nullptr);
 }
 void MItem::addItem(int item, const std::string& text) {
-    AppendMenuW((HMENU)this, MF_STRING, item, Widen(text).str());
+    AppendMenuW(reinterpret_cast<HMENU>(this), MF_STRING, item, Widen(text).str());
 }
 
 void MItem::addSubmenu(MItem* submenu, const std::string& text, bool grayed) {
     int flags = MF_STRING | MF_POPUP | (grayed * MF_GRAYED);
-    AppendMenuW((HMENU)this, MF_STRING | MF_POPUP, (UINT_PTR)submenu,
+    AppendMenuW(reinterpret_cast<HMENU>(this), MF_STRING | MF_POPUP, (UINT_PTR)submenu,
                 Widen(text).str());
 }
 
 void MItem::replaceSubmenu(int pos, MItem* submenu, const std::string& text,
                            bool grayed) {
     int flags = MF_BYPOSITION | MF_STRING | MF_POPUP | (grayed * MF_GRAYED);
-    DeleteMenu((HMENU)this, pos, MF_BYPOSITION);
-    InsertMenuW((HMENU)this, pos, flags, (UINT_PTR)submenu, Widen(text).str());
+    DeleteMenu(reinterpret_cast<HMENU>(this), pos, MF_BYPOSITION);
+    InsertMenuW(reinterpret_cast<HMENU>(this), pos, flags, (UINT_PTR)submenu, Widen(text).str());
 }
 
 void MItem::setChecked(int item, bool state) {
-    CheckMenuItem((HMENU)this, item, state ? MF_CHECKED : MF_UNCHECKED);
+    CheckMenuItem(reinterpret_cast<HMENU>(this), item, state ? MF_CHECKED : MF_UNCHECKED);
 }
 
 void MItem::setEnabled(int item, bool state) {
-    EnableMenuItem((HMENU)this, item, state ? MF_ENABLED : MF_GRAYED);
+    EnableMenuItem(reinterpret_cast<HMENU>(this), item, state ? MF_ENABLED : MF_GRAYED);
 }
 
 namespace {
@@ -205,10 +205,10 @@ namespace {
 // SystemImpl :: member data.
 
 struct SystemImpl : public System {
-    LPCWSTR myClassName;
+    LPCWSTR myClassName = L"ArrowVortex";
     HINSTANCE myInstance;
     std::chrono::steady_clock::time_point myApplicationStartTime;
-    Cursor::Icon myCursor;
+    Cursor::Icon myCursor = Cursor::ARROW;
     Key::Code myKeyMap[256];
     InputEvents myEvents;
     vec2i myMousePos, mySize;
@@ -220,10 +220,10 @@ struct SystemImpl : public System {
     HWND myHWND;
     HDC myHDC;
     HGLRC myHRC;
-    bool myIsActive;
-    bool myInitSuccesful;
-    bool myIsTerminated;
-    bool myIsInsideMessageLoop;
+    bool myIsActive = false;
+    bool myInitSuccesful = false;
+    bool myIsTerminated = false;
+    bool myIsInsideMessageLoop = false;
 
     // ================================================================================================
     // SystemImpl :: constructor and destructor.
@@ -241,15 +241,11 @@ struct SystemImpl : public System {
 
     SystemImpl()
         : myInstance(GetModuleHandle(nullptr)),
-          myClassName(L"ArrowVortex"),
-          myCursor(Cursor::ARROW),
+          
           myMousePos({0, 0}),
           mySize({0, 0}),
-          myTitle("ArrowVortex"),
-          myIsActive(false),
-          myInitSuccesful(false),
-          myIsTerminated(false),
-          myIsInsideMessageLoop(false) {
+          myTitle("ArrowVortex")
+          {
         myApplicationStartTime = Debug::getElapsedTime();
 
         // Register the window class.
@@ -269,15 +265,15 @@ struct SystemImpl : public System {
         memset(myKeyMap, 0, sizeof(myKeyMap));
         int k = sizeof(VKtoKCmap) / sizeof(VKtoKCmap[0]);
         for (int i = 0; i < k; i += 2)
-            myKeyMap[VKtoKCmap[i]] = (Key::Code)VKtoKCmap[i + 1];
+            myKeyMap[VKtoKCmap[i]] = static_cast<Key::Code>(VKtoKCmap[i + 1]);
         for (int i = 0; i < 26; ++i)
-            myKeyMap['A' + i] = (Key::Code)(Key::A + i);
+            myKeyMap['A' + i] = static_cast<Key::Code>(Key::A + i);
         for (int i = 0; i < 10; ++i)
-            myKeyMap['0' + i] = (Key::Code)(Key::DIGIT_0 + i);
+            myKeyMap['0' + i] = static_cast<Key::Code>(Key::DIGIT_0 + i);
         for (int i = 0; i < 15; ++i)
-            myKeyMap[VK_F1 + i] = (Key::Code)(Key::F1 + i);
+            myKeyMap[VK_F1 + i] = static_cast<Key::Code>(Key::F1 + i);
         for (int i = 0; i < 9; ++i)
-            myKeyMap[VK_NUMPAD0 + i] = (Key::Code)(Key::NUMPAD_0 + i);
+            myKeyMap[VK_NUMPAD0 + i] = static_cast<Key::Code>(Key::NUMPAD_0 + i);
 
         // Create a window handle.
         myStyle = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_OVERLAPPEDWINDOW;
@@ -286,11 +282,11 @@ struct SystemImpl : public System {
                                  myStyle, CW_USEDEFAULT, CW_USEDEFAULT, 640,
                                  480, nullptr, nullptr, myInstance, this);
 
-        if (LogCheckpoint(myHWND != 0, "creating window")) return;
+        if (LogCheckpoint(myHWND != nullptr, "creating window")) return;
 
         // Create a device context.
         myHDC = GetDC(myHWND);
-        if (LogCheckpoint(myHDC != 0, "creating device context")) return;
+        if (LogCheckpoint(myHDC != nullptr, "creating device context")) return;
 
         // Create the pixel format descriptor.
         PIXELFORMATDESCRIPTOR pfd;
@@ -317,7 +313,7 @@ struct SystemImpl : public System {
 
         // Create the OpenGL rendering context.
         myHRC = wglCreateContext(myHDC);
-        if (LogCheckpoint(myHRC != 0, "creating OpenGL context")) return;
+        if (LogCheckpoint(myHRC != nullptr, "creating OpenGL context")) return;
 
         BOOL mc = wglMakeCurrent(myHDC, myHRC);
         if (LogCheckpoint(mc != 0, "activating OpenGL context")) return;
@@ -336,7 +332,7 @@ struct SystemImpl : public System {
         // Enable vsync for now, we will disable it later if the settings
         // require it.
         wglSwapInterval =
-            (PFNWGLSWAPINTERVALFARPROC)wglGetProcAddress("wglSwapIntervalEXT");
+            reinterpret_cast<PFNWGLSWAPINTERVALFARPROC>(wglGetProcAddress("wglSwapIntervalEXT"));
         Debug::log("swap interval support :: %s\n",
                    wglSwapInterval ? "OK" : "MISSING");
         if (wglSwapInterval) {
@@ -383,7 +379,7 @@ struct SystemImpl : public System {
 
     void createMenu() {
         HMENU menu = CreateMenu();
-        gMenubar->init((MenuItem*)menu);
+        gMenubar->init(reinterpret_cast<MenuItem*>(menu));
         SetMenu(myHWND, menu);
     }
 
@@ -466,7 +462,7 @@ struct SystemImpl : public System {
 
             // End of frame
             auto curTime = Debug::getElapsedTime();
-            deltaTime = duration<double>((float)min(
+            deltaTime = duration<double>(static_cast<float>min(
                 max(0, duration<double>(curTime - prevTime).count()), 0.25));
             prevTime = curTime;
 
@@ -480,8 +476,8 @@ struct SystemImpl : public System {
             inputList.push_front(
                 duration<double>(inputTime - startTime).count());
 
-            if (abs(deltaTime.count() - 1.0 / (double)frameGuess) /
-                    (1.0 / (double)frameGuess) >
+            if (abs(deltaTime.count() - 1.0 / static_cast<double>(frameGuess)) /
+                    (1.0 / static_cast<double>(frameGuess)) >
                 0.01) {
                 lowcounts++;
             }
@@ -533,14 +529,14 @@ struct SystemImpl : public System {
     // ================================================================================================
     // SystemImpl :: clipboard functions.
 
-    bool setClipboardText(const std::string& text) {
+    bool setClipboardText(const std::string& text) override {
         bool result = false;
         if (OpenClipboard(nullptr)) {
             EmptyClipboard();
             WideString wtext = Widen(text);
             size_t size = sizeof(wchar_t) * (wtext.length() + 1);
             HGLOBAL bufferHandle = GlobalAlloc(GMEM_DDESHARE, size);
-            char* buffer = (char*)GlobalLock(bufferHandle);
+            char* buffer = static_cast<char*>(GlobalLock(bufferHandle));
             if (buffer) {
                 memcpy(buffer, wtext.str(), size);
                 GlobalUnlock(bufferHandle);
@@ -555,11 +551,11 @@ struct SystemImpl : public System {
         return result;
     }
 
-    std::string getClipboardText() const {
+    std::string getClipboardText() const override {
         std::string str;
         if (OpenClipboard(nullptr)) {
             HANDLE hData = GetClipboardData(CF_UNICODETEXT);
-            wchar_t* src = (wchar_t*)GlobalLock(hData);
+            wchar_t* src = static_cast<wchar_t*>(GlobalLock(hData));
             if (src) {
                 str = Narrow(src, wcslen(src));
                 GlobalUnlock(hData);
@@ -584,7 +580,7 @@ struct SystemImpl : public System {
         return cursorMap[min(max(0, myCursor), Cursor::NUM_CURSORS - 1)];
     }
 
-    int getKeyFlags() const {
+    int getKeyFlags() const override {
         int kc[6] = {Key::SHIFT_L, Key::SHIFT_R, Key::CTRL_L,
                      Key::CTRL_R,  Key::ALT_L,   Key::ALT_R};
         int kf[6] = {Keyflag::SHIFT, Keyflag::SHIFT, Keyflag::CTRL,
@@ -833,10 +829,10 @@ struct SystemImpl : public System {
     // SystemImpl :: dialog boxes.
 
     Result showMessageDlg(const std::string& title, const std::string& text,
-                          Buttons b, Icon i) {
+                          Buttons b, Icon i) override {
         WideString wtitle = Widen(title), wtext = Widen(text);
         int flags = sDlgType[b] | sDlgIcon[i], result = R_OK;
-        switch (MessageBoxW((HWND)gSystem->getHWND(), wtext.str(), wtitle.str(),
+        switch (MessageBoxW(static_cast<HWND>(gSystem->getHWND()), wtext.str(), wtitle.str(),
                             flags)) {
             case IDOK:
                 return R_OK;
@@ -850,25 +846,25 @@ struct SystemImpl : public System {
 
     std::string openFileDlg(const std::string& title,
                             const std::string& filename,
-                            const std::string& filters) {
+                            const std::string& filters) override {
         return ShowFileDialog(title, filename, filters, nullptr, false);
     }
 
     std::string saveFileDlg(const std::string& title,
                             const std::string& filename,
-                            const std::string& filters, int* index) {
+                            const std::string& filters, int* index) override {
         return ShowFileDialog(title, filename, filters, index, true);
     }
 
     // ================================================================================================
     // SystemImpl :: misc/get/set functions.
 
-    bool runSystemCommand(const std::string& cmd) {
+    bool runSystemCommand(const std::string& cmd) override {
         return runSystemCommand(cmd, nullptr, nullptr);
     }
 
     bool runSystemCommand(const std::string& cmd, CommandPipe* pipe,
-                          void* buffer) {
+                          void* buffer) override {
         bool result = false;
 
         // Copy the command to a Vector because CreateProcessW requires a
@@ -890,7 +886,7 @@ struct SystemImpl : public System {
             SECURITY_ATTRIBUTES attr;
             attr.nLength = sizeof(SECURITY_ATTRIBUTES);
             attr.bInheritHandle = TRUE;
-            attr.lpSecurityDescriptor = NULL;
+            attr.lpSecurityDescriptor = nullptr;
 
             // Create a pipe to send data to stdin of the child process.
             CreatePipe(&readPipe, &writePipe, &attr, 0);
@@ -904,14 +900,14 @@ struct SystemImpl : public System {
         int flags = CREATE_NO_WINDOW;
         PROCESS_INFORMATION processInfo;
         ZeroMemory(&processInfo, sizeof(processInfo));
-        if (CreateProcessW(NULL, wbuffer.data(), NULL, NULL, TRUE, flags, NULL,
-                           NULL, &startupInfo, &processInfo)) {
+        if (CreateProcessW(nullptr, wbuffer.data(), nullptr, nullptr, TRUE, flags, nullptr,
+                           nullptr, &startupInfo, &processInfo)) {
             if (pipe) {
                 DWORD bytesWritten;
                 int bytesRead = pipe->read();
                 while (bytesRead > 0) {
                     WriteFile(writePipe, buffer, bytesRead, &bytesWritten,
-                              NULL);
+                              nullptr);
                     bytesRead = pipe->read();
                 }
                 CloseHandle(writePipe);
@@ -925,59 +921,59 @@ struct SystemImpl : public System {
         return result;
     }
 
-    void openWebpage(const std::string& link) {
-        ShellExecuteW(0, 0, Widen(link).str(), 0, 0, SW_SHOW);
+    void openWebpage(const std::string& link) override {
+        ShellExecuteW(nullptr, nullptr, Widen(link).str(), nullptr, nullptr, SW_SHOW);
     }
 
-    void setWorkingDir(const std::string& path) {
+    void setWorkingDir(const std::string& path) override {
         SetCurrentDirectoryW(Widen(path).str());
     }
 
-    void setCursor(Cursor::Icon c) { myCursor = c; }
+    void setCursor(Cursor::Icon c) override { myCursor = c; }
 
-    void disableVsync() {
+    void disableVsync() override {
         if (wglSwapInterval) {
             Debug::log("[NOTE] turning off v-sync\n");
             wglSwapInterval(0);
         }
     }
 
-    double getElapsedTime() const {
+    double getElapsedTime() const override {
         return Debug::getElapsedTime(myApplicationStartTime);
     }
 
-    void* getHWND() const { return myHWND; }
+    void* getHWND() const override { return myHWND; }
 
-    std::string getExeDir() const { return Narrow(sExeDir); }
+    std::string getExeDir() const override { return Narrow(sExeDir); }
 
-    std::string getRunDir() const { return Narrow(sRunDir); }
+    std::string getRunDir() const override { return Narrow(sRunDir); }
 
-    Cursor::Icon getCursor() const { return myCursor; }
+    Cursor::Icon getCursor() const override { return myCursor; }
 
-    bool isKeyDown(Key::Code key) const { return myKeyState.test(key); }
+    bool isKeyDown(Key::Code key) const override { return myKeyState.test(key); }
 
-    bool isMouseDown(Mouse::Code button) const {
+    bool isMouseDown(Mouse::Code button) const override {
         return myMouseState.test(button);
     }
 
-    vec2i getMousePos() const { return myMousePos; }
+    vec2i getMousePos() const override { return myMousePos; }
 
-    void setWindowTitle(const std::string& text) {
+    void setWindowTitle(const std::string& text) override {
         if (!(myTitle == text)) {
             SetWindowTextW(myHWND, Widen(text).str());
             myTitle = text;
         }
     }
 
-    vec2i getWindowSize() const { return mySize; }
+    vec2i getWindowSize() const override { return mySize; }
 
-    const std::string& getWindowTitle() const { return myTitle; }
+    const std::string& getWindowTitle() const override { return myTitle; }
 
-    InputEvents& getEvents() { return myEvents; }
+    InputEvents& getEvents() override { return myEvents; }
 
-    bool isActive() const { return myIsActive; }
+    bool isActive() const override { return myIsActive; }
 
-    void terminate() { myIsTerminated = true; }
+    void terminate() override { myIsTerminated = true; }
 
 };  // SystemImpl.
 };  // anonymous namespace.
@@ -988,7 +984,7 @@ System* gSystem = nullptr;
 using namespace Vortex;
 
 std::string System::getLocalTime() {
-    time_t t = time(0);
+    time_t t = time(nullptr);
     tm* now = localtime(&t);
     std::string time = asctime(localtime(&t));
     if (time.back() == '\n') Str::pop_back(time);
@@ -1004,7 +1000,7 @@ std::string System::getBuildData() {
 static void ApplicationStart() {
     // Set the executable directory as the working dir.
     GetCurrentDirectoryW(MAX_PATH, sRunDir);
-    GetModuleFileNameW(NULL, sExeDir, MAX_PATH);
+    GetModuleFileNameW(nullptr, sExeDir, MAX_PATH);
     wchar_t* finalSlash = wcsrchr(sExeDir, L'\\');
     if (finalSlash) finalSlash[1] = 0;
     SetCurrentDirectoryW(sExeDir);
@@ -1018,7 +1014,7 @@ static void ApplicationStart() {
 
 static void ApplicationEnd() {
     // Log the application termination time.
-    time_t t = time(0);
+    time_t t = time(nullptr);
     tm* now = localtime(&t);
     Debug::logBlankLine();
     Debug::log("Closing ArrowVortex :: %s", System::getLocalTime().c_str());

--- a/src/System/Thread.cpp
+++ b/src/System/Thread.cpp
@@ -9,7 +9,7 @@ namespace Vortex {
 
 BackgroundThread::BackgroundThread() { done = false; }
 
-BackgroundThread::~BackgroundThread() {}
+BackgroundThread::~BackgroundThread() = default;
 
 void BackgroundThread::start() {
     if (isDone()) {


### PR DESCRIPTION
I used the -fix argument on clang-tidy to squash the hundreds of warnings that our style guide was creating on build.
Think it's fine.