### PR TITLE
Fix escaping for semicolon and pound characters

### DIFF
--- a/src/Simfile/SaveSm.cpp
+++ b/src/Simfile/SaveSm.cpp
@@ -58,7 +58,7 @@ static String Escape(const char* name, const char* str)
 	Str::replace(s, "\\", "\\\\");
 	Str::replace(s, ":", "\\:");
 	Str::replace(s, ";", "\\;");
-	Str::replace(s, ";", "\\#");
+	Str::replace(s, "#", "\\#");
 	return s;
 }
 


### PR DESCRIPTION
Seems like a typo that's causing `;` to be escaped as `\\#`, and `#` not being escaped at all.