### PR TITLE
Carry the preview time to and from .osu files

### DIFF
--- a/src/Simfile/LoadOsu.cpp
+++ b/src/Simfile/LoadOsu.cpp
@@ -44,6 +44,7 @@ struct OsuFile {
     int gameMode;
     int numCols;
     int overallDifficulty;
+    double previewTime = -1.0;
     std::string chartVersion;
     std::string musicPath;
     std::string songArtist;
@@ -159,6 +160,8 @@ static void ParseGeneral(OsuFile& out, Parser& parser) {
         const std::string& prop = parser.prop;
         if (IsProp(prop, "AudioFilename")) {
             out.musicPath = PropVal(prop);
+        } else if (IsProp(prop, "PreviewTime")) {
+            out.previewTime = Str::readInt(PropVal(prop)) * 0.001;
         } else if (IsProp(prop, "Mode")) {
             out.gameMode = Str::readInt(PropVal(prop));
         }
@@ -566,6 +569,11 @@ bool LoadOsu(fs::path path, Simfile* sim) {
     sim->music = mainFile->musicPath;
     sim->banner = mainFile->artwork;
     sim->background = mainFile->artwork;
+
+    // osu! marks a song with no preview with -1.
+    if (mainFile->previewTime > 0.0) {
+        sim->previewStart = mainFile->previewTime;
+    }
 
     // Convert the timing points to BPM changes.
     ConvertTimingPoints(sim, *mainFile);

--- a/src/Simfile/SaveOsu.cpp
+++ b/src/Simfile/SaveOsu.cpp
@@ -179,7 +179,8 @@ static void SaveChart(fs::path path, const Simfile* sim, const Chart* chart) {
     WriteBlock(out, "General");
     Write(out, "AudioFilename", sim->music);
     Write(out, "AudioLeadIn", "0");
-    Write(out, "PreviewTime", "-1");
+    Write(out, "PreviewTime",
+          sim->previewStart > 0.0 ? ToMilliseconds(sim->previewStart) : -1);
     Write(out, "Countdown", "0");
     Write(out, "SampleSet", "Soft");
     Write(out, "StackLeniency", "0.7");


### PR DESCRIPTION
The point a song previews from is lost in both directions when a `.osu` file is
involved.

## Why

`PreviewTime` is the same value as `#SAMPLESTART`, counted in milliseconds
rather than seconds. The writer emits a constant:

```cpp
Write(out, "PreviewTime", "-1");
```

so a simfile that has a preview loses it on export, and `ParseGeneral` reads
only `AudioFilename` and `Mode`, so a `.osu` that has one loses it on import.
osu! itself sets the field from its editor, and most ranked maps carry a real
value.

## The change

The loader reads it into `previewStart`, and the writer emits what is stored:

```cpp
} else if (IsProp(prop, "PreviewTime")) {
    out.previewTime = Str::readInt(PropVal(prop)) * 0.001;
}
```

```cpp
Write(out, "PreviewTime",
      sim->previewStart > 0.0 ? ToMilliseconds(sim->previewStart) : -1);
```

osu! writes -1 for a song with no preview, so that value is left alone on the
way in and still written on the way out when there is nothing to write.

Neither osu! nor a simfile agree on the length: osu! records only where the
preview starts. `#SAMPLELENGTH` therefore stays at zero on import, which is
what the games fall back to their own default on - the same thing that already
happens today, since nothing was imported at all.

## Reproducing

```
osu file format v14

[General]
AudioFilename: audio.mp3
PreviewTime: 60819
Mode: 3

[Metadata]
Title:Preview
Artist:Test
Version:Normal

[Difficulty]
CircleSize:4

[TimingPoints]
0,500,4,1,0,100,1,0

[HitObjects]
64,192,0,1,0,0:0:0:0:
192,192,500,1,0,0:0:0:0:
```

Open it and look at File -> Properties: the preview fields are empty. Save it
as `.sm` and `#SAMPLESTART` is `0.000000`.

## Testing

Built on Windows with clang-tidy and clang-format enforced, as the build does.

With the change, that file gives `#SAMPLESTART:60.819000;`, and saving back to
`.osu` gives `PreviewTime:60819`. The same file with `PreviewTime: -1` still
gives `#SAMPLESTART:0.000000;` and is written back as `PreviewTime:-1`, so a
map with no preview does not gain one at the start of the song.
