### PR TITLE
Make the NPS Graph work more like Stepmania's

### DIFF
--- a/src/Dialogs/ChartProperties.cpp
+++ b/src/Dialogs/ChartProperties.cpp
@@ -267,9 +267,7 @@ class DialogChartProperties::GraphWidget : public GuiWidget {
    public:
     ~GraphWidget() override;
     explicit GraphWidget(GuiContext* gui);
-
     void updateGraph();
-
     void onDraw() override;
 
    private:
@@ -280,92 +278,80 @@ class DialogChartProperties::GraphWidget : public GuiWidget {
     int endMeasure = 0;
     double endTime = 0.0;
 };
-
 DialogChartProperties::GraphWidget::~GraphWidget() = default;
-
 DialogChartProperties::GraphWidget::GraphWidget(GuiContext* gui)
     : GuiWidget(gui) {
     width_ = 340;
     height_ = 100;
 }
-
 void DialogChartProperties::GraphWidget::updateGraph() {
     if (gNotes->empty()) {
         return;
     }
-
     endMeasure = (gSimfile->getEndRow() - 1) / (ROWS_PER_BEAT * 4) + 1;
     endTime = gTempo->rowToTime(gSimfile->getEndRow());
     scale = endMeasure / width_;
-
+    HudError("scale is %d", scale);
+    if (scale < 1) scale = 1;
     int buckets = endMeasure;
-
-    // Just calculate everything for charts with <680 measures.
-    if (scale > 2)
-        buckets = buckets / scale + 1;
-    else
-        scale = 1;
-
     peak = 0;
     data.resize(buckets);
     for (int i = 0; i < buckets; i++) data[i] = 0;
-
     for (auto& note : *gNotes) {
         int measure = note.row / (ROWS_PER_BEAT * 4);
-        if (note.isMine || note.isWarped || note.isFake ||
-            (scale > 1 && measure % scale != 0))
-            continue;
-        data[measure / scale]++;
+        if (note.isMine || note.isWarped || note.isFake) continue;
+        data[measure]++;
     }
-
     // The peak calculation isn't always accurate if there is scaling,
     // but it should be good enough.
     for (int i = 0; i < buckets; i++) {
-        peak =
-            max(peak, static_cast<double>(
-                          data[i] / (gTempo->rowToTime((i * scale + 1) * 192) -
-                                     gTempo->rowToTime(i * scale * 192))));
+        peak = max(peak, static_cast<double>(data[i] /
+                                             (gTempo->rowToTime((i + 1) * 192) -
+                                              gTempo->rowToTime(i * 192))));
     }
 }
-
 void DialogChartProperties::GraphWidget::onDraw() {
     if (gNotes->empty()) {
         Draw::fill(rect_, Color32(20, 20, 20, 255));
         return;
     }
-
     int count = data.size();
     double barWidth = (static_cast<double>(width_) / count);
     int w = barWidth + 1;
-
     auto batch = Renderer::batchC();
     Draw::fill(rect_, Color32(20, 20, 20, 255));
-
-    for (int i = 0; i < count; ++i) {
-        int h =
-            static_cast<int>(round(data[i] /
-                                   (gTempo->rowToTime((i * scale + 1) * 192) -
-                                    gTempo->rowToTime(i * scale * 192)) /
-                                   peak * height_));
-        int x = rect_.x + static_cast<int>(gTempo->rowToTime(i * scale * 192) /
-                                           endTime * width_);
+    for (int i = 0; i < count;) {
+        int h = 0;
+        // If charts are too big (> 1hr), the averaging will look very strange.
+        // Capping the averaging to 10 measures will help maintain the expected
+        // shape.
+        int max_scale = 10;
+        int scale_iters = std::min(scale, max_scale);
+        int x = rect_.x +
+                static_cast<int>(gTempo->rowToTime(i * 192) / endTime * width_);
+        while (scale_iters > 0 && i < count) {
+            h += static_cast<int>(round(data[i] /
+                                        (gTempo->rowToTime((i + 1) * 192) -
+                                         gTempo->rowToTime(i * 192)) /
+                                        peak * height_));
+            scale_iters--;
+            i++;
+        }
+        h /= std::min(scale, max_scale);
+        if (scale > 4) i += scale - max_scale;
         int y = rect_.y + height_ - h;
-
         Draw::fill(&batch, {x, y, w, h}, Color32(80, 80, 80, 255));
     }
-
     double time = min(endTime, gView->getCursorTime());
     int x = (time / endTime) * width_;
     Draw::fill(&batch, {rect_.x + x, rect_.y, 1, height_},
                Color32(160, 160, 160, 255));
-
     batch.flush();
-
     TextStyle textStyle;
     std::string info = Str::fmt("Peak: %1 NPS").arg(peak, 1, 1).str;
     Text::arrange(Text::TL, textStyle, info.c_str());
     Text::draw(vec2i{rect_.x + 4, rect_.y + 2});
-}
+};
 
 void DialogChartProperties::myCreateGraph() {
     myLayout.row().col(340);

--- a/src/Dialogs/ChartProperties.cpp
+++ b/src/Dialogs/ChartProperties.cpp
@@ -301,48 +301,66 @@ void DialogChartProperties::GraphWidget::updateGraph() {
         if (note.isMine || note.isWarped || note.isFake) continue;
         data[measure]++;
     }
-    // The peak calculation isn't always accurate if there is scaling,
-    // but it should be good enough.
-    for (int i = 0; i < buckets; i++) {
-        peak = max(peak, static_cast<double>(data[i] /
-                                             (gTempo->rowToTime((i + 1) * 192) -
-                                              gTempo->rowToTime(i * 192))));
+    int slices = 1;
+    auto measure_time = [&](int measure) {
+        return gTempo->rowToTime(measure * 192);
+    };
+    int notes = 0;
+    for (int i = 0; i < buckets; i += slices) {
+        slices = 1;
+        notes = data[i];
+        // Check 1 second to get good NPS estimates
+        while (measure_time(i + slices) - measure_time(i) < 1.0f &&
+               i + slices < buckets) {
+            notes += data[i + slices];
+            slices++;
+        }
+        peak = max(peak, static_cast<double>(notes / (measure_time(i + slices) -
+                                                      measure_time(i))));
     }
 }
 void DialogChartProperties::GraphWidget::onDraw() {
+    auto measure_time = [&](int measure) {
+        return gTempo->rowToTime(measure * 192);
+    };
+    auto delta_measure_time = [&](int measure, int offset) {
+        return measure_time(measure + offset) - measure_time(measure);
+    };
+
     if (gNotes->empty()) {
         Draw::fill(rect_, Color32(20, 20, 20, 255));
         return;
     }
-    int count = data.size();
-    double barWidth = (static_cast<double>(width_) / count);
+    endTime = gTempo->rowToTime(gSimfile->getEndRow());
+    int buckets = data.size();
+    double barWidth = (static_cast<double>(width_) / buckets);
     int w = barWidth + 1;
     auto batch = Renderer::batchC();
     Draw::fill(rect_, Color32(20, 20, 20, 255));
-    for (int i = 0; i < count;) {
+    int slices = 1;
+
+    for (int i = 0; i < buckets; i += slices) {
         int h = 0;
-        // If charts are too big (> 1hr), the averaging will look very strange.
-        // Capping the averaging to 10 measures will help maintain the expected
-        // shape.
-        int max_scale = 10;
-        int scale_iters = std::min(scale, max_scale);
-        int x = rect_.x +
-                static_cast<int>(gTempo->rowToTime(i * 192) / endTime * width_);
-        while (scale_iters > 0 && i < count) {
-            h += static_cast<int>(round(data[i] /
-                                        (gTempo->rowToTime((i + 1) * 192) -
-                                         gTempo->rowToTime(i * 192)) /
-                                        peak * height_));
-            scale_iters--;
-            i++;
+        slices = 1;
+        int x = rect_.x + static_cast<int>(measure_time(i) / endTime * width_);
+        int notes = data[i];
+        while (delta_measure_time(i, slices + 1) <= endTime / width_ &&
+               // Averaging looks bad beyond 30 seconds
+               delta_measure_time(i, slices + 1) <= 30.f &&
+               i + slices < buckets) {
+            notes += data[i + slices];
+            slices++;
         }
-        h /= std::min(scale, max_scale);
-        if (scale > max_scale) i += scale - max_scale;
+        h = std::min(height_, static_cast<int>(
+                                  round(notes / delta_measure_time(i, slices) /
+                                        peak * height_)));
+        w = rect_.x +
+            static_cast<int>(measure_time(i + slices) / endTime * width_) - x;
         int y = rect_.y + height_ - h;
         Draw::fill(&batch, {x, y, w, h}, Color32(80, 80, 80, 255));
     }
     double time = min(endTime, gView->getCursorTime());
-    int x = (time / endTime) * width_;
+    int x = static_cast<int>(time / endTime * width_);
     Draw::fill(&batch, {rect_.x + x, rect_.y, 1, height_},
                Color32(160, 160, 160, 255));
     batch.flush();

--- a/src/Dialogs/ChartProperties.cpp
+++ b/src/Dialogs/ChartProperties.cpp
@@ -277,6 +277,7 @@ class DialogChartProperties::GraphWidget : public GuiWidget {
     std::vector<int> data;
     double peak = 0.0;
     int scale = 1;
+    int endMeasure = 0;
     double endTime = 0.0;
 };
 
@@ -293,24 +294,37 @@ void DialogChartProperties::GraphWidget::updateGraph() {
         return;
     }
 
+    endMeasure = (gSimfile->getEndRow() - 1) / (ROWS_PER_BEAT * 4) + 1;
     endTime = gTempo->rowToTime(gSimfile->getEndRow());
+    scale = endMeasure / width_;
 
-    int buckets = max(0, static_cast<int>(endTime)) + 1;
-    scale = max(1, static_cast<int>(ceil(buckets / 300)));
-    if (scale > 1) buckets = static_cast<int>(buckets / scale) + 1;
+    int buckets = endMeasure;
+
+    // Just calculate everything for charts with <680 measures.
+    if (scale > 2)
+        buckets = buckets / scale + 1;
+    else
+        scale = 1;
 
     peak = 0;
     data.resize(buckets);
     for (int i = 0; i < buckets; i++) data[i] = 0;
 
     for (auto& note : *gNotes) {
-        if (note.isMine || note.isWarped || note.isFake) continue;
-        int bucket = static_cast<int>((note.time + 0.5) / scale);
-        data[bucket]++;
+        int measure = note.row / (ROWS_PER_BEAT * 4);
+        if (note.isMine || note.isWarped || note.isFake ||
+            (scale > 1 && measure % scale != 0))
+            continue;
+        data[measure / scale]++;
     }
 
+    // The peak calculation isn't always accurate if there is scaling,
+    // but it should be good enough.
     for (int i = 0; i < buckets; i++) {
-        peak = max(peak, static_cast<double>(data[i]));
+        peak =
+            max(peak, static_cast<double>(
+                          data[i] / (gTempo->rowToTime((i * scale + 1) * 192) -
+                                     gTempo->rowToTime(i * scale * 192))));
     }
 }
 
@@ -328,8 +342,13 @@ void DialogChartProperties::GraphWidget::onDraw() {
     Draw::fill(rect_, Color32(20, 20, 20, 255));
 
     for (int i = 0; i < count; ++i) {
-        int h = data[i] / peak * height_;
-        int x = rect_.x + static_cast<int>(i * barWidth);
+        int h =
+            static_cast<int>(round(data[i] /
+                                   (gTempo->rowToTime((i * scale + 1) * 192) -
+                                    gTempo->rowToTime(i * scale * 192)) /
+                                   peak * height_));
+        int x = rect_.x + static_cast<int>(gTempo->rowToTime(i * scale * 192) /
+                                           endTime * width_);
         int y = rect_.y + height_ - h;
 
         Draw::fill(&batch, {x, y, w, h}, Color32(80, 80, 80, 255));
@@ -343,7 +362,7 @@ void DialogChartProperties::GraphWidget::onDraw() {
     batch.flush();
 
     TextStyle textStyle;
-    std::string info = Str::fmt("Peak: %1 NPS").arg(peak / scale, 0, 0).str;
+    std::string info = Str::fmt("Peak: %1 NPS").arg(peak, 1, 1).str;
     Text::arrange(Text::TL, textStyle, info.c_str());
     Text::draw(vec2i{rect_.x + 4, rect_.y + 2});
 }

--- a/src/Dialogs/ChartProperties.cpp
+++ b/src/Dialogs/ChartProperties.cpp
@@ -291,7 +291,6 @@ void DialogChartProperties::GraphWidget::updateGraph() {
     endMeasure = (gSimfile->getEndRow() - 1) / (ROWS_PER_BEAT * 4) + 1;
     endTime = gTempo->rowToTime(gSimfile->getEndRow());
     scale = endMeasure / width_;
-    HudError("scale is %d", scale);
     if (scale < 1) scale = 1;
     int buckets = endMeasure;
     peak = 0;

--- a/src/Dialogs/ChartProperties.cpp
+++ b/src/Dialogs/ChartProperties.cpp
@@ -305,10 +305,10 @@ void DialogChartProperties::GraphWidget::updateGraph() {
     auto measure_time = [&](int measure) {
         return gTempo->rowToTime(measure * 192);
     };
-    int notes = 0;
+
     for (int i = 0; i < buckets; i += slices) {
         slices = 1;
-        notes = data[i];
+        int notes = data[i];
         // Check 1 second to get good NPS estimates
         while (measure_time(i + slices) - measure_time(i) < 1.0f &&
                i + slices < buckets) {
@@ -340,7 +340,6 @@ void DialogChartProperties::GraphWidget::onDraw() {
     int slices = 1;
 
     for (int i = 0; i < buckets; i += slices) {
-        int h = 0;
         slices = 1;
         int x = rect_.x + static_cast<int>(measure_time(i) / endTime * width_);
         int notes = data[i];
@@ -351,9 +350,10 @@ void DialogChartProperties::GraphWidget::onDraw() {
             notes += data[i + slices];
             slices++;
         }
-        h = std::min(height_, static_cast<int>(
-                                  round(notes / delta_measure_time(i, slices) /
-                                        peak * height_)));
+        int h = std::min(
+            height_,
+            static_cast<int>(
+                round(notes / delta_measure_time(i, slices) / peak * height_)));
         w = rect_.x +
             static_cast<int>(measure_time(i + slices) / endTime * width_) - x;
         int y = rect_.y + height_ - h;

--- a/src/Dialogs/ChartProperties.cpp
+++ b/src/Dialogs/ChartProperties.cpp
@@ -338,7 +338,7 @@ void DialogChartProperties::GraphWidget::onDraw() {
             i++;
         }
         h /= std::min(scale, max_scale);
-        if (scale > 4) i += scale - max_scale;
+        if (scale > max_scale) i += scale - max_scale;
         int y = rect_.y + height_ - h;
         Draw::fill(&batch, {x, y, w, h}, Color32(80, 80, 80, 255));
     }


### PR DESCRIPTION
As discussed in #251, these are my recommended changes to the density graph to make it work based on measure instead of time, to avoid holes or unexpected behavior.

This isn't a recreation of the Simply Love density graph--that is a bunch of quads drawn for each measure, which seems very inefficient for large files. Although it means that this graph looks bad at high densities since it is limited to a 1px maximum resolution.

To work around that, I added some sampling/averaging calculations to the NPS graph that should make the density visible for long simfiles without looking too weird.

The one thing this solution does not do is handle files that have very high BPMs for short times. Files should still work in that case, but it is possible the averaging will make the graph look unnecessarily blocky. That said, this should be pretty uncommon, so it's probably fine.