### PR TITLE
Keep notes on the rightmost column when loading an .osu file

### DIFF
--- a/src/Simfile/LoadOsu.cpp
+++ b/src/Simfile/LoadOsu.cpp
@@ -432,7 +432,7 @@ static void ConvertNotes(Simfile* sim, OsuFile& osu, Chart& chart) {
         // x ranges from 0 to 512 (inclusive), y ranges from 0 to 384
         // (inclusive).
         int colWidth = 512 / std::max(osu.numCols, 1);
-        int col = std::clamp(hitObject.x / colWidth, 0, osu.numCols);
+        int col = std::clamp(hitObject.x / colWidth, 0, osu.numCols - 1);
 
         // Convert time and endtime to rows.
         int row = tracker.advance(hitObject.time);


### PR DESCRIPTION
Notes that sit on the rightmost column of a mania chart are dropped when the
file is opened.

## Why

osu! places a note by its x coordinate, which runs from 0 to 512 **inclusive**.
`ConvertNotes` turns that into a column:

```cpp
int colWidth = 512 / std::max(osu.numCols, 1);
int col = std::clamp(hitObject.x / colWidth, 0, osu.numCols);
```

For a four column chart `colWidth` is 128, so an x of 512 divides into 4 - one
past the last column, which is 3. The clamp allows it, because its upper bound
is `numCols` rather than `numCols - 1`.

The note then carries a column the chart has no room for. `NoteList::sanitize`
notices, counts it as an invalid column and throws the note away, so the file
imports with fewer notes than it has.

Whether a file is affected depends on how its notes were placed: editors that
centre notes in their column never produce 512, while files written with the
column edges do.

## The change

```cpp
int col = std::clamp(hitObject.x / colWidth, 0, osu.numCols - 1);
```

An x of exactly 512 now lands in the last column, which is where it belongs.

## Reproducing

A four column file with every other note at the right edge:

```
osu file format v14

[General]
AudioFilename: audio.mp3
Mode: 3

[Difficulty]
CircleSize:4

[TimingPoints]
0,500,4,1,0,100,1,0

[HitObjects]
64,192,0,1,0,0:0:0:0:
512,192,500,1,0,0:0:0:0:
64,192,1000,1,0,0:0:0:0:
512,192,1500,1,0,0:0:0:0:
64,192,2000,1,0,0:0:0:0:
512,192,2500,1,0,0:0:0:0:
64,192,3000,1,0,0:0:0:0:
512,192,3500,1,0,0:0:0:0:
```

Eight notes in the file. The chart list shows four before the change and eight
after it - the four at x = 512 are the ones that go missing.

## Testing

Measured on that file with both versions of the line, built from the same
source otherwise: four notes with the current bound, eight with `numCols - 1`.
The editor does not crash either way; the notes are discarded quietly by the
sanitize pass.
