### PR TITLE
Clickable Breakdown Menu

### DIFF
--- a/src/Dialogs/TempoBreakdown.cpp
+++ b/src/Dialogs/TempoBreakdown.cpp
@@ -6,6 +6,8 @@
 #include <Managers/TempoMan.h>
 #include <Managers/SimfileMan.h>
 
+#include <Editor/View.h>
+
 #include <Simfile/SegmentList.h>
 #include <Simfile/SegmentGroup.h>
 
@@ -39,6 +41,42 @@ struct DialogTempoBreakdown::TempoList : public WgScrollRegion {
         ClampScrollPositions();
     }
 
+    const Segment* getSegmentUnderMouse(vec2i position) {
+        int my = position.y - 16;
+        int y = rect_.y - scroll_position_y_;
+
+        if (!isMouseOver() || my < y || position.x > rect_.x + getViewWidth())
+            return nullptr;
+
+        auto segments = gTempo->getSegments();
+        for (const auto& segment : *segments) {
+            if (segment.size()) {
+                y += 22;
+                auto seg = segment.begin(), segEnd = segment.end();
+                while (seg != segEnd && y < my) {
+                    y += 16, ++seg;
+                }
+                y += 4;
+                if (y >= my) return seg.ptr;
+            }
+        }
+
+        return nullptr;
+    }
+
+    void onMousePress(MousePress& evt) override {
+        if (isMouseOver()) {
+            if (isEnabled() && evt.button == Mouse::LMB && evt.unhandled()) {
+                auto seg = getSegmentUnderMouse(gui_->getMousePos());
+                if (seg) {
+                    gView->setCursorRow(seg->row);
+                    evt.setHandled();
+                }
+            }
+        }
+        WgScrollRegion::onMousePress(evt);
+    }
+
     void onDraw() override {
         if (gSimfile->isClosed()) return;
 
@@ -53,6 +91,7 @@ struct DialogTempoBreakdown::TempoList : public WgScrollRegion {
 
         Draw::fill({view.x + view.w / 2, view.y, 1, view.h}, Color32(26));
 
+        vec2i m = gui_->getMousePos();
         auto segments = gTempo->getSegments();
         for (const auto& segment : *segments) {
             if (segment.size()) {
@@ -62,12 +101,15 @@ struct DialogTempoBreakdown::TempoList : public WgScrollRegion {
                 Draw::fill({x, y, view.w, 20}, Color32(26));
                 Text::arrange(Text::MC, style, meta->plural);
                 Text::draw({x, y, view.w, 20});
-                y += 26;
+                y += 22;
 
                 while (seg != segEnd && y < view.y - 20) {
                     y += 16, ++seg;
                 }
                 while (seg != segEnd && y < view.y + view.h + 20) {
+                    if (isMouseOver() && m.y >= y && m.y < y + 16)
+                        Draw::fill({x, y - 1, view.w, 20}, Color32(34));
+
                     std::string str = Str::val(seg->row * BEATS_PER_ROW, 3, 3);
                     Text::arrange(Text::MR, style, str.c_str());
                     Text::draw(vec2i{x + view.w / 2 - 6, y + 8});
@@ -78,6 +120,8 @@ struct DialogTempoBreakdown::TempoList : public WgScrollRegion {
 
                     y += 16, ++seg;
                 }
+
+                y += 4;
             }
         }
 


### PR DESCRIPTION
<img width="382" height="416" alt="image" src="https://github.com/user-attachments/assets/4f1fa969-8ad4-476a-9d22-5c8c3e69bd91" />

Allows the list to be clicked to jump to the location of the segment.

Fixes #154.