### PR TITLE
Read the .osu hit object type as a bitfield

### DIFF
--- a/src/Simfile/LoadOsu.cpp
+++ b/src/Simfile/LoadOsu.cpp
@@ -238,19 +238,18 @@ static void ParseHitObjects(OsuFile& out, Parser& parser) {
         int x = std::max(0, NoteVal(p)), y = NoteVal(p);
         double time = NoteVal(p) * 0.001;
         int type = NoteVal(p);
-        switch (type) {
-            case 1:  // Regular step.
-            case 4:  // Color combo update steps
-            case 5:
-            case 6:
-                out.hitObjects.emplace_back(x, time, time);
-                break;
-            case 128:  // Hold note.
-                int hitSound = NoteVal(p);
-                double endTime = std::max(time, NoteVal(p) * 0.001);
-                out.hitObjects.emplace_back(x, time, endTime);
-                break;
-        };
+
+        // Bit 0 of the type marks a hit circle and bit 7 an osu!mania hold;
+        // the rest carry combo flags.
+        enum { TYPE_CIRCLE = 1, TYPE_HOLD = 128 };
+
+        if (type & TYPE_HOLD) {
+            SkipNoteVal(p);  // hitSound
+            double endTime = std::max(time, NoteVal(p) * 0.001);
+            out.hitObjects.emplace_back(x, time, endTime);
+        } else if (type & TYPE_CIRCLE) {
+            out.hitObjects.emplace_back(x, time, time);
+        }
     }
 }
 


### PR DESCRIPTION
Notes go missing when a `.osu` file is opened: they are in the file, they are
not in the chart, and nothing is reported.

## Why

The `type` field of a hit object is a bitfield. Bit 0 marks a hit circle, bit 1
a slider, bit 3 a spinner and bit 7 an osu!mania hold; bit 2 marks a new combo
and bits 4 to 6 carry the colour skip that goes with it. Only two of those bits
say what the object is - the rest describe how it is coloured.

`ParseHitObjects` matches whole values instead:

```cpp
switch (type) {
    case 1:  // Regular step.
    case 4:  // Color combo update steps
    case 5:
    case 6:
        out.hitObjects.emplace_back(x, time, time);
        break;
    case 128:  // Hold note.
        ...
}
```

So a note is only kept when its combo bits happen to form one of those five
numbers. A circle that starts a new combo with a colour skip is
`1 | 4 | 16 = 21`, and a hold on a new combo is `128 | 4 = 132`. Neither matches
a label, so both fall through the switch and are dropped silently.

How many notes this loses depends on how the mapper set their combo colours,
which is why some files import whole and others quietly lose a handful.

## The change

Test the two bits that identify the object:

```cpp
enum { TYPE_CIRCLE = 1, TYPE_HOLD = 128 };

if (type & TYPE_HOLD) {
    SkipNoteVal(p);  // hitSound
    double endTime = std::max(time, NoteVal(p) * 0.001);
    out.hitObjects.emplace_back(x, time, endTime);
} else if (type & TYPE_CIRCLE) {
    out.hitObjects.emplace_back(x, time, time);
}
```

The hold is tested first so that an object carrying both bits keeps its end
time rather than being read as a plain circle. Sliders and spinners still
fall through, as they did before - they have no meaning in mania.

As a side effect this removes the `int hitSound` declaration inside a switch
case, which only compiled because it was the last label.

## Reproducing

Any mania file with combo flags will do. A minimal one:

```
osu file format v14

[General]
AudioFilename: audio.mp3
Mode: 3

[Difficulty]
CircleSize:4

[TimingPoints]
0,500,4,1,0,100,1,0

[HitObjects]
64,192,0,1,0,0:0:0:0:
192,192,500,21,0,0:0:0:0:
320,192,1000,133,0,0:0:0:0:
448,192,1500,132,0,0:0:0:0:
```

Four notes in the file, one in the chart before the change, four after it.

## Testing

The same change has been running in a downstream fork. It was checked
against a file of twelve hit objects with assorted combo flags, where
the count in the chart list went from a partial number to twelve, and against
the mania charts that first showed the problem, whose note counts now match
what osu! itself reports.
