### PR TITLE
Fix Empty First Measure Column Count Calculation

### DIFF
--- a/src/Simfile/LoadSm.cpp
+++ b/src/Simfile/LoadSm.cpp
@@ -358,7 +358,7 @@ static void ParseNotes(ParseData& data, Chart* chart, const std::string& style,
     // Derive the column count from the first note row.
     int numPlayers = 1;
     int numCols = 0;
-    while (*p == ' ' || *p == '\n') ++p;
+    while (*p == ' ' || *p == '\n' || *p == ',') ++p;
     for (; *p && *p != '\n'; ++p) {
         if (*p == '[') {
             while (*p && *p != ']') ++p;


### PR DESCRIPTION
Skip empty measures until the first valid looking note row when looking for the amount of columns a file has.

This fixes an edge case where the first measure doesn't contain any note data, so AV miscalculates the number of columns to 1 + white space after the comma.

Example:
```
#NOTES:
     dance-single:
     :
     Challenge:
     1:
     
     0.000,0.000,0.000,0.000,0.000:
  //  Measure 0
,  //  Measure 1
0000
0000
0000
0000
,  //  Measure 2
0000
0000
0000
0000
```

This results in a column count of 3 due to `,  `.