### PR TITLE
Replace special chars in labels with lookalikes

### DIFF
--- a/src/Dialogs/AdjustTempoSM5.cpp
+++ b/src/Dialogs/AdjustTempoSM5.cpp
@@ -256,7 +256,9 @@ void DialogAdjustTempoSM5::onAction(int id) {
             gTempo->addSegment(Fake(row, rows));
         } break;
         case ACT_LABEL_SET: {
-            if (strpbrk(myLabelText.c_str(), ";,=") != nullptr) {
+            const bool hasSpecialChars = Str::findAnyOf(myLabelText, ";,=") != std::string::npos;
+
+            if (hasSpecialChars) {
                 HudWarning(
                     "A Label cannot contain commas, semicolons, or equal "
                     "signs; they will be replaced with very similar-looking characters.");
@@ -264,6 +266,7 @@ void DialogAdjustTempoSM5::onAction(int id) {
                 Str::replace(myLabelText, ";", ";");
                 Str::replace(myLabelText, "=", "᐀");
             }
+
             gTempo->addSegment(Label(row, myLabelText));
         } break;
     };

--- a/src/Dialogs/AdjustTempoSM5.cpp
+++ b/src/Dialogs/AdjustTempoSM5.cpp
@@ -259,10 +259,10 @@ void DialogAdjustTempoSM5::onAction(int id) {
             if (strpbrk(myLabelText.c_str(), ";,=") != nullptr) {
                 HudWarning(
                     "A Label cannot contain commas, semicolons, or equal "
-                    "signs; they will be replaced with underscores.");
-                Str::replace(myLabelText, ",", "_");
-                Str::replace(myLabelText, ";", "_");
-                Str::replace(myLabelText, "=", "_");
+                    "signs; they will be replaced with very similar-looking characters.");
+                Str::replace(myLabelText, ",", "¸");
+                Str::replace(myLabelText, ";", ";");
+                Str::replace(myLabelText, "=", "᐀");
             }
             gTempo->addSegment(Label(row, myLabelText));
         } break;


### PR DESCRIPTION
Exactly what it says on the tin. Don't replace with underscores, replace with lookalikes.

Don't merge for a bit.