### PR TITLE
Release what a widget holds when it is disabled

### DIFF
--- a/src/Core/GuiWidget.cpp
+++ b/src/Core/GuiWidget.cpp
@@ -144,7 +144,14 @@ std::string GuiWidget::getTooltip() const {
     return GuiManager::getTooltip(this);
 }
 
-void GuiWidget::setEnabled(bool value) { SetFlags(flags_, WF_ENABLED, value); }
+void GuiWidget::setEnabled(bool value) {
+    if (!value) {
+        if (isCapturingMouse()) stopCapturingMouse();
+        if (isCapturingText()) stopCapturingText();
+        if (isCapturingFocus()) stopCapturingFocus();
+    }
+    SetFlags(flags_, WF_ENABLED, value);
+}
 
 void GuiWidget::setTooltip(const std::string& text) {
     GuiManager::setTooltip(this, text);


### PR DESCRIPTION
Disabling a widget between a mouse press and its release leaves the mouse
captured for good, and from that moment nothing in the interface answers the
mouse any more. The buttons are still drawn, they just stop reacting.

## Why

Pressing a widget takes the mouse:

```cpp
void WgButton::onMousePress(MousePress& evt) {
    if (isMouseOver()) {
        if (isEnabled() && evt.button == Mouse::LMB && !evt.handled) {
            startCapturingMouse();
            ...
```

and only its own `onMouseRelease` gives it back. That release arrives through
`handleInputs`, which `onTick` runs only while the widget is enabled:

```cpp
void GuiWidget::onTick() {
    if (HasFlags(flags_, WF_ENABLED)) {
        ...
        handleInputs(gui_->getEvents());
        ...
    }
}
```

`setEnabled` is a plain flag write, so a widget disabled while it holds the
capture never sees another event and never lets go.

What makes this lock the whole interface rather than just that one widget is
how mouse over is decided each frame:

```cpp
void GuiManager::startFrame(float dt) {
    GM->mouseBlockers.clear();
    GM->mouseOver = GM->mouseCapture;
}

void GuiManager::makeMouseOver(GuiWidget* w) {
    if (GM->mouseBlockers.empty() && !GM->mouseOver) {
        GM->mouseOver = w;
    }
}
```

While a capture is held, `mouseOver` starts every frame already pointing at the
captor, so `makeMouseOver` turns everyone else down. Every other widget's
`isMouseOver()` is false, so their press handlers do nothing - and since no
widget can handle a press, nothing can take the capture away either.

## Where it can happen

Any code that disables a widget between press and release, which includes
disabling a whole dialog at once. Two such calls are already in the tree:

- `Dialogs/AdjustSync.cpp:128` disables every widget in the dialog when the
  file is closed;
- `Dialogs/AdjustSync.cpp:165` disables `Apply BPM` when detection returns no
  results.

It also happens with a button that greys itself out in its own handler - a
button that starts a job and disables itself so it cannot be pressed twice.
That is how it turned up in a downstream fork: the button worked, and every
control in the dialog was dead afterwards.

## The change

Let go of what the widget holds before the flag is cleared:

```cpp
if (!value) {
    if (isCapturingMouse()) stopCapturingMouse();
    if (isCapturingText()) stopCapturingText();
    if (isCapturingFocus()) stopCapturingFocus();
}
```

Text and focus are released for the same reason: `stopCapturingText` is what
tells a line edit its capture ended, and a disabled field should not keep the
keyboard.

The branch runs only when disabling, and each call is guarded by the matching
`isCapturing…`, so a widget that holds nothing is untouched.

## Testing

Built and used in a downstream fork. Before the change, pressing a button that
disables itself left every widget in that dialog unresponsive - hovering
produced no highlight and no tooltip, which is the tell-tale sign that mouse
over never reaches them. After it, the same button works and the dialog carries
on as usual.
