### PR TITLE
Let the view scroll into the lead-in before the first beat

### DIFF
--- a/src/Editor/Action.cpp
+++ b/src/Editor/Action.cpp
@@ -387,10 +387,10 @@ void Action::perform(Type action) {
 
         CASE(CURSOR_UP)
         gView->setCursorRow(
-            gView->snapRow(gView->getCursorRow(), View::SNAP_UP));
+            gView->snapRow(gView->getCursorRowExact(), View::SNAP_UP));
         CASE(CURSOR_DOWN)
         gView->setCursorRow(
-            gView->snapRow(gView->getCursorRow(), View::SNAP_DOWN));
+            gView->snapRow(gView->getCursorRowExact(), View::SNAP_DOWN));
         CASE(CURSOR_PREVIOUS_BEAT)
         gView->setCursorToNextInterval(-48);
         CASE(CURSOR_NEXT_BEAT)

--- a/src/Editor/Common.cpp
+++ b/src/Editor/Common.cpp
@@ -68,7 +68,9 @@ RowType ToRowType(int rowIndex) {
             }
         }
     }
-    return map[rowIndex % 192];
+    // Rows in the lead-in are negative, and so is their remainder.
+    int index = rowIndex % 192;
+    return map[(index < 0) ? index + 192 : index];
 }
 
 uint32_t ToRowTypeColor(RowType type) { return ROW_TYPE_COLOR[type]; }

--- a/src/Editor/Notefield.cpp
+++ b/src/Editor/Notefield.cpp
@@ -361,7 +361,7 @@ struct NotefieldImpl : public Notefield {
         std::vector<MeasureLabel> labels;
 
         // Determine the first row and last row that should show beat lines.
-        int drawBeginRow = std::max(0, gView->offsetToRow(myFirstVisibleTor));
+        int drawBeginRow = gView->offsetToRow(myFirstVisibleTor);
         int drawEndRow = std::min(gView->offsetToRow(myLastVisibleTor),
                                   gSimfile->getEndRow()) +
                          1;
@@ -399,6 +399,35 @@ struct NotefieldImpl : public Notefield {
                 : ROWS_PER_BEAT;
 
         DrawPosHelper drawPos;
+
+        // The lead-in has no time signature of its own, so the first one is
+        // carried backwards to give measures -1, -2 and so on.
+        if (drawBeginRow < 0) {
+            int rpm = it->rowsPerMeasure;
+            int firstMeasure = -((-drawBeginRow + rpm - 1) / rpm);
+            for (int m = firstMeasure; m < 0; ++m) {
+                int measureRow = m * rpm;
+                int y = drawPos.advance(measureRow);
+                Draw::fill(&batch, {myX, y, myW, 1}, fullColor);
+                labels.emplace_back(m, y);
+
+                if (zoomedIn) {
+                    double beatRow = measureRow + snapStep;
+                    while (beatRow < measureRow + rpm) {
+                        int r = static_cast<int>(round(beatRow));
+                        uint32_t color =
+                            myShowBeatLinesColor || myVisualSyncBeatlinesPreset
+                                ? (ToRowTypeColor(ToRowType(r)) & halfColor)
+                                : halfColor;
+
+                        int by = drawPos.advance(r);
+                        Draw::fill(&batch, {myX, by, myW, 1}, color);
+                        beatRow += snapStep;
+                    }
+                }
+            }
+        }
+
         while (it != end && row < drawEndRow) {
             int endRow = drawEndRow;
             if (next != end) endRow = std::min(endRow, next->row);

--- a/src/Editor/View.cpp
+++ b/src/Editor/View.cpp
@@ -32,6 +32,16 @@
 namespace Vortex {
 namespace {};  // anonymous namespace
 
+// Rows in the lead-in are negative, and -1 % 48 is -1 rather than 47.
+static int FlooredMod(int value, int divisor) {
+    int mod = value % divisor;
+    return (mod < 0) ? mod + divisor : mod;
+}
+
+static int FlooredDiv(int value, int divisor) {
+    return (value - FlooredMod(value, divisor)) / divisor;
+}
+
 // ================================================================================================
 // ViewImpl :: member data.
 
@@ -222,7 +232,16 @@ struct ViewImpl : public View, public InputHandler {
         return myUseTimeBasedView ? myPixPerSec : myPixPerRow;
     }
 
-    int getCursorRow() const override { return myCursorRow; }
+    int getCursorRow() const override { return std::max(0, myCursorRow); }
+
+    int getCursorRowExact() const override { return myCursorRow; }
+
+    // The lead-in reaches back to the start of the audio.
+    double getLeadInTime() const { return std::min(0.0, gTempo->rowToTime(0)); }
+
+    int getLeadInRow() const {
+        return std::min(0, gTempo->timeToRow(getLeadInTime()));
+    }
 
     double getCursorTime() const override { return myCursorTime; }
 
@@ -274,7 +293,7 @@ struct ViewImpl : public View, public InputHandler {
         // Update the cursor time.
         if (!gMusic->isPaused()) {
             int endrow = gSimfile->getEndRow();
-            double begintime = gTempo->rowToTime(0);
+            double begintime = getLeadInTime();
             double endtime = gTempo->rowToTime(endrow);
             if (myCursorTime > endtime) {
                 myCursorTime = endtime;
@@ -402,7 +421,7 @@ struct ViewImpl : public View, public InputHandler {
     }
 
     void setCursorTime(double time) override {
-        double begintime = gTempo->rowToTime(0);
+        double begintime = getLeadInTime();
         double endtime = gTempo->rowToTime(gSimfile->getEndRow());
         myCursorTime = std::clamp(time, begintime, endtime);
         myCursorBeat = gTempo->timeToBeat(myCursorTime);
@@ -411,7 +430,7 @@ struct ViewImpl : public View, public InputHandler {
     }
 
     void setCursorRow(int row) override {
-        myCursorRow = std::clamp(row, 0, gSimfile->getEndRow());
+        myCursorRow = std::clamp(row, getLeadInRow(), gSimfile->getEndRow());
         myCursorBeat = myCursorRow * BEATS_PER_ROW;
         myCursorTime = gTempo->rowToTime(myCursorRow);
         gMusic->seek(myCursorTime);
@@ -431,14 +450,15 @@ struct ViewImpl : public View, public InputHandler {
         int rowsInInterval = abs(rows);
 
         if (rows < 0) {
-            int delta = myCursorRow % rowsInInterval;
+            int delta = FlooredMod(myCursorRow, rowsInInterval);
             if (delta == 0 ||
                 (delta < rowsInInterval / 2 && !gMusic->isPaused())) {
                 delta += rowsInInterval;
             }
             setCursorRow(myCursorRow - delta);
         } else {
-            int delta = rowsInInterval - myCursorRow % rowsInInterval;
+            int delta =
+                rowsInInterval - FlooredMod(myCursorRow, rowsInInterval);
             setCursorRow(myCursorRow + delta);
         }
     }
@@ -645,7 +665,8 @@ struct ViewImpl : public View, public InputHandler {
 
             // Custom snaps
             if (mySnapType == ST_CUSTOM) {
-                int measure = row / 192, measurerow = row % 192;
+                int measure = FlooredDiv(row, 192);
+                int measurerow = FlooredMod(row, 192);
                 if (dir == SNAP_UP) {
                     for (int i = myCustomSnap; i >= 0; --i) {
                         if (myCustomSnapSteps[i] <= measurerow) {
@@ -665,8 +686,9 @@ struct ViewImpl : public View, public InputHandler {
             } else  // Regular case, snap is divisible by 192.
             {
                 int snap = sRowSnapTypes[mySnapType];
-                if (row % snap && dir != SNAP_UP) row += snap;
-                row -= row % snap;
+                int mod = FlooredMod(row, snap);
+                if (mod && dir != SNAP_UP) row += snap;
+                row -= mod;
             }
 
             return row;
@@ -680,10 +702,11 @@ struct ViewImpl : public View, public InputHandler {
         if (snap == 0) {
             return std::find(myCustomSnapSteps,
                              myCustomSnapSteps + myCustomSnap,
-                             row % 192) != myCustomSnapSteps + myCustomSnap;
+                             FlooredMod(row, 192)) !=
+                   myCustomSnapSteps + myCustomSnap;
         }
 
-        return (row % snap == 0);
+        return (FlooredMod(row, snap) == 0);
     }
 
     bool isMouseOverReceptors(int x, int y) const {

--- a/src/Editor/View.h
+++ b/src/Editor/View.h
@@ -81,6 +81,10 @@ struct View {
     virtual double getPixPerOfs() const = 0;
 
     virtual int getCursorRow() const = 0;
+
+    /// The cursor row as it is, negative while the cursor is in the lead-in.
+    /// getCursorRow stops at zero, since nothing is placed below it.
+    virtual int getCursorRowExact() const = 0;
     virtual double getCursorTime() const = 0;
     virtual double getCursorBeat() const = 0;
     virtual ChartOffset getCursorOffset() const = 0;

--- a/src/Simfile/TimingData.cpp
+++ b/src/Simfile/TimingData.cpp
@@ -392,7 +392,19 @@ static const Event* MostRecentEvent(const std::vector<Event>& events,
     return &(*it);
 }
 
+static bool IsLeadIn(const Event* it, int row) {
+    return row < it->row && it->spr > 0.0;
+}
+
+static bool IsLeadIn(const Event* it, double time) {
+    return time < it->rowTime && it->spr > 0.0;
+}
+
 static double TimeToBeat(const Event* it, double time) {
+    if (IsLeadIn(it, time)) {
+        double row = it->row + (time - it->rowTime) / it->spr;
+        return row * BEATS_PER_ROW;
+    }
     double row = it->row;
     if (time > it->endTime && it->spr > 0.0) {
         row += (time - it->endTime) / it->spr;
@@ -401,6 +413,10 @@ static double TimeToBeat(const Event* it, double time) {
 }
 
 static int TimeToRow(const Event* it, double time) {
+    if (IsLeadIn(it, time)) {
+        return it->row +
+               static_cast<int>(round((time - it->rowTime) / it->spr));
+    }
     int row = it->row;
     if (time > it->endTime && it->spr > 0.0) {
         row += static_cast<int>(round((time - it->endTime) / it->spr));
@@ -412,6 +428,9 @@ static double RowToTime(const Event* it, int row) {
     if (row > it->row) {
         return it->endTime + (row - it->row) * it->spr;
     }
+    if (IsLeadIn(it, row)) {
+        return it->rowTime + (row - it->row) * it->spr;
+    }
     return it->rowTime;
 }
 
@@ -419,6 +438,9 @@ static double BeatToTime(const Event* it, double beat) {
     double row = beat * ROWS_PER_BEAT;
     if (row > it->row) {
         return it->endTime + (row - it->row) * it->spr;
+    }
+    if (row < it->row && it->spr > 0.0) {
+        return it->rowTime + (row - it->row) * it->spr;
     }
     return it->rowTime;
 }


### PR DESCRIPTION
Most songs do not start on their first beat. `#OFFSET` puts a second or two of
audio in front of it, and that stretch cannot be looked at: the view stops at
row 0.

```cpp
    void setCursorRow(int row) override {
        myCursorRow = std::clamp(row, 0, gSimfile->getEndRow());
```

It is a stretch worth looking at. It is where the offset is checked against the
waveform, and where a song that begins on a pickup keeps the notes that lead
into measure 0.

## The change

The cursor now stops at the start of the audio rather than at the first beat,
and the notefield draws what is up there: measures -1, -2 and so on, carrying
the first time signature backwards, since the lead-in has no signature of its
own.

Three things had to follow from that.

`RowToTime` and `TimeToRow` returned the first event's own row and time for
anything below it, so every row in the lead-in collapsed onto row 0. They now
extrapolate backwards from that event at its own tempo:

```cpp
    static bool IsLeadIn(const Event* it, double time) {
        return time < it->rowTime && it->spr > 0.0;
    }
```

Snapping did arithmetic that only holds for positive rows - `row % snap`, with
`-1 % 48` being `-1` rather than `47`, which leaves the cursor stuck where it
is instead of moving it up a row. Those places use a floored remainder now.
`ToRowType` indexed its colour table by the same remainder, which is worse than
stuck.

`getCursorRow()` still stops at zero. Nothing is placed on a negative row, so
every caller that edits or measures notes gets what it always did;
`getCursorRowExact()` is there for the two places that need to know where the
cursor really is, which are the ones that snap it.

## What this is not

The lead-in is drawn and can be scrolled through, not edited. There are no
negative rows in the file and none are written to it.

## Testing

Built on Windows with clang-tidy and clang-format enforced, as the build does.

A song with `#OFFSET:-6.000000;` at 120 BPM has six seconds in front of its
first beat, which is three measures. Scrolling up stops at `Measure: -3.00
Time: 00:00.000` - the start of the audio, three measures above row 0 - with
the measure lines for -3 and -2 drawn and labelled, and the beat lines between
them coloured the way they are anywhere else. The same song with
`#OFFSET:-2.000000;` stops at `Measure: -1.00`.

A song with `#OFFSET:0` behaves as it did: there is nothing before the first
beat, so the view stops there.
