### PR TITLE
Multiple Format Clipboard

### DIFF
--- a/src/Editor/CMakeLists.txt
+++ b/src/Editor/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND INC
 	"Action.h"
+	"Clipboard.h"
 	"Common.h"
 	"ConvertToOgg.h"
 	"Editing.h"
@@ -26,6 +27,7 @@ list(APPEND INC
 
 list(APPEND SRC
 	"Action.cpp"
+	"Clipboard.cpp"
 	"Common.cpp"
 	"ConvertToOgg.cpp"
 	"Editing.cpp"

--- a/src/Editor/Clipboard.cpp
+++ b/src/Editor/Clipboard.cpp
@@ -1,0 +1,133 @@
+#include <Editor/Clipboard.h>
+
+#include <Core/StringUtils.h>
+
+#include <Managers/TempoMan.h>
+#include <Managers/NoteMan.h>
+
+#include <System/System.h>
+
+namespace Vortex {
+
+static const char* tag = "ArrowVortex:";
+static const uint8_t version = 2;
+static const uint8_t tagLength = strlen(tag);
+
+// ================================================================================================
+// Clipboard functions.
+
+bool HasClipboardData() {
+    std::string text = gSystem->getClipboardText();
+    return Str::startsWith(text, tag) && text.length() > tagLength;
+}
+
+void SetClipboardData(std::string& data) {
+    std::string text = "ArrowVortex:ver:" + Str::val(version) + ":" + data;
+    gSystem->setClipboardText(text);
+}
+
+ClipboardData GetClipboardData() {
+    ClipboardData clip;
+
+    std::string text = gSystem->getClipboardText();
+
+    if (Str::startsWith(text, tag)) {
+        auto dem = Str::endsWith(text, ":") ? 1 : 0;
+
+        text = Str::substr(text, tagLength, text.length() - tagLength - dem);
+        if (text.length() == 0) return clip;
+
+        auto pairs = Str::split(text, ":", false, false);
+
+        // Parse "key:data" pairs.
+        for (size_t i = 0; i + 1 < pairs.size(); i += 2) {
+            std::string& key = pairs[i];
+            std::string& value = pairs[i + 1];
+
+            if (key == "ver")
+                clip.version = Str::readInt(value);
+
+            else if (key == NotesMan::clipboardTag)
+                Base64Decode(clip.notes, value.c_str());
+
+            else if (key == TempoMan::clipboardTag)
+                Base64Decode(clip.tempos, value.c_str());
+        }
+    }
+
+    return clip;
+}
+
+// ================================================================================================
+// Encoding & Decoding functions.
+
+static const char base64Table[65] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789+/";
+
+static const int8_t base64TableDecode[256] = {
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 62, 64, 64, 64, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+    61, 64, 64, 64, 65, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64,
+    64, 64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+    43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64};
+
+void Base64Encode(std::string& out, const uint8_t* in, int size) {
+    int i = 0;
+    out.push_back(':');
+    while (i < size) {
+        uint32_t v = (in[i] << 16) | ((i + 1 < size ? in[i + 1] : 0) << 8) |
+                     ((i + 2 < size ? in[i + 2] : 0));
+
+        // Compression - 3 chars -> 1 char
+        if (v == 0 && i + 2 < size) {
+            out.push_back('-');
+            i += 3;
+            continue;
+        }
+
+        out.push_back(base64Table[(v >> 18) & 63]);
+        out.push_back(base64Table[(v >> 12) & 63]);
+        out.push_back(i + 1 < size ? base64Table[(v >> 6) & 63] : '=');
+        out.push_back(i + 2 < size ? base64Table[v & 63] : '=');
+
+        i += 3;
+    }
+    out.push_back(':');
+}
+
+void Base64Decode(Vector<uint8_t>& out, const char* in) {
+    uint32_t v = 0;
+    int valb = -8;
+
+    for (const char* p = in; *p; p++) {
+        // Compression - 1 char -> 3 chars
+        if (*p == '-') {
+            out.push_back(0);
+            out.push_back(0);
+            out.push_back(0);
+            continue;
+        }
+
+        uint8_t d = base64TableDecode[static_cast<uint8_t>(*p)];
+        if (d == 64) continue;
+        if (d == 65) break;
+        v = (v << 6) | d;
+        valb += 6;
+        if (valb >= 0) {
+            out.push_back((v >> valb) & 0xFF);
+            valb -= 8;
+        }
+    }
+}
+}  // namespace Vortex

--- a/src/Editor/Clipboard.cpp
+++ b/src/Editor/Clipboard.cpp
@@ -47,11 +47,15 @@ ClipboardData GetClipboardData() {
             if (key == "ver")
                 clip.version = Str::readInt(value);
 
-            else if (key == NotesMan::clipboardTag)
+            else if (key == NotesMan::clipboardTag) {
                 Base64Decode(clip.notes, value.c_str());
+                clip.count++;
+            }
 
-            else if (key == TempoMan::clipboardTag)
+            else if (key == TempoMan::clipboardTag) {
                 Base64Decode(clip.tempos, value.c_str());
+                clip.count++;
+            }
         }
     }
 

--- a/src/Editor/Clipboard.h
+++ b/src/Editor/Clipboard.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Core/Vector.h>
+
+#include <Simfile/Common.h>
+
+namespace Vortex {
+
+struct ClipboardData {
+    uint8_t version;
+    Vector<uint8_t> notes;
+    Vector<uint8_t> tempos;
+};
+
+// Returns true clipboard has ArrowVortex data.
+bool HasClipboardData();
+
+// Encodes the given data to an Base64- string and sends it to the clipboard.
+void SetClipboardData(std::string& data);
+
+// Reads a string from the clipboard and decodes it using Base64-.
+ClipboardData GetClipboardData();
+
+// Encodes StreamData into Base64-.
+// This prepends/appends ":" before and after the encoded data.
+// Slight compression is done by replacing "AAA" instances with `-`.
+void Base64Encode(std::string& out, const uint8_t* in, int size);
+
+// Decodes Base64- data into StreamData.
+void Base64Decode(Vector<uint8_t>& out, const char* in);
+
+}  // namespace Vortex

--- a/src/Editor/Clipboard.h
+++ b/src/Editor/Clipboard.h
@@ -8,6 +8,7 @@ namespace Vortex {
 
 struct ClipboardData {
     uint8_t version;
+    uint8_t count;
     Vector<uint8_t> notes;
     Vector<uint8_t> tempos;
 };

--- a/src/Editor/Common.cpp
+++ b/src/Editor/Common.cpp
@@ -6,88 +6,11 @@
 #include <Core/StringUtils.h>
 #include <Core/Draw.h>
 
-#include <System/Debug.h>
 #include <System/System.h>
 
 #include <Editor/TextOverlay.h>
 
 namespace Vortex {
-
-// ================================================================================================
-// Clipboard functions.
-
-static const int a85shift[4] = {24, 16, 8, 0};
-static const uint32_t a85div[5] = {85 * 85 * 85 * 85, 85 * 85 * 85, 85 * 85, 85,
-                                   1};
-
-static void Ascii85enc(std::string& out, const uint8_t* in, int size) {
-    // Convert to 32-bit integers (big endian) and pad with zeroes.
-    Vector<uint32_t> blocks((size + 3) / 4, 0);
-    for (int i = 0; i < size; ++i) {
-        blocks[i / 4] += in[i] << a85shift[i & 3];
-    }
-
-    // Encode 32-bit integers to base 85.
-    for (int i = 0; i != blocks.size(); ++i) {
-        if (blocks[i] == 0 && i != blocks.size() - 1) {
-            Str::append(out, 'z');
-        } else
-            for (unsigned int j : a85div) {
-                Str::append(out, 33 + (blocks[i] / j) % 85);
-            }
-    }
-
-    // Remove padded bytes from output.
-    int padding = blocks.size() * 4 - size;
-    Str::truncate(out, out.length() - padding);
-}
-
-static void Ascii85dec(Vector<uint8_t>& out, const char* in) {
-    // Convert from base 85 to 32-bit integers.
-    int padding = 0;
-    while (*in) {
-        if (*in == 'z') {
-            out.resize(out.size() + 4, 0);
-            ++in;
-        } else {
-            int v = 0, i = 0;
-            for (; i != 5 && *in; ++i) {
-                v = v * 85 + (*in++) - 33;
-            }
-            for (; i != 5; ++i, ++padding) {
-                v = v * 85 + 'u' - 33;
-            }
-            for (i = 0; i != 4; ++i) {
-                out.push_back((v >> a85shift[i]) & 0xFF);
-            }
-        }
-    }
-
-    // Remove padded bytes from output.
-    out.resize(out.size() - padding);
-}
-
-bool HasClipboardData(const std::string& tag) {
-    std::string text = gSystem->getClipboardText();
-    std::string prefix = "ArrowVortex:" + tag + ":";
-    return Str::startsWith(text, prefix.c_str());
-}
-
-void SetClipboardData(const std::string& tag, const uint8_t* data, int size) {
-    std::string text = "ArrowVortex:" + tag + ":";
-    Ascii85enc(text, data, size);
-    gSystem->setClipboardText(text);
-}
-
-Vector<uint8_t> GetClipboardData(const std::string& tag) {
-    Vector<uint8_t> buffer;
-    std::string text = gSystem->getClipboardText();
-    std::string prefix = "ArrowVortex:" + tag + ":";
-    if (Str::startsWith(text, prefix.c_str())) {
-        Ascii85dec(buffer, text.data() + prefix.length());
-    }
-    return buffer;
-}
 
 // ================================================================================================
 // Utility functions.

--- a/src/Editor/Common.h
+++ b/src/Editor/Common.h
@@ -117,15 +117,6 @@ enum BackgroundStyle {
     BG_STYLE_CROP        ///< Scale uniformly and crop.
 };
 
-// Returns true if the tag of the clipboard data matches the given tag.
-bool HasClipboardData(const std::string& tag);
-
-// Encodes the given data to an ascii85 string and sends it to the clipboard.
-void SetClipboardData(const std::string& tag, const uint8_t* data, int size);
-
-// Reads a string from the clipboard and decodes it using ascii85.
-Vector<uint8_t> GetClipboardData(const std::string& tag);
-
 // Returns a text representation of the given snap type.
 const char* ToString(SnapType st);
 

--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -1,17 +1,19 @@
 #include <Editor/Editing.h>
 
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <set>
+#include <string>
 
+#include <Core/Core.h>
+#include <Core/Input.h>
 #include <Core/StringUtils.h>
 #include <Core/Utils.h>
+#include <Core/Vector.h>
 #include <Core/Xmr.h>
 
-#include <System/Debug.h>
-#include <System/System.h>
-
-#include <Simfile/SegmentGroup.h>
-
+#include <Editor/Clipboard.h>
 #include <Editor/Common.h>
 #include <Editor/History.h>
 #include <Editor/Menubar.h>
@@ -21,24 +23,22 @@
 #include <Editor/TempoBoxes.h>
 #include <Editor/View.h>
 
+#include <Managers/ChartMan.h>
+#include <Managers/NoteMan.h>
 #include <Managers/SimfileMan.h>
 #include <Managers/StyleMan.h>
 #include <Managers/TempoMan.h>
 
-#include <cmath>
-#include <Core/Core.h>
-#include <Core/Input.h>
-#include <Core/Vector.h>
-#include <cstdint>
-#include <Managers/ChartMan.h>
-#include <Managers/NoteMan.h>
 #include <Simfile/Chart.h>
 #include <Simfile/Common.h>
 #include <Simfile/NoteList.h>
 #include <Simfile/Notes.h>
+#include <Simfile/SegmentGroup.h>
 #include <Simfile/Segments.h>
 #include <Simfile/Tempo.h>
-#include <string>
+
+#include <System/Debug.h>
+#include <System/System.h>
 
 namespace Vortex {
 
@@ -1019,17 +1019,36 @@ struct EditingImpl : public Editing {
                                 !(gSelection->getSelectedRegion()).isEmpty();
         bool hasSelectedSegments = !gTempoBoxes->noneSelected();
 
-        if (hasSelectedNotes && hasSelectedSegments) {
-            HudWarning(
-                "Both timing segments and notes selected, copying notes only.");
-            gNotes->copyToClipboard(myUseTimeBasedCopy);
-            if (remove) gNotes->removeSelectedNotes();
-        } else if (hasSelectedNotes && !hasSelectedSegments) {
-            gNotes->copyToClipboard(myUseTimeBasedCopy);
-            if (remove) gNotes->removeSelectedNotes();
-        } else if (!hasSelectedNotes && hasSelectedSegments) {
-            gTempo->copyToClipboard();
-            if (remove) gTempo->removeSelectedSegments();
+        if (hasSelectedNotes || hasSelectedSegments) {
+            std::string out;
+            auto useTimeCopy = myUseTimeBasedCopy && !hasSelectedSegments;
+
+            // Time-Based Warning for Tempo
+            if (hasSelectedNotes && hasSelectedSegments && myUseTimeBasedCopy)
+                HudWarning(
+                    "Time-based copy does not work for tempo segments, using "
+                    "Row-based copy for both.");
+
+            // Find starting row.
+            int minRow = INT_MAX;
+            if (hasSelectedSegments)
+                minRow = min(minRow, gTempo->minSelectionRow());
+            if (hasSelectedNotes)
+                minRow = min(minRow, gNotes->minSelectionRow());
+
+            // Notes
+            if (hasSelectedNotes) {
+                gNotes->copyToClipboard(out, minRow, useTimeCopy);
+                if (remove) gNotes->removeSelectedNotes();
+            }
+            // Tempo
+            if (hasSelectedSegments) {
+                gTempo->copyToClipboard(out, minRow);
+                if (remove) gTempo->removeSelectedSegments();
+            }
+
+            if (out.length() > 0) SetClipboardData(out);
+
         } else {
             std::string time = Str::formatTime(gView->getCursorTime());
             gSystem->setClipboardText(Str::fmt("%1").arg(time));
@@ -1038,10 +1057,11 @@ struct EditingImpl : public Editing {
     }
 
     void pasteFromClipboard(bool insert) {
-        if (gChart->isOpen() && HasClipboardData(NotesMan::clipboardTag)) {
-            gNotes->pasteFromClipboard(insert);
-        } else if (HasClipboardData(TempoMan::clipboardTag)) {
-            gTempo->pasteFromClipboard(insert);
+        if (HasClipboardData()) {
+            auto clipboard = GetClipboardData();
+
+            if (gChart->isOpen()) gNotes->pasteFromClipboard(clipboard, insert);
+            gTempo->pasteFromClipboard(clipboard, insert);
         } else {
             std::string text = gSystem->getClipboardText();
             double target = Str::readTime(text);

--- a/src/Editor/Editing.cpp
+++ b/src/Editor/Editing.cpp
@@ -1060,8 +1060,13 @@ struct EditingImpl : public Editing {
         if (HasClipboardData()) {
             auto clipboard = GetClipboardData();
 
+            if (clipboard.count > 1) gHistory->startChain();
+
             if (gChart->isOpen()) gNotes->pasteFromClipboard(clipboard, insert);
             gTempo->pasteFromClipboard(clipboard, insert);
+
+            if (clipboard.count > 1)
+                gHistory->finishChain("Pasted from clipboard.");
         } else {
             std::string text = gSystem->getClipboardText();
             double target = Str::readTime(text);

--- a/src/Editor/Selection.cpp
+++ b/src/Editor/Selection.cpp
@@ -118,20 +118,12 @@ struct SelectionImpl : public Selection {
     void onKeyPress(KeyPress& evt) override {
         if (evt.key == Key::A && (evt.keyflags & Keyflag::CTRL) &&
             !evt.handled) {
-
-            // Ctrl + Shift + A == Notes + Tempo
             if ((evt.keyflags & Keyflag::SHIFT)) {
                 gTempoBoxes->selectAll();
                 if (gChart->isOpen()) gNotes->selectAll();
-            }
-
-            // Ctrl + Alt + A || Chart Closed == Tempo
-            if (!gChart->isOpen() || (evt.keyflags & Keyflag::ALT)) {
+            } else if (!gChart->isOpen() || (evt.keyflags & Keyflag::ALT)) {
                 gTempoBoxes->selectAll();
-            }
-            
-            // Ctrl + A == Notes
-            else {
+            } else {
                 gNotes->selectAll();
             }
             evt.handled = true;

--- a/src/Editor/Selection.cpp
+++ b/src/Editor/Selection.cpp
@@ -118,10 +118,21 @@ struct SelectionImpl : public Selection {
     void onKeyPress(KeyPress& evt) override {
         if (evt.key == Key::A && (evt.keyflags & Keyflag::CTRL) &&
             !evt.handled) {
-            if (gChart->isOpen()) {
-                gNotes->selectAll();
-            } else {
+
+            // Ctrl + Shift + A == Notes + Tempo
+            if ((evt.keyflags & Keyflag::SHIFT)) {
                 gTempoBoxes->selectAll();
+                if (gChart->isOpen()) gNotes->selectAll();
+            }
+
+            // Ctrl + Alt + A || Chart Closed == Tempo
+            if (!gChart->isOpen() || (evt.keyflags & Keyflag::ALT)) {
+                gTempoBoxes->selectAll();
+            }
+            
+            // Ctrl + A == Notes
+            else {
+                gNotes->selectAll();
             }
             evt.handled = true;
         }
@@ -343,8 +354,8 @@ struct SelectionImpl : public Selection {
     void selectRegion(int row, int endRow) override {
         setRegion(row, endRow);
 
-        auto firstRow = std::min(row, endRow);
-        auto lastRow = std::max(row, endRow);
+        auto firstRow = min(row, endRow);
+        auto lastRow = max(row, endRow);
         if (row != endRow) {
             double m1 = gTempo->beatToMeasure(firstRow * BEATS_PER_ROW);
             double m2 = gTempo->beatToMeasure(lastRow * BEATS_PER_ROW);

--- a/src/Managers/NoteMan.cpp
+++ b/src/Managers/NoteMan.cpp
@@ -1,31 +1,33 @@
 #include <Managers/NoteMan.h>
 
 #include <algorithm>
-
-#include <Core/StringUtils.h>
-#include <Core/Utils.h>
-
-#include <Managers/SimfileMan.h>
-#include <Managers/StyleMan.h>
-#include <Managers/TempoMan.h>
-#include <Simfile/TimingData.h>
+#include <cstdint>
+#include <string>
 
 #include <Core/ByteStream.h>
 #include <Core/Core.h>
+#include <Core/StringUtils.h>
+#include <Core/Utils.h>
 #include <Core/Vector.h>
-#include <cstdint>
+
+#include <Editor/Clipboard.h>
 #include <Editor/Common.h>
 #include <Editor/Editing.h>
 #include <Editor/Editor.h>
 #include <Editor/History.h>
 #include <Editor/Selection.h>
 #include <Editor/View.h>
+
+#include <Managers/SimfileMan.h>
+#include <Managers/StyleMan.h>
+#include <Managers/TempoMan.h>
+
 #include <Simfile/Chart.h>
 #include <Simfile/Common.h>
 #include <Simfile/NoteList.h>
 #include <Simfile/Notes.h>
 #include <Simfile/Simfile.h>
-#include <string>
+#include <Simfile/TimingData.h>
 
 namespace Vortex {
 
@@ -684,7 +686,26 @@ struct NotesManImpl : public NotesMan {
     // ================================================================================================
     // NotesManImpl :: clipboard functions.
 
-    void copyToClipboard(bool timeBased) override {
+    int minSelectionRow() const override {
+        int minRow = INT_MAX;
+
+        // Region
+        auto region = gSelection->getSelectedRegion();
+        if (!region.isEmpty()) minRow = min(minRow, region.beginRow);
+
+        // Notes
+        for (auto& note : myNotes) {
+            if (note.isSelected) {
+                minRow = min(minRow, note.row);
+                break;
+            }
+        }
+
+        return minRow;
+    }
+
+    void copyToClipboard(std::string& out, int minRow,
+                         bool timeBased) override {
         // Get the note selection.
         NoteList notes;
         int numNotes = gSelection->getSelectedNotes(notes);
@@ -697,15 +718,18 @@ struct NotesManImpl : public NotesMan {
             if (timeBased) {
                 notes.encode(stream, gTempo->getTimingData(), true);
             } else {
-                notes.encode(stream, true);
+                notes.encode(stream, true, minRow);
             }
-            SetClipboardData(clipboardTag, stream.data(), stream.size());
+            out.append(clipboardTag);
+            Base64Encode(out, stream.data(), stream.size());
             HudInfo("Copied %i notes", numNotes);
         }
     }
 
-    void pasteFromClipboard(bool insert) override {
-        Vector<uint8_t> buffer = GetClipboardData(clipboardTag);
+    void pasteFromClipboard(ClipboardData clipboard, bool insert) override {
+        Vector<uint8_t> buffer = clipboard.notes;
+        if (buffer.size() == 0) return;
+
         ReadStream stream(buffer.data(), buffer.size());
 
         // Check if the note data is time-based.

--- a/src/Managers/NoteMan.h
+++ b/src/Managers/NoteMan.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Editor/Clipboard.h>
+
 #include <Simfile/Notes.h>
 
 namespace Vortex {
@@ -61,8 +63,10 @@ struct NotesMan {
     virtual void insertRows(int row, int numRows, bool curChartOnly) = 0;
 
     // Clipboard functions.
-    virtual void copyToClipboard(bool timeBased) = 0;
-    virtual void pasteFromClipboard(bool insert) = 0;
+    virtual int minSelectionRow() const = 0;
+    virtual void copyToClipboard(std::string& out, int minRow,
+                                 bool timeBased) = 0;
+    virtual void pasteFromClipboard(ClipboardData clipboard, bool insert) = 0;
 
     // Statistics functions.
     virtual int getNumSteps() const = 0;  ///< Includes jumps/holds/rolls.

--- a/src/Managers/TempoMan.cpp
+++ b/src/Managers/TempoMan.cpp
@@ -1,26 +1,26 @@
 #include <Managers/TempoMan.h>
 
+#include <algorithm>
 #include <math.h>
 
-#include <Core/Utils.h>
-#include <Core/StringUtils.h>
-#include <Core/VectorUtils.h>
 #include <Core/ByteStream.h>
+#include <Core/StringUtils.h>
+#include <Core/Utils.h>
+#include <Core/VectorUtils.h>
 
-#include <Simfile/SegmentList.h>
-#include <Simfile/SegmentGroup.h>
-#include <Simfile/TimingData.h>
+#include <Editor/Clipboard.h>
+#include <Editor/Common.h>
+#include <Editor/Editor.h>
+#include <Editor/History.h>
+#include <Editor/Selection.h>
+#include <Editor/TempoBoxes.h>
+#include <Editor/View.h>
 
 #include <Managers/SimfileMan.h>
 
-#include <Editor/History.h>
-#include <Editor/Common.h>
-#include <Editor/Editor.h>
-#include <Editor/Selection.h>
-#include <Editor/View.h>
-#include <Editor/TempoBoxes.h>
-
-#include <algorithm>
+#include <Simfile/SegmentGroup.h>
+#include <Simfile/SegmentList.h>
+#include <Simfile/TimingData.h>
 
 #define TEMPO_MAN ((TempoManImpl*)gTempo)
 
@@ -461,7 +461,15 @@ struct TempoManImpl : public TempoMan {
     // ================================================================================================
     // TempoManImpl :: clipboard functions.
 
-    void copyToClipboard() override {
+    int minSelectionRow() const override {
+        auto boxes = gTempoBoxes->getBoxes();
+        for (auto& box : boxes) {
+            if (box.isSelected) return box.row;
+        }
+        return INT_MAX;
+    }
+
+    void copyToClipboard(std::string& out, int minRow) override {
         SegmentGroup clipboard;
 
         // Copy all the selected segments.
@@ -484,10 +492,12 @@ struct TempoManImpl : public TempoMan {
         }
 
         // Find out what the first row is.
-        int row = INT_MAX;
-        for (auto& list : clipboard) {
-            if (list.size()) {
-                row = min(row, list.begin()->row);
+        int row = minRow;
+        if (row == INT_MAX) {
+            for (auto& list : clipboard) {
+                if (list.size()) {
+                    row = min(row, list.begin()->row);
+                }
             }
         }
 
@@ -502,18 +512,21 @@ struct TempoManImpl : public TempoMan {
         if (clipboard.numSegments() > 0) {
             WriteStream stream;
             clipboard.encode(stream);
-            SetClipboardData(clipboardTag, stream.data(), stream.size());
+            out.append(clipboardTag);
+            Base64Encode(out, stream.data(), stream.size());
             HudNote("Copied %s", clipboard.description().c_str());
         }
     }
 
-    void pasteFromClipboard(bool insert) override {
-        SegmentEdit clipboard;
+    void pasteFromClipboard(ClipboardData clipboard, bool insert) override {
+        SegmentEdit edit;
 
         // Decode the clipboard data.
-        Vector<uint8_t> data = GetClipboardData(clipboardTag);
-        ReadStream stream(data.begin(), data.size());
-        clipboard.add.decode(stream);
+        Vector<uint8_t> buffer = clipboard.tempos;
+        if (buffer.size() == 0) return;
+
+        ReadStream stream(buffer.begin(), buffer.size());
+        edit.add.decode(stream);
         if (stream.success() == false || stream.bytesleft() > 0) {
             HudError("Clipboard contains invalid tempo data.");
             return;
@@ -521,14 +534,14 @@ struct TempoManImpl : public TempoMan {
 
         // Offset all segments to the cursor row.
         int row = gView->getCursorRow();
-        for (auto& list : clipboard.add) {
+        for (auto& list : edit.add) {
             for (auto seg = list.begin(), end = list.end(); seg != end; ++seg) {
                 seg->row += row;
             }
         }
 
         // Add the pasted segments to the current tempo.
-        modify(clipboard, !insert);
+        modify(edit, !insert);
     }
 
     // ================================================================================================

--- a/src/Managers/TempoMan.h
+++ b/src/Managers/TempoMan.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Editor/Clipboard.h>
+
 #include <Simfile/Tempo.h>
 #include <Simfile/SegmentGroup.h>
 
@@ -72,8 +74,11 @@ struct TempoMan {
     virtual void modify(const SegmentEdit& edit, bool clearRegion) = 0;
     virtual void insertRows(int row, int numRows, bool curChartOnly) = 0;
     virtual void removeSelectedSegments() = 0;
-    virtual void pasteFromClipboard(bool insert) = 0;
-    virtual void copyToClipboard() = 0;
+
+    /// Clipboard
+    virtual int minSelectionRow() const = 0;
+    virtual void pasteFromClipboard(ClipboardData clipboard, bool insert) = 0;
+    virtual void copyToClipboard(std::string& out, int minRow) = 0;
 
     /// Sets the global music offset.
     virtual void setOffset(double offset) = 0;

--- a/src/Simfile/NoteList.cpp
+++ b/src/Simfile/NoteList.cpp
@@ -507,10 +507,14 @@ static void DecodeNote(ReadStream& in, Note& out, TempoRowTracker& tracker,
 }
 
 void NoteList::encode(WriteStream& out, bool removeOffset) const {
+    encode(out, removeOffset, INT_MAX);
+}
+
+void NoteList::encode(WriteStream& out, bool removeOffset, int rowStart) const {
     int offsetRows = 0;
     out.writeNum(myNum);
     if (removeOffset && myNum > 0) {
-        offsetRows = -myNotes[0].row;
+        offsetRows = -min(myNotes[0].row, rowStart);
     }
     for (int i = 0; i < myNum; ++i) {
         EncodeNote(out, myNotes[i], offsetRows);

--- a/src/Simfile/NoteList.h
+++ b/src/Simfile/NoteList.h
@@ -49,6 +49,7 @@ class NoteList {
 
     // Encodes the note data and writes it to a bytestream.
     void encode(WriteStream& out, bool removeOffset) const;
+    void encode(WriteStream& out, bool removeOffset, int rowStart) const;
 
     // Alternative version of encode that writes time stamps instead of rows.
     void encode(WriteStream& out, const TimingData& timing, bool removeOffset);


### PR DESCRIPTION
# Main Features
- New Shortcuts:
    - Ctrl + Alt + A = "Select All Tempo"
    - Ctrl + Shift + A = "Select All Tempo + Notes"
	
- Format supports multiple "tag:data" pairs.
- Has a version tag to identify breaking encoding changes.
- Mostly stock Base64 encoding.
     - Tweaked to encode a `0` value to a `-` to compress 3 characters to 1 character.
- Moved into separate class to organize better.

Example:
`ArrowVortex:ver:2:notes:AAEDAMA=:tempo:AQAA--AACAZkAA:`

**Small Details:**
- Intentionally breaks compatibility with older paste detection to prevent issues.
     - Done by forcing the version tag at the beginning, as older versions check for `ArrowVortex:notes` or `ArrowVortex:tempo`.
- Starting row when copying both notes and tempo is based on the min row between them.
- Time-based copy is disabled when copying both, due to tempo lacking the functionallity.