### PR TITLE
Various Fixes

### DIFF
--- a/src/Dialogs/AdjustSync.cpp
+++ b/src/Dialogs/AdjustSync.cpp
@@ -162,7 +162,15 @@ void DialogAdjustSync::onTick() {
                 fmt.arg(i + 1).arg(t.bpm, 2, 2).arg(t.fitness * 100, 0, 0);
                 myBPMList->addItem(fmt);
             }
-            myApplyBPM->setEnabled(true);
+            if (myDetectionResults.size() == 0) {
+                myBPMList->addItem("- no results found -");
+                myBPMList->setEnabled(false);
+                mySelectedResult = -1;
+                myApplyBPM->setEnabled(false);
+            } else {
+                myBPMList->setEnabled(true);
+                myApplyBPM->setEnabled(true);
+            }
             delete myTempoDetector;
             myTempoDetector = nullptr;
         }

--- a/src/Dialogs/ChartProperties.cpp
+++ b/src/Dialogs/ChartProperties.cpp
@@ -71,7 +71,7 @@ void DialogChartProperties::onChanges(int changes) {
     }
 
     // Update the chart breakdown and note counts if notes change.
-    if (changes & VCM_NOTES_CHANGED) {
+    if (changes & (VCM_NOTES_CHANGED | VCM_TEMPO_CHANGED)) {
         myUpdateNoteInfo();
         myUpdateBreakdown();
     }
@@ -200,7 +200,7 @@ void DialogChartProperties::myUpdateNoteInfo() {
 
     double density = 0.0;
     if (gNotes->begin() < gNotes->end()) {
-        density = static_cast<double>(count[0]) /
+        density = static_cast<double>(gNotes->getNumJudge()) /
                   max(1.0, (gNotes->end() - 1)->time - gNotes->begin()->time);
     }
 

--- a/src/Editor/FindTempo.cpp
+++ b/src/Editor/FindTempo.cpp
@@ -329,7 +329,6 @@ static void CalculateBPM(SerializedTempo* data, Onset* onsets, int numOnsets) {
 
     // In order to determine the BPM, we need at least two onsets.
     if (numOnsets < 2) {
-        tempo.push_back({SIM_DEFAULT_BPM, 0.0, 1.0});
         return;
     }
 

--- a/src/Editor/Selection.cpp
+++ b/src/Editor/Selection.cpp
@@ -120,11 +120,12 @@ struct SelectionImpl : public Selection {
             !evt.handled) {
             if ((evt.keyflags & Keyflag::SHIFT)) {
                 gTempoBoxes->selectAll();
-                if (gChart->isOpen()) gNotes->selectAll();
+                if (gChart->isOpen())
+                    showSelectionResult(SELECT_SET, gNotes->selectAll());
             } else if (!gChart->isOpen() || (evt.keyflags & Keyflag::ALT)) {
                 gTempoBoxes->selectAll();
             } else {
-                gNotes->selectAll();
+                showSelectionResult(SELECT_SET, gNotes->selectAll());
             }
             evt.handled = true;
         }
@@ -273,6 +274,7 @@ struct SelectionImpl : public Selection {
                 HudNote("%s %i %ss.", typeName, numSelected, noteName);
             }
         }
+        gEditor->reportChanges(VCM_SELECTION_CHANGED);
     }
 
     void selectAllNotes() override {

--- a/src/Managers/NoteMan.cpp
+++ b/src/Managers/NoteMan.cpp
@@ -44,6 +44,7 @@ struct NotesManImpl : public NotesMan {
     int myNumSteps = 0, myNumJumps = 0;
     int myNumHolds = 0, myNumRolls = 0;
     int myNumMines = 0, myNumWarps = 0;
+    int myNumFakes = 0, myNumJudge = 0;
 
     Simfile* mySimfile;
     Chart* myChart;
@@ -161,6 +162,7 @@ struct NotesManImpl : public NotesMan {
         myNumSteps = 0, myNumJumps = 0;
         myNumHolds = 0, myNumRolls = 0;
         myNumMines = 0, myNumWarps = 0;
+        myNumFakes = 0, myNumJudge = 0;
 
         int lastRow = -1;
         for (auto& note : myNotes) {
@@ -174,7 +176,9 @@ struct NotesManImpl : public NotesMan {
             } else {
                 ++myNumMines;
             }
+            myNumJudge += !(note.isMine | note.isFake | note.isWarped);
             myNumWarps += note.isWarped;
+            myNumFakes += note.isFake;
         }
     }
 
@@ -196,6 +200,7 @@ struct NotesManImpl : public NotesMan {
         myUpdateNoteTimes();
         myUpdateWarpedNotes();
         myUpdateFakedNotes();
+        myUpdateNoteStats();
     }
 
     // ================================================================================================
@@ -812,6 +817,10 @@ struct NotesManImpl : public NotesMan {
     int getNumRolls() const override { return myNumRolls; }
 
     int getNumWarps() const override { return myNumWarps; }
+
+    int getNumFakes() const override { return myNumFakes; }
+
+    int getNumJudge() const override { return myNumJudge; }
 
     const ExpandedNote* begin() const override { return myNotes.begin(); }
 

--- a/src/Managers/NoteMan.h
+++ b/src/Managers/NoteMan.h
@@ -77,6 +77,8 @@ struct NotesMan {
     virtual int getNumHolds() const = 0;
     virtual int getNumRolls() const = 0;
     virtual int getNumWarps() const = 0;
+    virtual int getNumFakes() const = 0;
+    virtual int getNumJudge() const = 0;  ///< only counts hittable steps.
 
     /// Returns a pointer to the first note.
     virtual const ExpandedNote* begin() const = 0;

--- a/src/Simfile/NoteList.cpp
+++ b/src/Simfile/NoteList.cpp
@@ -354,7 +354,7 @@ void NoteList::prepareEdit(const NoteEdit& in, NoteEditResult& out,
         }
 
         // Check if the note is inside the modified region.
-        if (clearRegion && row >= regionBegin && row < regionEnd) {
+        if (clearRegion && row >= regionBegin && row <= regionEnd) {
             removeNote = true;
         }
 


### PR DESCRIPTION
Each fix is a different commit for easier viewing.

**Report Note Selection for all actions.**
Updates the minimap in line with selections more accurately.
Adds Hud Msg when using Select All shortcut.

**Update NoteStats on Warp/Fake changes.**
This updates Chart Properties when changed.
Changes Note Density text to only factor real hittable notes, as warp based files or large fake usage will skew the value.

**Ignore default found BPM when none found.**
Inform the user no bpm was found instead of giving a bad result.
Fixes #159.

**Include notes at the exact end of region when clearing.**
This prevent left over notes when pasting notes, scaling notes, switching sides, and the stream generator.
Tempo region clearing already included this condition.