### PR TITLE
Fill the osu! creator and tags from the simfile

### DIFF
--- a/src/Simfile/SaveOsu.cpp
+++ b/src/Simfile/SaveOsu.cpp
@@ -29,6 +29,14 @@ namespace {
 // ===================================================================================
 // Exporting utilities.
 
+// The author osu! shows for the map. A StepMania file usually names the
+// author in the song credit rather than per chart, so that is where this
+// looks when the chart itself says nothing.
+static std::string ChartCreator(const Simfile* sim, const Chart* chart) {
+    if (chart && chart->artist.length()) return chart->artist;
+    return sim ? sim->credit : std::string();
+}
+
 static int ToMilliseconds(double time) {
     return static_cast<int>(time * 1000.0 + 0.5);
 }
@@ -202,11 +210,11 @@ static void SaveChart(fs::path path, const Simfile* sim, const Chart* chart) {
     Write(out, "TitleUnicode", sim->title);
     Write(out, "Artist", sim->artistTr.length() ? sim->artistTr : sim->artist);
     Write(out, "ArtistUnicode", sim->artist);
-    Write(out, "Creator", chart ? chart->artist : "Unknown");
+    Write(out, "Creator", ChartCreator(sim, chart));
     Write(out, "Version",
           chart ? GetDifficultyName(chart->difficulty) : "Normal");
     Write(out, "Source", "");
-    Write(out, "Tags", "");
+    Write(out, "Tags", sim->genre);
     Write(out, "BeatmapID", "0");
     Write(out, "BeatmapSetID", "-1");
 


### PR DESCRIPTION
Two fields of the `[Metadata]` block are written blind:

```cpp
    Write(out, "Creator", chart ? chart->artist : "Unknown");
    ...
    Write(out, "Tags", "");
```

so a map exported from here is by `Unknown` and carries no tags, though the
simfile usually knows both.

## Creator

A StepMania file names the author in `#CREDIT` more often than per chart -
`chart->artist` is empty in most files - so `Unknown` is what nearly every
export gets. The creator now falls back to the credit of the song, and is left
empty rather than filled with a placeholder when neither is set.

This is the same value the exported filename uses, so the name of the file and
the field inside it agree.

## Tags

`#GENRE` is the closest thing a simfile has to the keywords osu! puts in
`Tags`, and it is otherwise dropped on export - nothing else in the `.osu`
carries it.

## What is left alone

`BeatmapID:0` and `BeatmapSetID:-1` stay as they are: that is what osu! writes
for a map which has not been submitted, which is what an export from here is. I
checked a few hundred local beatmaps to be sure rather than guess - every
unsubmitted one has exactly that pair.

`Version` also stays as it is. A simfile has no free-form difficulty name to
put there - `#SUBTITLE` belongs to the song rather than the chart, so using it
would give every difficulty in the set the same `Version`.

## Testing

Built on Windows with clang-tidy and clang-format enforced, as the build does.

A song with `#GENRE:witch house, russian, tiktok;` and `#CREDIT:WiRED;`, whose
chart has no step artist, exports as:

```
[Metadata]
Title:Plak-Plak
TitleUnicode:Плак-Плак
Artist:IC3PEAK
ArtistUnicode:IC3PEAK
Creator:WiRED
Version:Hard
Source:
Tags:witch house, russian, tiktok
BeatmapID:0
BeatmapSetID:-1
```

Before the change the same file gave `Creator:Unknown` and an empty `Tags`.
