### PR TITLE
Clipboard, String Replace fixes.

### DIFF
--- a/src/Core/StringUtils.cpp
+++ b/src/Core/StringUtils.cpp
@@ -265,7 +265,7 @@ void Str::replace(std::string& s, const char* fnd, const char* rep) {
     while (pos != std::string::npos) {
         s.erase(s.begin() + pos, s.begin() + pos + fndlen);
         insert(s, pos, rep);
-        pos = find(s, fnd);
+        pos = find(s, fnd, pos + replen);
     }
 }
 

--- a/src/Editor/Clipboard.cpp
+++ b/src/Editor/Clipboard.cpp
@@ -93,7 +93,7 @@ void Base64Encode(std::string& out, const uint8_t* in, int size) {
         uint32_t v = (in[i] << 16) | ((i + 1 < size ? in[i + 1] : 0) << 8) |
                      ((i + 2 < size ? in[i + 2] : 0));
 
-        // Compression - 3 chars -> 1 char
+        // Compression - 4 chars -> 1 char
         if (v == 0 && i + 2 < size) {
             out.push_back('-');
             i += 3;
@@ -115,7 +115,7 @@ void Base64Decode(Vector<uint8_t>& out, const char* in) {
     int valb = -8;
 
     for (const char* p = in; *p; p++) {
-        // Compression - 1 char -> 3 chars
+        // Compression - 1 char -> 4 chars
         if (*p == '-') {
             out.push_back(0);
             out.push_back(0);

--- a/src/Editor/Clipboard.h
+++ b/src/Editor/Clipboard.h
@@ -7,8 +7,8 @@
 namespace Vortex {
 
 struct ClipboardData {
-    uint8_t version;
-    uint8_t count;
+    uint8_t version = 0;
+    uint8_t count = 0;
     Vector<uint8_t> notes;
     Vector<uint8_t> tempos;
 };

--- a/src/Editor/Selection.cpp
+++ b/src/Editor/Selection.cpp
@@ -156,8 +156,7 @@ struct SelectionImpl : public Selection {
         bool timeBased = gView->isTimeBased();
 
         // For this particular case, since this is done via mouse selection, we
-        // allow notes to be selected
-        //   outside the region
+        // allow notes to be selected outside the region.
         if (xl == xr && torT == torB) {
             double clickY = gView->offsetToY(torT);
             const ExpandedNote* closest = nullptr;

--- a/src/Managers/NoteMan.cpp
+++ b/src/Managers/NoteMan.cpp
@@ -691,7 +691,15 @@ struct NotesManImpl : public NotesMan {
 
         // Region
         auto region = gSelection->getSelectedRegion();
-        if (!region.isEmpty()) minRow = min(minRow, region.beginRow);
+        if (!region.isEmpty()) {
+            for (auto& note : myNotes) {
+                if (note.row < region.beginRow) continue;
+                if (note.row > region.endRow) break;
+
+                minRow = min(minRow, note.row);
+                break;
+            }
+        }
 
         // Notes
         for (auto& note : myNotes) {


### PR DESCRIPTION
- Make String replace no longer potentially infinite loop.
- Fix some code comments.
- Set default ClipboardData values.
- Only use notes within a region, not region itself, for minRow.