### PR TITLE
Name exported .osu files the way osu! names them

### DIFF
--- a/src/Simfile/SaveOsu.cpp
+++ b/src/Simfile/SaveOsu.cpp
@@ -29,6 +29,43 @@ namespace {
 // ===================================================================================
 // Exporting utilities.
 
+// The author osu! shows for the map: the chart's step artist, falling back
+// to the credit of the song.
+static std::string ChartCreator(const Simfile* sim, const Chart* chart) {
+    if (chart && chart->artist.length()) return chart->artist;
+    return sim ? sim->credit : std::string();
+}
+
+// Strips the characters a filename cannot hold, so that a title or an artist
+// can be used as one.
+static std::string FileSafe(const std::string& name) {
+    std::string out;
+    for (char c : name) {
+        if (c == '\\' || c == '/' || c == ':' || c == '*' || c == '?' ||
+            c == '"' || c == '<' || c == '>' || c == '|') {
+            continue;
+        }
+        out.push_back(c);
+    }
+    while (out.length() && out.back() == ' ') out.pop_back();
+    return out;
+}
+
+// The part of the filename shared by every difficulty of the song, in the
+// shape osu! uses: "Artist - Title (Creator)". The romanised names are
+// preferred, the same way the metadata block prefers them.
+static std::string FileStem(const Simfile* sim, const Chart* chart) {
+    const std::string& artist =
+        sim->artistTr.length() ? sim->artistTr : sim->artist;
+    const std::string& title =
+        sim->titleTr.length() ? sim->titleTr : sim->title;
+
+    std::string creator = ChartCreator(sim, chart);
+    std::string out = artist + " - " + title;
+    if (creator.length()) out = out + " (" + creator + ")";
+    return FileSafe(out);
+}
+
 static int ToMilliseconds(double time) {
     return static_cast<int>(time * 1000.0 + 0.5);
 }
@@ -256,29 +293,31 @@ static void SaveChart(fs::path path, const Simfile* sim, const Chart* chart) {
 };  // namespace
 
 bool SaveOsu(const Simfile* sim, bool backup) {
-    fs::path path = utf8ToPath(sim->dir);
-    path.append(stringToUtf8(sim->file));
-    path.replace_extension(".osu");
+    fs::path lastPath;
+
     if (sim->charts.empty()) {
+        fs::path path = utf8ToPath(sim->dir);
+        path.append(stringToUtf8(FileStem(sim, nullptr) + ".osu"));
         SaveChart(path, sim, nullptr);
+        lastPath = path;
     } else {
         std::map<std::string, int> duplicateCounters;
         for (auto chart : sim->charts) {
             auto diffName = std::string(GetDifficultyName(chart->difficulty));
-            fs::path path = utf8ToPath(sim->dir);
-            path.append(stringToUtf8(sim->file));
-            path.replace_extension();
-            path.concat(" [");
-            path.concat(diffName);
             int& counter = duplicateCounters[diffName];
             if (++counter > 1) {
-                path.concat(Str::fmt(" %1").arg(counter).str);
+                diffName = diffName + Str::fmt(" %1").arg(counter).str;
             }
-            path.concat("].osu");
+
+            fs::path path = utf8ToPath(sim->dir);
+            path.append(
+                stringToUtf8(FileStem(sim, chart) + " [" + diffName + "].osu"));
             SaveChart(path, sim, chart);
+            lastPath = path;
         }
     }
-    HudInfo("Saved: %s", pathToUtf8(path.filename()).c_str());
+
+    HudInfo("Saved: %s", pathToUtf8(lastPath.filename()).c_str());
     return true;
 }
 


### PR DESCRIPTION
A chart exported to `.osu` is named after the simfile it came from:

```cpp
    path.append(stringToUtf8(sim->file));
    path.replace_extension();
    path.concat(" [");
    path.concat(diffName);
```

so `mysong.sm` becomes `mysong [Challenge].osu`. osu! names a difficulty

```
Artist - Title (Creator) [Difficulty].osu
```

and that is what its song folders hold, what its beatmap listings show, and
what the editors that read them expect. A chart exported from here does not sit
beside the ones that came from the game.

## The change

The name is built from the same values the metadata block already writes a few
lines above:

```cpp
    Write(out, "Title", sim->titleTr.length() ? sim->titleTr : sim->title);
    Write(out, "Artist", sim->artistTr.length() ? sim->artistTr : sim->artist);
```

- artist and title: the romanised forms where the simfile has them, the
  originals otherwise;
- creator: the chart's step artist, falling back to the credit of the song.
  With neither, the brackets are left out rather than filled with a
  placeholder.

`FileSafe` drops the characters a filename cannot hold. That did not matter
before, when the name was one that was already a filename, and it does now that
it is built from free text.

The duplicate counter moves from the path to the difficulty name, so a second
`Challenge` becomes `[Challenge 2]` exactly as it did.

## Note on the creator

The metadata block writes `Creator` as `chart->artist` with `"Unknown"` when
there is none, while the filename falls back to the song's `#CREDIT` and omits
the brackets when both are empty. Most StepMania files put the author in
`#CREDIT` rather than per chart, so a filename built from `chart->artist` alone
would drop the creator for nearly every song. I left the metadata line alone to
keep this to the filename; say the word and I will make the two agree.

## Reproducing

A simfile with romanised names and a credit:

```
#TITLE:Плак-Плак;
#ARTIST:Музыкант;
#TITLETRANSLIT:Plak-Plak;
#ARTISTTRANSLIT:Muzykant;
#CREDIT:WiRED;
```

with an Easy and a Challenge chart. Saving to `.osu` gives `song [Easy].osu`
and `song [Challenge].osu` today.

## Testing

Built on Windows with clang-tidy and clang-format enforced, as the build does.

That file now exports as

```
Muzykant - Plak-Plak (WiRED) [Easy].osu
Muzykant - Plak-Plak (WiRED) [Challenge].osu
```

The same song with no romanised names and no credit exports as
`Музыкант - Плак-Плак [Easy].osu` - the original names, and no empty brackets.

One thing worth knowing: a song exported before this change keeps its old files
under the old name, so the folder holds both until the old ones are removed by
hand.
