### PR TITLE
Build song folder paths from UTF-8 instead of the ANSI code page

### DIFF
--- a/src/Dialogs/SongProperties.cpp
+++ b/src/Dialogs/SongProperties.cpp
@@ -339,7 +339,7 @@ void DialogSongProperties::myUpdateCdTitle() {
         auto meta = gSimfile->get();
         std::string filename = meta->cdTitle;
         if (filename.length()) {
-            fs::path path = fs::path(gSimfile->getDir().c_str());
+            fs::path path = utf8ToPath(gSimfile->getDir());
             path.append(stringToUtf8(filename));
             myCdTitleWidget->tex = extractSpriteSheet(path);
         }

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -544,7 +544,7 @@ struct EditorImpl : public Editor, public InputHandler {
         if (gSimfile->isClosed()) return false;
 
         // Make a list of all simfiles in the current pack.
-        fs::path this_dir = fs::path(gSimfile->getDir());
+        fs::path this_dir = utf8ToPath(gSimfile->getDir());
         fs::path packDir = this_dir.parent_path();
         auto songDirs = File::findDirs(packDir, false);
 

--- a/src/Editor/Music.cpp
+++ b/src/Editor/Music.cpp
@@ -498,8 +498,8 @@ struct MusicImpl : public Music, public MixSource {
                 if (myAudioConversionThread->isSimfile) {
                     fs::path out = utf8ToPath(myAudioConversionThread->outPath);
                     if (gSimfile->isOpen()) {
-                        fs::path path = fs::relative(
-                            out, fs::path(gSimfile->getDir().c_str()));
+                        fs::path path =
+                            fs::relative(out, utf8ToPath(gSimfile->getDir()));
                         gMetadata->setMusicPath(pathToUtf8(path));
                     } else {
                         gEditor->openSimfile(out);

--- a/src/Managers/MetadataMan.cpp
+++ b/src/Managers/MetadataMan.cpp
@@ -196,7 +196,7 @@ struct MetadataManImpl : public MetadataMan {
     // MetadataManImpl :: autofill functions.
 
     fs::path findImageFile(const char* full, const char* abbrev) {
-        fs::path sim_dir = fs::path(gSimfile->getDir().c_str());
+        fs::path sim_dir = utf8ToPath(gSimfile->getDir());
         auto paths = File::findFiles(sim_dir, false);
         auto parent_paths = File::findFiles(sim_dir.parent_path(), false);
         for (auto& path : parent_paths) {
@@ -212,12 +212,12 @@ struct MetadataManImpl : public MetadataMan {
                 if (Str::startsWith(f, prefix.c_str()) ||
                     Str::endsWith(f, postfix.c_str())) {
                     return fs::relative(path,
-                                        fs::path(gSimfile->getDir().c_str()));
+                                        utf8ToPath(gSimfile->getDir()));
                 }
             }
             if (Str::find(f, abbrev) != std::string::npos ||
                 Str::find(f, full) != std::string::npos) {
-                return fs::relative(path, fs::path(gSimfile->getDir().c_str()));
+                return fs::relative(path, utf8ToPath(gSimfile->getDir()));
             }
         }
         return fs::path("");
@@ -244,7 +244,7 @@ struct MetadataManImpl : public MetadataMan {
                 priority = 1;
             }
         }
-        return fs::relative(out, fs::path(gSimfile->getDir().c_str()));
+        return fs::relative(out, utf8ToPath(gSimfile->getDir()));
     }
 
     fs::path findBannerFile() override { return findImageFile("bn", "banner"); }


### PR DESCRIPTION
A song whose folder name is not spelled in the system code page loses its
artwork. The banner, background and CD title are never found, the fields in
File -> Properties stay empty, and stepping to the next song in the pack does
nothing. The chart itself opens, which makes it look like the images are
missing rather than the folder.

## Why

`SimfileMan::getDir` returns UTF-8 - it is filled from `pathToUtf8`. Several
places hand that string to the narrow `fs::path` constructor:

```cpp
fs::path sim_dir = fs::path(gSimfile->getDir().c_str());
```

On Windows that constructor decodes the bytes with the process code page. There
is no manifest asking for UTF-8, so it is whatever ANSI code page the system
runs - 1251, 1252, 932. A folder named `Плак-Плак` arrives as UTF-8 bytes, gets
read as if it were 1251 and turns into a different name that no directory has.

`findImageFile` then lists a directory that does not exist and returns nothing,
which is why the artwork silently disappears. `openNextSimfile` walks the parent
of the same broken path, and the relative path for a converted audio file is
computed against it too.

On Linux the narrow encoding is already UTF-8, so this only shows on Windows.

## The change

Use `utf8ToPath`, which `System/File.h` provides for exactly this and is already
used elsewhere in the same files:

```cpp
fs::path sim_dir = utf8ToPath(gSimfile->getDir());
```

Eight call sites across four files, no behaviour change for folders that happen
to be spelled in ascii.

## Reproducing

Put any song in a folder whose name is outside the system code page - Cyrillic,
Japanese, Greek - with a banner or background beside it. Open the chart and look
at File -> Properties: the image fields are empty and the previews are blank.
With the change the files are found and shown.

## Testing

Built and used in a downstream fork against a pack of songs with Cyrillic
folder names: banners and backgrounds are picked up, the previews render, and
moving to the next song in the pack works. Folders with ascii names behave as
before.
