### PR TITLE
Accept typed text outside ascii

### DIFF
--- a/src/System/System.cpp
+++ b/src/System/System.cpp
@@ -838,9 +838,15 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event) {
         case SDL_EVENT_TEXT_INPUT: {
             const char* wp = event->text.text;
             const char n = '\n';
-            if (*wp >= 32)
+
+            // The text arrives as UTF-8, where anything outside ascii
+            // starts with a byte of 0x80 or above. Read through a plain
+            // char, which is signed, such a byte is negative and fails the
+            // test below, so every non-ascii character was thrown away.
+            const unsigned char lead = static_cast<unsigned char>(*wp);
+            if (lead >= 32)
                 myEvents.addTextInput(wp);
-            else if (*wp == '\r')
+            else if (lead == '\r')
                 myEvents.addTextInput(&n);
             break;
         }


### PR DESCRIPTION
No character outside ascii can be typed anywhere in the editor. Cyrillic,
Japanese, accented latin - the key does nothing at all, in every text field:
song title, artist, step artist, the search box. Pasting the same text works,
which is what makes it look like a keyboard problem rather than a text one.

## Why

SDL delivers typed text as UTF-8, and every character outside ascii starts with
a byte of 0x80 or above. The handler tests that first byte:

```cpp
case SDL_EVENT_TEXT_INPUT: {
    const char* wp = event->text.text;
    const char n = '\n';
    if (*wp >= 32)
        myEvents.addTextInput(wp);
    else if (*wp == '\r')
        myEvents.addTextInput(&n);
    break;
}
```

`char` is signed on the compilers this is built with, so a lead byte of 0xD0 -
the start of most Cyrillic letters - is -48. It fails `>= 32`, the event is
dropped, and nothing reaches the field. Only bytes 32 to 127 survive, which is
exactly ascii.

## The change

Read the first byte through `unsigned char` before comparing:

```cpp
const unsigned char lead = static_cast<unsigned char>(*wp);
if (lead >= 32)
    myEvents.addTextInput(wp);
else if (lead == '\r')
    myEvents.addTextInput(&n);
```

The rest is untouched: the string handed to `addTextInput` is still the whole
UTF-8 sequence, and control characters below 32 are still filtered, with the
carriage return still turned into a newline.

## Reproducing

Open any song, open File -> Properties, click into the title field and type a
letter that is not ascii. Nothing appears. With the change it does.

## Testing

Built and used in a downstream fork. Typing Russian and Japanese into the song
property fields works, ascii input is unchanged, and Enter still ends the edit
as before.
