### PR TITLE
Animated Song Banner / CDTitle images.

### DIFF
--- a/src/Core/Texture.h
+++ b/src/Core/Texture.h
@@ -75,6 +75,11 @@ class Texture {
                            Texture* outTiles, bool mipmap = false,
                            Format fmt = RGBA);
 
+    /// Creates a set of textures from a sprite sheet / tile sheet.
+    static int createTiles(const char* path, int tileW, int tileH, int numTiles,
+                           std::vector<Texture>& outTiles, bool mipmap = false,
+                           Format fmt = RGBA);
+
    private:
     Data* data_;  // TODO: replace with a more descriptive variable name.
 };

--- a/src/Core/TextureImpl.cpp
+++ b/src/Core/TextureImpl.cpp
@@ -522,4 +522,31 @@ int Texture::createTiles(const char* path, int tileW, int tileH, int numTiles,
     return tileIndex;
 }
 
+int Texture::createTiles(const char* path, int tileW, int tileH, int numTiles,
+                         std::vector<Texture>& outTiles, bool mipmap,
+                         Format fmt) {
+    ImageLoader::Data image = ImageLoader::load(path, TexLoadFormats[fmt]);
+    int ch = sNumChannels[fmt];
+
+    Vector<uint8_t> pixelData;
+    pixelData.resize(tileW * tileH * ch, 0);
+    uint8_t* dst = pixelData.begin();
+    int tileIndex = 0;
+
+    for (int y = 0; y + tileH <= image.height; y += tileH) {
+        for (int x = 0; x + tileW <= image.width; x += tileW) {
+            if (tileIndex < numTiles) {
+                uint8_t* src = image.pixels + ((y * image.width) + x) * ch;
+                for (int line = 0; line < tileH; ++line) {
+                    memcpy(dst + line * tileW * ch,
+                           src + line * image.width * ch, tileW * ch);
+                }
+                outTiles.emplace_back(tileW, tileH, dst, mipmap, fmt);
+            }
+        }
+    }
+    ImageLoader::release(image);
+
+    return tileIndex;
+}
 };  // namespace Vortex

--- a/src/Dialogs/SongProperties.cpp
+++ b/src/Dialogs/SongProperties.cpp
@@ -33,8 +33,7 @@ struct DialogSongProperties::BannerWidget : public GuiWidget {
         auto index = 0;
         if (tex.size() > 1) {
             timer += clamp(deltaTime.count(), 0.0, 1.0);
-            index =
-                static_cast<int>(floor(timer / 0.1)) % tex.size();  // 10 FPS
+            index = static_cast<int>(timer / 0.1) % tex.size();  // 10 FPS
         }
 
         Texture frame = tex[index];
@@ -56,8 +55,7 @@ struct DialogSongProperties::CdTitleWidget : public GuiWidget {
         auto index = 0;
         if (tex.size() > 1) {
             timer += clamp(deltaTime.count(), 0.0, 1.0);
-            index =
-                static_cast<int>(floor(timer / 0.1)) % tex.size();  // 10 FPS
+            index = static_cast<int>(timer / 0.1) % tex.size();  // 10 FPS
         }
 
         Texture frame = tex[index];

--- a/src/Dialogs/SongProperties.cpp
+++ b/src/Dialogs/SongProperties.cpp
@@ -28,14 +28,21 @@ struct DialogSongProperties::BannerWidget : public GuiWidget {
         height_ = BANNER_H;
     }
     void onDraw() override {
-        recti r = rect_;
-        if (tex.handle()) {
-            Draw::fill(rect_, Colors::white, tex.handle());
-        } else {
-            Draw::fill(rect_, Color32(26));
+        if (tex.size() == 0 || !tex[0].handle()) return;
+
+        auto index = 0;
+        if (tex.size() > 1) {
+            timer += clamp(deltaTime.count(), 0.0, 1.0);
+            index =
+                static_cast<int>(floor(timer / 0.1)) % tex.size();  // 10 FPS
         }
+
+        Texture frame = tex[index];
+        recti r = rect_;
+        Draw::fill(rect_, Colors::white, frame.handle());
     }
-    Texture tex;
+    std::vector<Texture> tex;
+    double timer = 0;
 };
 
 struct DialogSongProperties::CdTitleWidget : public GuiWidget {
@@ -44,9 +51,19 @@ struct DialogSongProperties::CdTitleWidget : public GuiWidget {
         height_ = 75;
     }
     void onDraw() override {
+        if (tex.size() == 0 || !tex[0].handle()) return;
+
+        auto index = 0;
+        if (tex.size() > 1) {
+            timer += clamp(deltaTime.count(), 0.0, 1.0);
+            index =
+                static_cast<int>(floor(timer / 0.1)) % tex.size();  // 10 FPS
+        }
+
+        Texture frame = tex[index];
         recti r = rect_;
-        auto h = tex.height();
-        auto w = tex.width();
+        auto h = frame.height();
+        auto w = frame.width();
         // Scale the CD Title to fit if it is too big
         auto aspect = static_cast<float>(w) / static_cast<float>(h);
         if (h > height_) {
@@ -59,11 +76,10 @@ struct DialogSongProperties::CdTitleWidget : public GuiWidget {
         }
         // Place the CD Title in the middle of the box
         r = {rect_.x + (width_ - w) / 2, rect_.y + (height_ - h) / 2, w, h};
-        if (tex.handle()) {
-            Draw::fill(r, Colors::white, tex.handle());
-        }
+        Draw::fill(r, Colors::white, frame.handle());
     }
-    Texture tex;
+    std::vector<Texture> tex;
+    double timer = 0;
 };
 
 DialogSongProperties::~DialogSongProperties() {
@@ -281,37 +297,57 @@ void DialogSongProperties::myUpdateProperties() {
 }
 
 void DialogSongProperties::myUpdateBanner() {
-    myBannerWidget->tex = Texture();
+    myBannerWidget->tex.clear();
     if (gSimfile->isOpen()) {
         auto meta = gSimfile->get();
         std::string filename = meta->banner;
         if (filename.length()) {
             std::string path = gSimfile->getDir() + filename;
-            myBannerWidget->tex = Texture(path.c_str());
-            if (myBannerWidget->tex.handle() == 0) {
-                HudWarning("Could not open \"%s\".", filename.c_str());
-            }
+            myBannerWidget->tex = extractSpriteSheet(path, filename);
         }
     }
 }
 
 void DialogSongProperties::myUpdateCdTitle() {
-    myCdTitleWidget->tex = Texture();
+    myCdTitleWidget->tex.clear();
     if (gSimfile->isOpen()) {
         auto meta = gSimfile->get();
         std::string filename = meta->cdTitle;
         if (filename.length()) {
             std::string path = gSimfile->getDir() + filename;
-            myCdTitleWidget->tex = Texture(path.c_str());
-            if (myCdTitleWidget->tex.handle() == 0) {
-                HudWarning("Could not open \"%s\".", filename.c_str());
-            }
+            myCdTitleWidget->tex = extractSpriteSheet(path, filename);
         }
     }
 }
 
 // ================================================================================================
 // Other functions.
+
+std::vector<Texture> DialogSongProperties::extractSpriteSheet(
+    const std::string& path, const std::string& filename) {
+    Texture full = Texture(path.c_str());
+    std::vector<Texture> frames;
+
+    if (full.handle() == 0) {
+        HudWarning("Could not open \"%s\".", filename.c_str());
+        frames.push_back(full);
+        return frames;
+    }
+
+    int w = 0, h = 0, tiles = 1;
+    if (sscanf(filename.c_str(), "%*[^ ] %dx%d.%*s", &w, &h) == 2) {
+        tiles = max(1, w * h);
+    }
+
+    if (tiles > 1) {
+        auto tileW = full.width() / w;
+        auto tileH = full.height() / h;
+        Texture::createTiles(path.c_str(), tileW, tileH, tiles, frames);
+    } else
+        frames.push_back(full);
+
+    return frames;
+}
 
 void DialogSongProperties::onChanges(int changes) {
     if (changes & VCM_SONG_PROPERTIES_CHANGED) {

--- a/src/Dialogs/SongProperties.h
+++ b/src/Dialogs/SongProperties.h
@@ -39,6 +39,9 @@ class DialogSongProperties : public EditorDialog {
     void mySetProperty(int p);
     void mySetDisplayBpm();
 
+    std::vector<Texture> extractSpriteSheet(const std::string& path,
+                                            const std::string& filename);
+
     std::string myTitle;
     std::string mySubtitle;
     std::string myArtist;


### PR DESCRIPTION
This adds basic animation support for files using the `filename ##x##.ext` filename structure.
Playback rate is based on game reference and is around 10 FPS based on test.

Most games seem to support animated CDTitle in this manner, but banners are lacking support generally.