### PR TITLE
Keep osu! notes that come before the first timing point

### DIFF
--- a/src/Simfile/LoadOsu.cpp
+++ b/src/Simfile/LoadOsu.cpp
@@ -1,6 +1,7 @@
 ﻿#include <Core/Core.h>
 
 #include <cmath>
+#include <limits>
 #include <map>
 #include <algorithm>
 
@@ -368,7 +369,25 @@ static void AssignDifficulties(Simfile* sim,
 // ================================================================================================
 // Timing point conversion.
 
-static void ConvertTimingPoints(Simfile* sim, OsuFile& osu) {
+// osu! counts beats from the first timing point, and a file is free to place
+// notes before it. A simfile has no rows below zero, so every one of those
+// notes lands on row zero, where the ones that share a column are thrown away
+// as duplicates. Beat zero moves back by whole measures instead, which makes
+// room for them and leaves the bar lines where the file put them.
+static const int ROWS_PER_MEASURE = 48 * 4;
+
+static int LeadingRows(const OsuFile& osu, double earliestTime) {
+    if (osu.timingPoints.empty()) return 0;
+
+    const auto& first = *osu.timingPoints.begin();
+    if (first.second.bpm <= 0.1 || earliestTime >= first.first) return 0;
+
+    double rows = 48.0 * (first.first - earliestTime) * first.second.bpm / 60.0;
+    int measures = static_cast<int>(ceil(rows / ROWS_PER_MEASURE));
+    return std::max(0, measures) * ROWS_PER_MEASURE;
+}
+
+static void ConvertTimingPoints(Simfile* sim, OsuFile& osu, int leadingRows) {
     auto tempo = sim->tempo;
 
     // If the timing points list is empty, return the fallback BPM 120.
@@ -381,12 +400,16 @@ static void ConvertTimingPoints(Simfile* sim, OsuFile& osu) {
     BpmChange initialBpm;
     initialBpm.bpm = it->second.bpm;
     tempo->segments->append(initialBpm);
-    tempo->offset = -it->first;
 
     // Calculate the rows of the other BPM values relative to the previous BPM.
     double spb = 60.0 / it->second.bpm;
     double last_bpm = it->second.bpm;
-    double prevTime = -tempo->offset, prevRow = 0.0;
+
+    // The first timing point lands on row zero, unless measures were added in
+    // front of it to make room for the notes that come earlier.
+    tempo->offset = -(it->first - leadingRows * spb / 48.0);
+
+    double prevTime = it->first, prevRow = leadingRows;
     for (++it; it != end; ++it) {
         if (it->second.bpm <= 0.1 || it->second.bpm >= 10000) continue;
 
@@ -567,8 +590,18 @@ bool LoadOsu(fs::path path, Simfile* sim) {
     sim->banner = mainFile->artwork;
     sim->background = mainFile->artwork;
 
+    // All the charts share one set of timing points, so beat zero has to sit
+    // ahead of the earliest note of every chart that is loaded.
+    double earliest = std::numeric_limits<double>::max();
+    for (auto file : files) {
+        if (file->gameMode != OSUMANIA) continue;
+        for (auto& hitObject : file->hitObjects) {
+            earliest = std::min(earliest, hitObject.time);
+        }
+    }
+
     // Convert the timing points to BPM changes.
-    ConvertTimingPoints(sim, *mainFile);
+    ConvertTimingPoints(sim, *mainFile, LeadingRows(*mainFile, earliest));
 
     // Convert the hit objects to DDR/ITG charts.
     std::vector<std::string> versions;


### PR DESCRIPTION
A `.osu` file whose chart starts before its first timing point imports with
fewer notes than it holds, and the ones that survive are in the wrong place.

## Why

osu! counts beats from the first timing point, and nothing stops a mapper
putting notes ahead of it - a lead-in phrase before the section the BPM is
measured on. A simfile has no rows below zero, and `TimeToRow` gives those
notes row zero:

```cpp
static int TimeToRow(const Event* it, double time) {
    int row = it->row;
    if (time > it->endTime && it->spr > 0.0) {
        row += static_cast<int>(round((time - it->endTime) / it->spr));
    }
    return row;
}
```

Every note before the first event fails that test and keeps `it->row`, which
is zero. They all stack on the first row, and `NoteList::sanitize` then throws
away the ones sharing a column, since two notes cannot occupy the same row and
column. What is left is a chart with missing notes and a cluster of leftovers
on row zero.

## The change

Move beat zero back by whole measures, far enough to fit the earliest note:

```cpp
static int LeadingRows(const OsuFile& osu, double earliestTime) {
    if (osu.timingPoints.empty()) return 0;

    const auto& first = *osu.timingPoints.begin();
    if (first.second.bpm <= 0.1 || earliestTime >= first.first) return 0;

    double rows = 48.0 * (first.first - earliestTime) * first.second.bpm / 60.0;
    int measures = static_cast<int>(ceil(rows / ROWS_PER_MEASURE));
    return std::max(0, measures) * ROWS_PER_MEASURE;
}
```

`ConvertTimingPoints` then puts the first timing point on that row rather than
on row zero, and adjusts the offset by the same amount, so the point keeps its
position in time. Whole measures rather than whole beats, so the bar lines stay
where the file put them.

The shift is measured from the earliest note of every mania file in the folder,
because they all share the timing points of the file that was opened.

A file whose notes all sit on or after the first timing point gets a shift of
zero and imports exactly as before.

## Reproducing

A four column file whose first timing point is at 2 s, with eight notes before
it:

```
osu file format v14

[General]
AudioFilename: audio.mp3
Mode: 3

[Difficulty]
CircleSize:4

[TimingPoints]
2000,500,4,1,0,100,1,0

[HitObjects]
64,192,1000,1,0,0:0:0:0:
192,192,1125,1,0,0:0:0:0:
320,192,1250,1,0,0:0:0:0:
448,192,1375,1,0,0:0:0:0:
64,192,1500,1,0,0:0:0:0:
192,192,1625,1,0,0:0:0:0:
320,192,1750,1,0,0:0:0:0:
448,192,1875,1,0,0:0:0:0:
64,192,2000,1,0,0:0:0:0:
192,192,2500,1,0,0:0:0:0:
320,192,3000,1,0,0:0:0:0:
448,192,3500,1,0,0:0:0:0:
```

Twelve notes. Open it and save it as `.sm`: the chart holds seven, and the
first row is `1111` - four notes stacked where the eight before the timing
point collapsed, one of them colliding with the note that sits on the timing
point itself.

## Testing

Built on Windows with clang-tidy and clang-format enforced, as the build does.

Measured on that file with both versions, built from the same source otherwise:
seven notes before, twelve after, with the lead-in phrase on eighth notes in a
measure of its own and the timing point on the following bar line. Files with
no notes before the first timing point come out byte for byte the same.
